### PR TITLE
Remove page from ayah bookmarks

### DIFF
--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/AyahBookmark.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/AyahBookmark.kt
@@ -5,7 +5,6 @@ import com.quran.shared.persistence.util.PlatformDateTime
 data class AyahBookmark(
     val sura: Int,
     val ayah: Int,
-    val page: Int,
     val lastUpdated: PlatformDateTime,
     val localId: String?
 )

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/ayah/AyahBookmarkQueriesExtensions.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/ayah/AyahBookmarkQueriesExtensions.kt
@@ -11,7 +11,6 @@ internal fun DatabaseAyahBookmark.toBookmark(): AyahBookmark {
     return AyahBookmark(
         sura.toInt(),
         ayah.toInt(),
-        page.toInt(),
         Instant.fromEpochSeconds(created_at).toPlatform(),
         local_id.toString()
     )

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/ayah_bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/ayah_bookmarks.sq
@@ -3,7 +3,6 @@ CREATE TABLE ayah_bookmark(
   remote_id TEXT,
   sura INTEGER NOT NULL,
   ayah INTEGER NOT NULL,
-  page INTEGER NOT NULL,
   created_at INTEGER DEFAULT (strftime('%s', 'now')) NOT NULL,
   modified_at INTEGER DEFAULT (strftime('%s', 'now')) NOT NULL,
   -- Ensure deleted is either 0 or 1


### PR DESCRIPTION
Let the ayah bookmarks table not contain the page number. This
simplifies migrations for page types without 604 pages (ex Shemerly).
