### PR TITLE
Use kmp native coroutines and clean up visibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.sqldelight) apply false
     alias(libs.plugins.vanniktech.maven.publish) apply false
+    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.native.coroutines) apply false
 }
 
 group = "com.quran.shared"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,10 @@ agp = "8.12.0"
 kotlin = "2.2.21"
 kotlinx-serialization = "1.9.0"
 kotlinx-datetime = "0.7.1-0.6.x-compat"
+ksp = "2.3.0"
+
 kermit = "2.0.8"
+native-coroutines = "1.0.0-ALPHA-47"
 
 maven-publish = "0.34.0"
 
@@ -70,3 +73,5 @@ kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref 
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+native-coroutines = { id = "com.rickclephas.kmp.nativecoroutines", version.ref = "native-coroutines" }

--- a/persistence/build.gradle.kts
+++ b/persistence/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.sqldelight)
     alias(libs.plugins.vanniktech.maven.publish)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.native.coroutines)
 }
 
 kotlin {
@@ -54,6 +56,10 @@ kotlin {
         nativeMain.dependencies {
             implementation(libs.sqldelight.native.driver)
         }
+    }
+
+    sourceSets.all {
+        languageSettings.optIn("kotlin.experimental.ExperimentalObjCName")
     }
 
     // don't show warnings for expect/actual classes

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/DriverFactory.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/DriverFactory.kt
@@ -6,7 +6,7 @@ expect class DriverFactory {
     fun makeDriver(): SqlDriver
 }
 
-fun makeDatabase(driverFactory: DriverFactory): QuranDatabase {
+internal fun makeDatabase(driverFactory: DriverFactory): QuranDatabase {
     val driver = driverFactory.makeDriver()
     return QuranDatabase(driver)
 }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/DatabaseTypes.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/DatabaseTypes.kt
@@ -2,4 +2,4 @@ package com.quran.shared.persistence.model
 
 import com.quran.shared.persistence.Page_bookmark
 
-typealias DatabasePageBookmark = Page_bookmark
+internal typealias DatabasePageBookmark = Page_bookmark

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/PageBookmarkQueriesExtensions.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/PageBookmarkQueriesExtensions.kt
@@ -7,7 +7,7 @@ import com.quran.shared.persistence.model.DatabasePageBookmark
 import com.quran.shared.persistence.model.PageBookmark
 import kotlin.time.Instant
 
-fun DatabasePageBookmark.toBookmark(): PageBookmark {
+internal fun DatabasePageBookmark.toBookmark(): PageBookmark {
     return PageBookmark(
         page = page.toInt(),
         lastUpdated = Instant.fromEpochSeconds(created_at),
@@ -15,7 +15,7 @@ fun DatabasePageBookmark.toBookmark(): PageBookmark {
     )
 }
 
-fun DatabasePageBookmark.toBookmarkMutation(): LocalModelMutation<PageBookmark> = LocalModelMutation(
+internal fun DatabasePageBookmark.toBookmarkMutation(): LocalModelMutation<PageBookmark> = LocalModelMutation(
     mutation = if (deleted == 0L) Mutation.CREATED else Mutation.DELETED,
     model = toBookmark(),
     remoteID = remote_id,

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/PageBookmarksRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/PageBookmarksRepository.kt
@@ -1,36 +1,11 @@
 package com.quran.shared.persistence.repository
 
-import com.quran.shared.mutations.LocalModelMutation
-import com.quran.shared.mutations.RemoteModelMutation
 import com.quran.shared.persistence.model.PageBookmark
+import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
 import kotlinx.coroutines.flow.Flow
 
 class DuplicatePageBookmarkException(message: String) : Exception(message)
 class PageBookmarkNotFoundException(message: String) : Exception(message)
-
-interface PageBookmarksSynchronizationRepository {
-    /**
-     * Returns a list of bookmarks that have been mutated locally (created or deleted)
-     * and need to be synchronized with the remote server.
-     */
-    suspend fun fetchMutatedBookmarks(): List<LocalModelMutation<PageBookmark>>
-
-    /**
-     * Persists the remote state of bookmarks after a successful synchronization operation.
-     * This method should be called after the remote server has confirmed the changes.
-     *
-     * @param updatesToPersist List of bookmarks with their remote IDs and mutation states to be
-     * persisted. These must have a remoteID setup.
-     * @param localMutationsToClear List of local mutations to be cleared. An item of this list
-     * denotes either a mutation that was committed remotely, or a mutation that overridden. If it
-     * was committed, a counterpart is expected in `updatesToPersists` to persist it as a remote
-     * bookmark. These must be input from the list returned by `fetchMutatedBookmarks`.
-     */
-    suspend fun applyRemoteChanges(updatesToPersist: List<RemoteModelMutation<PageBookmark>>,
-                                   localMutationsToClear: List<LocalModelMutation<PageBookmark>>)
-
-    suspend fun remoteResourcesExist(remoteIDs: List<String>): Map<String, Boolean>
-}
 
 interface PageBookmarksRepository {
     /**
@@ -39,18 +14,21 @@ interface PageBookmarksRepository {
      *
      * @return Flow<List<PageBookmark>> A flow that emits the current list of bookmarks
      */
+    @NativeCoroutines
     fun getAllBookmarks(): Flow<List<PageBookmark>>
 
     /**
      * Adds a bookmark for a specific page.
      * @throws DuplicatePageBookmarkException if a bookmark for this page already exists
      */
+    @NativeCoroutines
     suspend fun addPageBookmark(page: Int)
 
     /**
      * Deletes a bookmark for a specific page.
      * @throws PageBookmarkNotFoundException if no bookmark exists for this page
      */
+    @NativeCoroutines
     suspend fun deletePageBookmark(page: Int)
 
     /**
@@ -62,5 +40,6 @@ interface PageBookmarksRepository {
      * @throws IllegalStateException if either bookmarks or mutations tables are not empty
      * @throws IllegalArgumentException if any bookmark has a remote ID or is marked as deleted
      */
+    @NativeCoroutines
     suspend fun migrateBookmarks(bookmarks: List<PageBookmark>)
 }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/PageBookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/PageBookmarksRepositoryImpl.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 
-class PageBookmarksRepositoryImpl(
+internal class PageBookmarksRepositoryImpl(
     private val database: QuranDatabase
 ) : PageBookmarksRepository, PageBookmarksSynchronizationRepository {
     private val logger = Logger.withTag("PageBookmarksRepository")

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/PageBookmarksSynchronizationRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/PageBookmarksSynchronizationRepository.kt
@@ -1,0 +1,29 @@
+package com.quran.shared.persistence.repository
+
+import com.quran.shared.mutations.LocalModelMutation
+import com.quran.shared.mutations.RemoteModelMutation
+import com.quran.shared.persistence.model.PageBookmark
+
+interface PageBookmarksSynchronizationRepository {
+    /**
+     * Returns a list of bookmarks that have been mutated locally (created or deleted)
+     * and need to be synchronized with the remote server.
+     */
+    suspend fun fetchMutatedBookmarks(): List<LocalModelMutation<PageBookmark>>
+
+    /**
+     * Persists the remote state of bookmarks after a successful synchronization operation.
+     * This method should be called after the remote server has confirmed the changes.
+     *
+     * @param updatesToPersist List of bookmarks with their remote IDs and mutation states to be
+     * persisted. These must have a remoteID setup.
+     * @param localMutationsToClear List of local mutations to be cleared. An item of this list
+     * denotes either a mutation that was committed remotely, or a mutation that overridden. If it
+     * was committed, a counterpart is expected in `updatesToPersists` to persist it as a remote
+     * bookmark. These must be input from the list returned by `fetchMutatedBookmarks`.
+     */
+    suspend fun applyRemoteChanges(updatesToPersist: List<RemoteModelMutation<PageBookmark>>,
+                                   localMutationsToClear: List<LocalModelMutation<PageBookmark>>)
+
+    suspend fun remoteResourcesExist(remoteIDs: List<String>): Map<String, Boolean>
+}


### PR DESCRIPTION
This PR cleans up the visibility of various Kotlin functions to avoid
certain methods (ex the specific underlying database methods) from being
called from Android/Swift apps. It also adds the dependency and
annotations for kmp-nativecoroutines.
