### PR TITLE
Support jvm

### DIFF
--- a/mutations-definitions/build.gradle.kts
+++ b/mutations-definitions/build.gradle.kts
@@ -1,8 +1,5 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.android.library)
     alias(libs.plugins.vanniktech.maven.publish)
 }
 
@@ -11,12 +8,7 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
-    androidTarget {
-        publishLibraryVariants("release")
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
-    }
+    jvm()
 
     sourceSets {
         commonMain.dependencies {
@@ -35,20 +27,6 @@ kotlin {
                 freeCompilerArgs.add("-Xexpect-actual-classes")
             }
         }
-    }
-}
-
-android {
-    namespace = "com.quran.shared.mutations"
-    compileSdk = libs.versions.android.compile.sdk.get().toInt()
-
-    defaultConfig {
-        minSdk = libs.versions.android.min.sdk.get().toInt()
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.valueOf("VERSION_${libs.versions.android.java.version.get()}")
-        targetCompatibility = JavaVersion.valueOf("VERSION_${libs.versions.android.java.version.get()}")
     }
 }
 

--- a/persistence/build.gradle.kts
+++ b/persistence/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
+    jvm()
     androidTarget {
         publishLibraryVariants("release")
         compilerOptions {
@@ -31,6 +32,10 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutines.test)
+        }
+
+        jvmMain.dependencies {
+            implementation(libs.sqldelight.sqlite.driver)
         }
 
         androidMain.dependencies {

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/PageBookmarkQueriesExtensions.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/PageBookmarkQueriesExtensions.kt
@@ -3,8 +3,8 @@ package com.quran.shared.persistence.repository
 
 import com.quran.shared.mutations.LocalModelMutation
 import com.quran.shared.mutations.Mutation
-import com.quran.shared.persistence.model.PageBookmark
 import com.quran.shared.persistence.model.DatabasePageBookmark
+import com.quran.shared.persistence.model.PageBookmark
 import kotlin.time.Instant
 
 fun DatabasePageBookmark.toBookmark(): PageBookmark {

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/PageBookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/PageBookmarksRepositoryImpl.kt
@@ -8,11 +8,11 @@ import com.quran.shared.mutations.Mutation
 import com.quran.shared.mutations.RemoteModelMutation
 import com.quran.shared.persistence.QuranDatabase
 import com.quran.shared.persistence.model.PageBookmark
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 
 class PageBookmarksRepositoryImpl(
     private val database: QuranDatabase

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/PageBookmarksRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/PageBookmarksRepositoryTest.kt
@@ -1,15 +1,20 @@
 @file:OptIn(kotlin.time.ExperimentalTime::class)
 package com.quran.shared.persistence.repository
 
-import com.quran.shared.persistence.QuranDatabase
-import com.quran.shared.persistence.model.PageBookmark
-import com.quran.shared.mutations.LocalModelMutation
-import com.quran.shared.mutations.RemoteModelMutation
 import com.quran.shared.mutations.Mutation
+import com.quran.shared.mutations.RemoteModelMutation
+import com.quran.shared.persistence.QuranDatabase
+import com.quran.shared.persistence.TestDatabaseDriver
+import com.quran.shared.persistence.model.PageBookmark
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
-import kotlin.test.*
-import com.quran.shared.persistence.TestDatabaseDriver
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.time.Instant
 
 class PageBookmarksRepositoryTest {

--- a/persistence/src/jvmMain/kotlin/com/quran/shared/persistence/DriverFactory.jvm.kt
+++ b/persistence/src/jvmMain/kotlin/com/quran/shared/persistence/DriverFactory.jvm.kt
@@ -1,0 +1,11 @@
+package com.quran.shared.persistence
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import java.util.*
+
+actual class DriverFactory {
+    actual fun makeDriver(): SqlDriver {
+        return JdbcSqliteDriver("jdbc:sqlite:quran.db", Properties(), QuranDatabase.Schema)
+    }
+}

--- a/persistence/src/jvmTest/kotlin/com/quran/shared/persistence/TestDatabaseDriver.jvm.kt
+++ b/persistence/src/jvmTest/kotlin/com/quran/shared/persistence/TestDatabaseDriver.jvm.kt
@@ -1,0 +1,12 @@
+package com.quran.shared.persistence
+
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+
+actual class TestDatabaseDriver {
+    actual fun createDriver(): SqlDriver {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        QuranDatabase.Schema.create(driver)
+        return driver
+    }
+}

--- a/sync-pipelines/build.gradle.kts
+++ b/sync-pipelines/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
+    jvm()
     androidTarget {
         publishLibraryVariants("release")
         compilerOptions {

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncEnginePipeline.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncEnginePipeline.kt
@@ -6,8 +6,8 @@ import com.quran.shared.mutations.LocalModelMutation
 import com.quran.shared.mutations.RemoteModelMutation
 import com.quran.shared.persistence.repository.PageBookmarksSynchronizationRepository
 import com.quran.shared.syncengine.AuthenticationDataFetcher
-import com.quran.shared.syncengine.LocalModificationDateFetcher
 import com.quran.shared.syncengine.LocalDataFetcher
+import com.quran.shared.syncengine.LocalModificationDateFetcher
 import com.quran.shared.syncengine.PageBookmark
 import com.quran.shared.syncengine.PageBookmarksSynchronizationConfigurations
 import com.quran.shared.syncengine.ResultNotifier

--- a/syncengine/build.gradle.kts
+++ b/syncengine/build.gradle.kts
@@ -1,9 +1,6 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.android.library)
     alias(libs.plugins.vanniktech.maven.publish)
 }
 
@@ -12,12 +9,7 @@ kotlin {
     iosArm64()
     iosSimulatorArm64()
 
-    androidTarget {
-        publishLibraryVariants("release")
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
-    }
+    jvm()
 
     sourceSets {
 
@@ -33,7 +25,7 @@ kotlin {
             api(projects.mutationsDefinitions)
         }
 
-        androidMain.dependencies {
+        jvmMain.dependencies {
             implementation(libs.ktor.client.okhttp)
         }
 
@@ -55,26 +47,6 @@ kotlin {
             compileTaskProvider.get().compilerOptions {
                 freeCompilerArgs.add("-Xexpect-actual-classes")
             }
-        }
-    }
-}
-
-android {
-    namespace = "com.quran.shared.syncengine"
-    compileSdk = libs.versions.android.compile.sdk.get().toInt()
-
-    defaultConfig {
-        minSdk = libs.versions.android.min.sdk.get().toInt()
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.valueOf("VERSION_${libs.versions.android.java.version.get()}")
-        targetCompatibility = JavaVersion.valueOf("VERSION_${libs.versions.android.java.version.get()}")
-    }
-
-    testOptions {
-        unitTests {
-            isIncludeAndroidResources = true
         }
     }
 }

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/PageBookmarksSynchronizationExecutor.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/PageBookmarksSynchronizationExecutor.kt
@@ -3,11 +3,11 @@ package com.quran.shared.syncengine
 import co.touchlab.kermit.Logger
 import com.quran.shared.mutations.LocalModelMutation
 import com.quran.shared.mutations.RemoteModelMutation
-import com.quran.shared.syncengine.conflict.ConflictDetector
 import com.quran.shared.syncengine.conflict.ConflictDetectionResult
-import com.quran.shared.syncengine.conflict.ResourceConflict
-import com.quran.shared.syncengine.conflict.ConflictResolver
+import com.quran.shared.syncengine.conflict.ConflictDetector
 import com.quran.shared.syncengine.conflict.ConflictResolutionResult
+import com.quran.shared.syncengine.conflict.ConflictResolver
+import com.quran.shared.syncengine.conflict.ResourceConflict
 import com.quran.shared.syncengine.preprocessing.LocalMutationsPreprocessor
 import com.quran.shared.syncengine.preprocessing.RemoteMutationsPreprocessor
 

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/conflict/ResourceConflict.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/conflict/ResourceConflict.kt
@@ -2,7 +2,6 @@ package com.quran.shared.syncengine.conflict
 
 import com.quran.shared.mutations.LocalModelMutation
 import com.quran.shared.mutations.RemoteModelMutation
-import com.quran.shared.syncengine.PageBookmark
 
 /**
  * Represents a group of conflicting local and remote mutations for the same resource.

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/GetMutationsRequest.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/GetMutationsRequest.kt
@@ -5,10 +5,12 @@ import co.touchlab.kermit.Logger
 import com.quran.shared.mutations.Mutation
 import com.quran.shared.mutations.RemoteModelMutation
 import com.quran.shared.syncengine.PageBookmark
-import io.ktor.client.*
-import io.ktor.client.call.*
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/HttpClientFactory.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/HttpClientFactory.kt
@@ -1,9 +1,6 @@
 package com.quran.shared.syncengine.network
 
-import io.ktor.client.*
-import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.plugins.logging.*
-import io.ktor.serialization.kotlinx.json.*
+import io.ktor.client.HttpClient
 
 expect object HttpClientFactory {
     fun createHttpClient(): HttpClient

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/PostMutationsRequest.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/PostMutationsRequest.kt
@@ -6,11 +6,16 @@ import com.quran.shared.mutations.LocalModelMutation
 import com.quran.shared.mutations.Mutation
 import com.quran.shared.mutations.RemoteModelMutation
 import com.quran.shared.syncengine.PageBookmark
-import io.ktor.client.*
-import io.ktor.client.call.*
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
-import io.ktor.http.*
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.headers
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
 import kotlinx.serialization.Serializable
 import kotlin.time.Instant
 

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/preprocessing/RemoteMutationsPreprocessor.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/preprocessing/RemoteMutationsPreprocessor.kt
@@ -1,7 +1,7 @@
 package com.quran.shared.syncengine.preprocessing
 
-import com.quran.shared.mutations.RemoteModelMutation
 import com.quran.shared.mutations.Mutation
+import com.quran.shared.mutations.RemoteModelMutation
 import com.quran.shared.syncengine.PageBookmark
 
 class RemoteMutationsPreprocessor(

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/scheduling/Scheduler.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/scheduling/Scheduler.kt
@@ -2,10 +2,10 @@ package com.quran.shared.syncengine.scheduling
 
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/PageBookmarksSynchronizationExecutorTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/PageBookmarksSynchronizationExecutorTest.kt
@@ -5,8 +5,13 @@ import com.quran.shared.mutations.LocalModelMutation
 import com.quran.shared.mutations.Mutation
 import com.quran.shared.mutations.RemoteModelMutation
 import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import kotlin.time.Instant
-import kotlin.test.*
+
 class PageBookmarksSynchronizationExecutorTest {
     
     private val pipeline = PageBookmarksSynchronizationExecutor()

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/SynchronizationClientIntegrationTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/SynchronizationClientIntegrationTest.kt
@@ -2,19 +2,17 @@
 package com.quran.shared.syncengine
 
 import com.quran.shared.mutations.LocalModelMutation
-import com.quran.shared.mutations.RemoteModelMutation
 import com.quran.shared.mutations.Mutation
-import com.quran.shared.syncengine.network.HttpClientFactory
+import com.quran.shared.mutations.RemoteModelMutation
 import io.ktor.client.HttpClient
-import kotlin.test.Test
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Ignore
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.test.runTest
 import kotlin.time.Instant
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Integration tests for SynchronizationClient.

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/conflict/ConflictResolverTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/conflict/ConflictResolverTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.time.Instant
-import kotlinx.coroutines.test.runTest
+
 class ConflictResolverTest {
     
     @Test

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/preprocessing/LocalMutationsPreprocessorTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/preprocessing/LocalMutationsPreprocessorTest.kt
@@ -6,9 +6,10 @@ import com.quran.shared.mutations.Mutation
 import com.quran.shared.syncengine.PageBookmark
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 import kotlin.time.Instant
+
 class LocalMutationsPreprocessorTest {
     
     private val preprocessor = LocalMutationsPreprocessor()

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/preprocessing/RemoteMutationsPreprocessorTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/preprocessing/RemoteMutationsPreprocessorTest.kt
@@ -1,15 +1,14 @@
 @file:OptIn(kotlin.time.ExperimentalTime::class)
 package com.quran.shared.syncengine.preprocessing
 
-import com.quran.shared.mutations.LocalModelMutation
-import com.quran.shared.mutations.RemoteModelMutation
 import com.quran.shared.mutations.Mutation
+import com.quran.shared.mutations.RemoteModelMutation
 import com.quran.shared.syncengine.PageBookmark
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Instant
-import kotlinx.coroutines.test.runTest
 
 class RemoteMutationsPreprocessorTest {
     

--- a/syncengine/src/iosMain/kotlin/com/quran/shared/syncengine/network/HttpClientFactory.ios.kt
+++ b/syncengine/src/iosMain/kotlin/com/quran/shared/syncengine/network/HttpClientFactory.ios.kt
@@ -1,10 +1,11 @@
 package com.quran.shared.syncengine.network
 
-import io.ktor.client.*
-import io.ktor.client.engine.darwin.*
-import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.plugins.logging.*
-import io.ktor.serialization.kotlinx.json.*
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.darwin.Darwin
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.serialization.kotlinx.json.json
 
 actual object HttpClientFactory {
     actual fun createHttpClient(): HttpClient {

--- a/syncengine/src/jvmMain/kotlin/com/quran/shared/syncengine/network/HttpClientFactory.jvm.kt
+++ b/syncengine/src/jvmMain/kotlin/com/quran/shared/syncengine/network/HttpClientFactory.jvm.kt
@@ -1,10 +1,11 @@
 package com.quran.shared.syncengine.network
 
-import io.ktor.client.*
-import io.ktor.client.engine.okhttp.*
-import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.plugins.logging.*
-import io.ktor.serialization.kotlinx.json.*
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.serialization.kotlinx.json.json
 
 actual object HttpClientFactory {
     actual fun createHttpClient(): HttpClient {


### PR DESCRIPTION
When possible, support jvm instead of Android. In cases when we need it,
support both.
