### PR TITLE
[WIP] - Bookmarks Repository

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,10 +10,15 @@ sqldelight = "2.1.0"
 
 [libraries]
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 
 sqldelight-extensions = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
 sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }
 sqldelight-native-driver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
+sqldelight-sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose" }
 compose-foundation = { module = "androidx.compose.foundation:foundation" }

--- a/persistence/build.gradle.kts
+++ b/persistence/build.gradle.kts
@@ -26,6 +26,13 @@ kotlin {
             implementation(libs.sqldelight.extensions)
         }
 
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.sqldelight.sqlite.driver)
+            implementation("app.cash.sqldelight:jdbc-driver")
+        }
+
         androidMain.dependencies {
             implementation(libs.sqldelight.android.driver)
         }
@@ -56,6 +63,12 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
     }
 }
 

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/Bookmark.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/Bookmark.kt
@@ -1,11 +1,18 @@
 package com.quran.shared.persistence.model
 
+enum class BookmarkLocalMutation {
+    NONE,
+    CREATED,
+    DELETED
+}
+
 data class Bookmark(
     val id: Long,
     val sura: Int?,
     val ayah: Int?,
     val page: Int?,
     val remoteId: String?,
+    val localMutation: BookmarkLocalMutation,
     val lastUpdated: Long
 ) {
     val isPageBookmark: Boolean
@@ -13,4 +20,4 @@ data class Bookmark(
 
     val isAyahBookmark: Boolean
         get() = sura != null && ayah != null && page == null
-} 
+}

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/Bookmark.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/Bookmark.kt
@@ -7,7 +7,6 @@ enum class BookmarkLocalMutation {
 }
 
 data class Bookmark(
-    val id: Long,
     val sura: Int?,
     val ayah: Int?,
     val page: Int?,

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/Bookmark.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/Bookmark.kt
@@ -1,0 +1,16 @@
+package com.quran.shared.persistence.model
+
+data class Bookmark(
+    val id: Long,
+    val sura: Int?,
+    val ayah: Int?,
+    val page: Int?,
+    val remoteId: String?,
+    val lastUpdated: Long
+) {
+    val isPageBookmark: Boolean
+        get() = page != null && sura == null && ayah == null
+
+    val isAyahBookmark: Boolean
+        get() = sura != null && ayah != null && page == null
+} 

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarkRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarkRepository.kt
@@ -4,6 +4,7 @@ import com.quran.shared.persistence.model.Bookmark
 import kotlinx.coroutines.flow.Flow
 
 class DuplicateBookmarkException(message: String) : Exception(message)
+class BookmarkNotFoundException(message: String) : Exception(message)
 
 interface BookmarkRepository {
 

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarkRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarkRepository.kt
@@ -1,0 +1,22 @@
+package com.quran.shared.persistence.repository
+
+import com.quran.shared.persistence.model.Bookmark
+import kotlinx.coroutines.flow.Flow
+
+interface BookmarkRepository {
+    fun getAllBookmarks(): Flow<List<Bookmark>>
+
+    suspend fun addPageBookmark(sura: Int): Bookmark
+
+    suspend fun addAyahBookmark(sura: Int, ayah: Int): Bookmark
+
+    suspend fun deleteBookmark(id: Long)
+
+    suspend fun fetchMutatedBookmarks(): List<Bookmark>
+
+    suspend fun persistedRemoteUpdates(mutations: List<Bookmark>)
+
+    suspend fun clearLocalMutations()
+
+    suspend fun addAll(bookmarks: List<Bookmark>)
+}

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarkRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarkRepository.kt
@@ -4,19 +4,26 @@ import com.quran.shared.persistence.model.Bookmark
 import kotlinx.coroutines.flow.Flow
 
 interface BookmarkRepository {
+
+    // region Fetch, add and delete
     fun getAllBookmarks(): Flow<List<Bookmark>>
 
-    suspend fun addPageBookmark(sura: Int): Bookmark
+    suspend fun addPageBookmark(page: Int): Bookmark
 
     suspend fun addAyahBookmark(sura: Int, ayah: Int): Bookmark
 
-    suspend fun deleteBookmark(id: Long)
+    suspend fun deletePageBookmark(page: Int)
 
+    suspend fun deleteAyahBookmark(sura: Int, ayah: Int)
+
+    suspend fun addAll(bookmarks: List<Bookmark>)
+    // endregion
+
+    // region Synchronization-related
     suspend fun fetchMutatedBookmarks(): List<Bookmark>
 
     suspend fun persistedRemoteUpdates(mutations: List<Bookmark>)
 
     suspend fun clearLocalMutations()
-
-    suspend fun addAll(bookmarks: List<Bookmark>)
+    // endregion
 }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarkRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarkRepository.kt
@@ -8,9 +8,9 @@ interface BookmarkRepository {
     // region Fetch, add and delete
     fun getAllBookmarks(): Flow<List<Bookmark>>
 
-    suspend fun addPageBookmark(page: Int): Bookmark
+    suspend fun addPageBookmark(page: Int)
 
-    suspend fun addAyahBookmark(sura: Int, ayah: Int): Bookmark
+    suspend fun addAyahBookmark(sura: Int, ayah: Int)
 
     suspend fun deletePageBookmark(page: Int)
 

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarkRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarkRepository.kt
@@ -3,6 +3,8 @@ package com.quran.shared.persistence.repository
 import com.quran.shared.persistence.model.Bookmark
 import kotlinx.coroutines.flow.Flow
 
+class DuplicateBookmarkException(message: String) : Exception(message)
+
 interface BookmarkRepository {
 
     // region Fetch, add and delete

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarkRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarkRepository.kt
@@ -19,7 +19,7 @@ interface BookmarkRepository {
 
     suspend fun deleteAyahBookmark(sura: Int, ayah: Int)
 
-    suspend fun addAll(bookmarks: List<Bookmark>)
+    suspend fun migrateBookmarks(bookmarks: List<Bookmark>)
     // endregion
 
     // region Synchronization-related

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarkRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarkRepository.kt
@@ -25,7 +25,7 @@ interface BookmarkRepository {
     // region Synchronization-related
     suspend fun fetchMutatedBookmarks(): List<Bookmark>
 
-    suspend fun persistedRemoteUpdates(mutations: List<Bookmark>)
+    suspend fun persistRemoteUpdates(mutations: List<Bookmark>)
 
     suspend fun clearLocalMutations()
     // endregion

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryImpl.kt
@@ -42,6 +42,12 @@ class BookmarksRepositoryImpl(
         if (bookmarks.isNotEmpty() && !bookmarks.none { it.deleted == 0L }) {
             throw DuplicateBookmarkException("A bookmark already exists for page $page")
         }
+        val persistedBookmarks = database.bookmarksQueries.getBookmarksForPage(page.toLong())
+            .executeAsList()
+        if (persistedBookmarks.isNotEmpty()) {
+            // TODO: It remains to check if that is deleted.
+            throw DuplicateBookmarkException("A bookmark already exists for page $page")
+        }
         database.bookmarks_mutationsQueries.createBookmark(null, null, page.toLong(), null)
     }
 
@@ -49,6 +55,14 @@ class BookmarksRepositoryImpl(
         val bookmarks = database.bookmarks_mutationsQueries.recordsForAyah(sura.toLong(), ayah.toLong())
             .executeAsList()
         if (bookmarks.isNotEmpty() && !bookmarks.none{ it.deleted == 0L }) {
+            throw DuplicateBookmarkException("A bookmark already exists for ayah #$ayah of sura #$sura")
+        }
+        val persistedBookmarks = database.bookmarksQueries.getBookmarksForAyah(
+            sura = sura.toLong(),
+            ayah = ayah.toLong()
+        ).executeAsList()
+        if (persistedBookmarks.isNotEmpty()) {
+            // TODO: It remains to check if that is deleted.
             throw DuplicateBookmarkException("A bookmark already exists for ayah #$ayah of sura #$sura")
         }
         database.bookmarks_mutationsQueries.createBookmark(sura.toLong(), ayah.toLong(), null, null)

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryImpl.kt
@@ -1,21 +1,39 @@
 package com.quran.shared.persistence.repository
 
+import app.cash.sqldelight.coroutines.asFlow
 import com.quran.shared.persistence.QuranDatabase
 import com.quran.shared.persistence.model.Bookmark
+import com.quran.shared.persistence.model.BookmarkLocalMutation
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 
 class BookmarksRepositoryImpl(
     private val database: QuranDatabase
 ) : BookmarkRepository {
-    override fun getAllBookmarks(): Flow<List<Bookmark>> = flowOf(emptyList())
-
-    override suspend fun addPageBookmark(page: Int): Bookmark {
-        TODO("Not yet implemented")
+    override fun getAllBookmarks(): Flow<List<Bookmark>> {
+        return database.bookmarks_mutationsQueries.getBookmarksMutations()
+            .asFlow()
+            .map { query ->
+                query.executeAsList()
+                    .map { mutation ->
+                        Bookmark(
+                        sura = mutation.sura?.toInt(),
+                        ayah = mutation.ayah?.toInt(),
+                        page = mutation.page?.toInt(),
+                        remoteId = mutation.remote_id,
+                        localMutation = if (mutation.deleted == 1L) BookmarkLocalMutation.DELETED else BookmarkLocalMutation.CREATED,
+                        lastUpdated = mutation.created_at
+                    )
+                    }
+            }
     }
 
-    override suspend fun addAyahBookmark(sura: Int, ayah: Int): Bookmark {
-        TODO("Not yet implemented")
+    override suspend fun addPageBookmark(page: Int) {
+        database.bookmarks_mutationsQueries.createBookmark(null, null, page.toLong(), null)
+    }
+
+    override suspend fun addAyahBookmark(sura: Int, ayah: Int) {
+        database.bookmarks_mutationsQueries.createBookmark(sura.toLong(), ayah.toLong(), null, null)
     }
 
     override suspend fun addAll(bookmarks: List<Bookmark>) {

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryImpl.kt
@@ -37,10 +37,20 @@ class BookmarksRepositoryImpl(
     }
 
     override suspend fun addPageBookmark(page: Int) {
+        val bookmarks = database.bookmarks_mutationsQueries.recordsForPage(page.toLong())
+            .executeAsList()
+        if (bookmarks.isNotEmpty() && !bookmarks.none { it.deleted == 0L }) {
+            throw DuplicateBookmarkException("A bookmark already exists for page $page")
+        }
         database.bookmarks_mutationsQueries.createBookmark(null, null, page.toLong(), null)
     }
 
     override suspend fun addAyahBookmark(sura: Int, ayah: Int) {
+        val bookmarks = database.bookmarks_mutationsQueries.recordsForAyah(sura.toLong(), ayah.toLong())
+            .executeAsList()
+        if (bookmarks.isNotEmpty() && !bookmarks.none{ it.deleted == 0L }) {
+            throw DuplicateBookmarkException("A bookmark already exists for ayah #$ayah of sura #$sura")
+        }
         database.bookmarks_mutationsQueries.createBookmark(sura.toLong(), ayah.toLong(), null, null)
     }
 

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryImpl.kt
@@ -115,14 +115,16 @@ class BookmarksRepositoryImpl(
     }
 
     override suspend fun fetchMutatedBookmarks(): List<Bookmark> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun persistedRemoteUpdates(mutations: List<Bookmark>) {
-        TODO("Not yet implemented")
+        return database.bookmarks_mutationsQueries.getBookmarksMutations()
+            .executeAsList()
+            .map { it.toBookmark() }
     }
 
     override suspend fun clearLocalMutations() {
+        database.bookmarks_mutationsQueries.clearBookmarkMutations()
+    }
+
+    override suspend fun persistRemoteUpdates(mutations: List<Bookmark>) {
         TODO("Not yet implemented")
     }
 }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryImpl.kt
@@ -1,0 +1,44 @@
+package com.quran.shared.persistence.repository
+
+import com.quran.shared.persistence.QuranDatabase
+import com.quran.shared.persistence.model.Bookmark
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class BookmarksRepositoryImpl(
+    private val database: QuranDatabase
+) : BookmarkRepository {
+    override fun getAllBookmarks(): Flow<List<Bookmark>> = flowOf(emptyList())
+
+    override suspend fun addPageBookmark(page: Int): Bookmark {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun addAyahBookmark(sura: Int, ayah: Int): Bookmark {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun addAll(bookmarks: List<Bookmark>) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun fetchMutatedBookmarks(): List<Bookmark> {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun persistedRemoteUpdates(mutations: List<Bookmark>) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun clearLocalMutations() {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun deletePageBookmark(page: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun deleteAyahBookmark(sura: Int, ayah: Int) {
+        TODO("Not yet implemented")
+    }
+} 

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks.sq
@@ -21,3 +21,6 @@ getBookmarksForPage:
 
 getBookmarksForAyah:
     SELECT * FROM bookmarks WHERE sura = ? AND ayah = ?;
+
+deleteBookmarkByRemoteId:
+    DELETE FROM bookmarks WHERE remote_id = ?;

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks.sq
@@ -15,3 +15,9 @@ addBookmark:
 batchInsertBookmarks:
     INSERT INTO bookmarks (remote_id, sura, ayah, page, created_at)
     VALUES (?, ?, ?, ?, ?);
+
+getBookmarksForPage:
+    SELECT * FROM bookmarks WHERE page = ?;
+
+getBookmarksForAyah:
+    SELECT * FROM bookmarks WHERE sura = ? AND ayah = ?;

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks.sq
@@ -1,14 +1,17 @@
 CREATE TABLE bookmarks(
-  local_id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  remote_id TEXT NOT NULL PRIMARY KEY,
   sura INTEGER,
   ayah INTEGER,
   page INTEGER,
-  remote_id TEXT,
-  last_updated INTEGER DEFAULT (strftime('%s', 'now')) NOT NULL
+  created_at INTEGER NOT NULL
 );
 
 getBookmarks:
     SELECT * FROM bookmarks;
 
 addBookmark:
-    INSERT INTO bookmarks (sura, ayah, page, remote_id) VALUES (?, ?, ?, ?);
+    INSERT INTO bookmarks (remote_id, sura, ayah, page, created_at) VALUES (?, ?, ?, ?, ?);
+
+batchInsertBookmarks:
+    INSERT INTO bookmarks (remote_id, sura, ayah, page, created_at)
+    VALUES (?, ?, ?, ?, ?);

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks.sq
@@ -1,7 +1,9 @@
 CREATE TABLE bookmarks(
-  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-  sura INTEGER NOT NULL,
-  ayah INTEGER NOT NULL,
+  local_id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  sura INTEGER,
+  ayah INTEGER,
+  page INTEGER,
+  remote_id TEXT,
   last_updated INTEGER DEFAULT (strftime('%s', 'now')) NOT NULL
 );
 
@@ -9,4 +11,4 @@ getBookmarks:
     SELECT * FROM bookmarks;
 
 addBookmark:
-    INSERT INTO bookmarks (sura, ayah) VALUES (?, ?);
+    INSERT INTO bookmarks (sura, ayah, page, remote_id) VALUES (?, ?, ?, ?);

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks.sq
@@ -12,15 +12,8 @@ getBookmarks:
 addBookmark:
     INSERT INTO bookmarks (remote_id, sura, ayah, page, created_at) VALUES (?, ?, ?, ?, ?);
 
-batchInsertBookmarks:
-    INSERT INTO bookmarks (remote_id, sura, ayah, page, created_at)
-    VALUES (?, ?, ?, ?, ?);
-
-getBookmarksForPage:
-    SELECT * FROM bookmarks WHERE page = ?;
-
-getBookmarksForAyah:
-    SELECT * FROM bookmarks WHERE sura = ? AND ayah = ?;
+getBookmarksFor:
+    SELECT * FROM bookmarks WHERE page = ? AND sura = ? AND ayah = ?;
 
 deleteBookmarkByRemoteId:
     DELETE FROM bookmarks WHERE remote_id = ?;

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks_mutations.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks_mutations.sq
@@ -28,3 +28,9 @@ batchInsertBookmarkMutations:
 
 deleteBookmarkMutation:
     DELETE FROM bookmarks_mutations WHERE local_id = ?;
+
+recordsForPage:
+    SELECT * FROM bookmarks_mutations WHERE page = ?;
+
+recordsForAyah:
+    SELECT * FROM bookmarks_mutations WHERE sura = ? AND ayah = ?;

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks_mutations.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks_mutations.sq
@@ -22,15 +22,8 @@ createMarkAsDeletedRecord:
 clearBookmarkMutations:
     DELETE FROM bookmarks_mutations;
 
-batchInsertBookmarkMutations:
-    INSERT INTO bookmarks_mutations (sura, ayah, page, remote_id, deleted)
-    VALUES (?, ?, ?, ?, ?);
-
 deleteBookmarkMutation:
     DELETE FROM bookmarks_mutations WHERE local_id = ?;
 
-recordsForPage:
-    SELECT * FROM bookmarks_mutations WHERE page = ?;
-
-recordsForAyah:
-    SELECT * FROM bookmarks_mutations WHERE sura = ? AND ayah = ?;
+getBookmarksMutationsFor:
+    SELECT * FROM bookmarks_mutations WHERE page = ? AND sura = ? AND ayah = ?;

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks_mutations.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks_mutations.sq
@@ -1,0 +1,30 @@
+CREATE TABLE bookmarks_mutations(
+  local_id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  sura INTEGER,
+  ayah INTEGER,
+  page INTEGER,
+  remote_id TEXT,
+  deleted INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER DEFAULT (strftime('%s', 'now')) NOT NULL
+);
+
+getBookmarksMutations:
+    SELECT * FROM bookmarks_mutations;
+
+createBookmark:
+    INSERT INTO bookmarks_mutations (sura, ayah, page, remote_id, deleted)
+    VALUES (?, ?, ?, ?, 0);
+
+createMarkAsDeletedRecord:
+    INSERT INTO bookmarks_mutations (sura, ayah, page, remote_id, deleted)
+    VALUES (?, ?, ?, ?, 1);
+
+clearBookmarkMutations:
+    DELETE FROM bookmarks_mutations;
+
+batchInsertBookmarkMutations:
+    INSERT INTO bookmarks_mutations (sura, ayah, page, remote_id, deleted)
+    VALUES (?, ?, ?, ?, ?);
+
+deleteBookmarkMutation:
+    DELETE FROM bookmarks_mutations WHERE local_id = ?;

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarkRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarkRepositoryTest.kt
@@ -110,5 +110,15 @@ class BookmarkRepositoryTest {
         assertEquals(2, updatedBookmarks.size, "Should have two bookmarks total")
         assertEquals(1, updatedBookmarks.count { it.isAyahBookmark }, "Should have one ayah bookmark")
         assertEquals(1, updatedBookmarks.count { it.isPageBookmark }, "Should have one page bookmark")
+
+        database.bookmarksQueries.addBookmark("rem_id_1", null, null, 105, 10_000L)
+        database.bookmarksQueries.addBookmark("rem_id_2", 9, 50, null, 10_050L)
+
+        assertFailsWith<DuplicateBookmarkException>{
+            repository.addPageBookmark(105)
+        }
+        assertFailsWith<DuplicateBookmarkException> {
+            repository.addAyahBookmark(9, 50)
+        }
     }
 }

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarkRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarkRepositoryTest.kt
@@ -201,7 +201,8 @@ class BookmarkRepositoryTest {
         assertEquals(listOf(15), bookmarks.mapNotNull { it.page })
         assertEquals(listOf(2), bookmarks.mapNotNull { it.sura })
 
-        val mutatedBookmarksPage15 = database.bookmarks_mutationsQueries.recordsForPage(15L)
+        val mutatedBookmarksPage15 = database.bookmarks_mutationsQueries
+            .getBookmarksMutationsFor(page = 15L, null, null)
             .executeAsList()
         assertEquals(2, mutatedBookmarksPage15.count())
         assertEquals("rem_id_1", mutatedBookmarksPage15.firstOrNull { it.deleted == 1L }?.remote_id,

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarkRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarkRepositoryTest.kt
@@ -1,0 +1,110 @@
+package com.quran.shared.persistence.repository
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.quran.shared.persistence.QuranDatabase
+import com.quran.shared.persistence.model.Bookmark
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BookmarkRepositoryTest {
+    private lateinit var driver: SqlDriver
+    private lateinit var database: QuranDatabase
+    private lateinit var repository: BookmarkRepository
+
+    @BeforeTest
+    fun setup() {
+        // Create in-memory database
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        
+        // Create tables
+        QuranDatabase.Schema.create(driver)
+        
+        // Initialize database
+        database = QuranDatabase(driver)
+        
+        // Initialize repository
+        repository = BookmarksRepositoryImpl(database)
+    }
+
+    @Test
+    fun `getAllBookmarks returns empty list when no bookmarks exist`() = runTest {
+        val bookmarks = repository.getAllBookmarks().first()
+        assertTrue(bookmarks.isEmpty())
+    }
+
+    @Test
+    fun `addPageBookmark adds page bookmark to database`() = runTest {
+        val page = 1
+        val bookmark = repository.addPageBookmark(page)
+        assertEquals(page, bookmark.page)
+    }
+
+    @Test
+    fun `addAyahBookmark adds ayah bookmark to database`() = runTest {
+//        val sura = 1
+//        val ayah = 1
+//        val bookmark = repository.addAyahBookmark(sura, ayah)
+//        assertEquals(sura, bookmark.sura)
+//        assertEquals(ayah, bookmark.ayah)
+        assertTrue(false)
+    }
+
+    @Test
+    fun `addAll adds multiple bookmarks to database`() = runTest {
+//        val bookmarks = listOf(
+//            Bookmark(page = 1),
+//            Bookmark(sura = 1, ayah = 1)
+//        )
+//        repository.addAll(bookmarks)
+//        val result = repository.getAllBookmarks().first()
+//        assertEquals(bookmarks.size, result.size)
+    }
+
+    @Test
+    fun `fetchMutatedBookmarks returns empty list when no mutations exist`() = runTest {
+//        val mutations = repository.fetchMutatedBookmarks()
+//        assertTrue(mutations.isEmpty())
+    }
+
+    @Test
+    fun `persistedRemoteUpdates marks mutations as persisted`() = runTest {
+//        val mutations = listOf(
+//            Bookmark(page = 1),
+//            Bookmark(sura = 1, ayah = 1)
+//        )
+//        repository.persistedRemoteUpdates(mutations)
+//        val result = repository.fetchMutatedBookmarks()
+//        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `clearLocalMutations removes all mutations from database`() = runTest {
+//        repository.clearLocalMutations()
+//        val mutations = repository.fetchMutatedBookmarks()
+//        assertTrue(mutations.isEmpty())
+    }
+
+    @Test
+    fun `deletePageBookmark removes page bookmark from database`() = runTest {
+//        val page = 1
+//        repository.addPageBookmark(page)
+//        repository.deletePageBookmark(page)
+//        val bookmarks = repository.getAllBookmarks().first()
+//        assertTrue(bookmarks.isEmpty())
+    }
+
+    @Test
+    fun `deleteAyahBookmark removes ayah bookmark from database`() = runTest {
+//        val sura = 1
+//        val ayah = 1
+//        repository.addAyahBookmark(sura, ayah)
+//        repository.deleteAyahBookmark(sura, ayah)
+//        val bookmarks = repository.getAllBookmarks().first()
+//        assertTrue(bookmarks.isEmpty())
+    }
+} 


### PR DESCRIPTION
Introduces the bookmarks repository. 

The API handles:
- The needed APIs for the flow, adding and deleting.
- Functions needed for synchronization; fetching mutations, persisting remote updates and clearing mutations.
- One function for migrating from the old storage. 

Some design decisions:
- Decided to keep both ayah and page bookmarks in the same storage. 
- Use one table for persisted data (bookmarks.sq "might rename it"), and one for mutations. 

I still need to give the API another look (do we need IDs in the public model type? Should the mutation be added to the model? ... ) so there'll be updates. 