### PR TITLE
Update deprecated jvmTarget in demo/android

### DIFF
--- a/demo/android/build.gradle.kts
+++ b/demo/android/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -18,8 +20,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
     }
 
     buildFeatures.compose = true


### PR DESCRIPTION
The deprecated syntax for setting jvmTarget prevents Kotlin 2.3.0 from
compiling, so fix it.
