### PR TITLE
Organize and update sync call

### DIFF
--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/BookmarksSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/BookmarksSyncAdapter.kt
@@ -1,0 +1,232 @@
+package com.quran.shared.syncengine
+
+import co.touchlab.kermit.Logger
+import com.quran.shared.mutations.LocalModelMutation
+import com.quran.shared.mutations.Mutation
+import com.quran.shared.mutations.RemoteModelMutation
+import com.quran.shared.syncengine.conflict.ConflictDetector
+import com.quran.shared.syncengine.conflict.ConflictResolutionResult
+import com.quran.shared.syncengine.conflict.ConflictResolver
+import com.quran.shared.syncengine.conflict.ConflictDetectionResult
+import com.quran.shared.syncengine.conflict.ResourceConflict
+import com.quran.shared.syncengine.model.SyncBookmark
+import com.quran.shared.syncengine.preprocessing.LocalMutationsPreprocessor
+import com.quran.shared.syncengine.preprocessing.RemoteMutationsPreprocessor
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.time.Instant
+
+internal class BookmarksSyncAdapter(
+    private val configurations: BookmarksSynchronizationConfigurations
+) : SyncResourceAdapter {
+
+    override val resourceName: String = "BOOKMARK"
+    override val localModificationDateFetcher: LocalModificationDateFetcher =
+        configurations.localModificationDateFetcher
+
+    private val logger = Logger.withTag("BookmarksSyncAdapter")
+
+    override suspend fun buildPlan(
+        lastModificationDate: Long,
+        remoteMutations: List<SyncMutation>
+    ): ResourceSyncPlan {
+        val localMutations = configurations.localDataFetcher.fetchLocalMutations(lastModificationDate)
+        logger.i {
+            "Local data fetched for $resourceName: " +
+                "lastModificationDate=$lastModificationDate, localMutations=${localMutations.size}"
+        }
+        val preprocessedLocal = preprocessLocalMutations(localMutations)
+        logger.d {
+            "Local mutations preprocessed for $resourceName: " +
+                "${localMutations.size} -> ${preprocessedLocal.size}"
+        }
+
+        val parsedRemote = parseRemoteMutations(remoteMutations)
+        val preprocessedRemote = preprocessRemoteMutations(parsedRemote)
+        logger.d {
+            "Remote mutations preprocessed for $resourceName: " +
+                "${parsedRemote.size} -> ${preprocessedRemote.size}"
+        }
+
+        val conflictDetection = detectConflicts(preprocessedRemote, preprocessedLocal)
+        logger.d {
+            "Conflict detection for $resourceName: " +
+                "conflicts=${conflictDetection.conflicts.size}, " +
+                "nonConflictingLocal=${conflictDetection.nonConflictingLocalMutations.size}, " +
+                "nonConflictingRemote=${conflictDetection.nonConflictingRemoteMutations.size}"
+        }
+
+        val conflictResolution = resolveConflicts(conflictDetection.conflicts)
+        logger.d {
+            "Conflict resolution for $resourceName: " +
+                "persist=${conflictResolution.mutationsToPersist.size}, " +
+                "push=${conflictResolution.mutationsToPush.size}"
+        }
+
+        val mutationsToPush = conflictDetection.nonConflictingLocalMutations + conflictResolution.mutationsToPush
+        val mutationsToPersist = conflictDetection.nonConflictingRemoteMutations + conflictResolution.mutationsToPersist
+
+        return BookmarksResourceSyncPlan(
+            localMutationsToClear = preprocessedLocal,
+            remoteMutationsToPersist = mutationsToPersist,
+            localMutationsToPush = mutationsToPush
+        )
+    }
+
+    override suspend fun didFail(message: String) {
+        configurations.resultNotifier.didFail(message)
+    }
+
+    private fun parseRemoteMutations(
+        mutations: List<SyncMutation>
+    ): List<RemoteModelMutation<SyncBookmark>> {
+        return mutations.mapNotNull { mutation ->
+            if (!mutation.resource.equals(resourceName, ignoreCase = true)) {
+                return@mapNotNull null
+            }
+            val resourceId = mutation.resourceId
+            if (resourceId == null) {
+                logger.w { "Skipping bookmark mutation without resourceId" }
+                return@mapNotNull null
+            }
+            val bookmark = mutation.toSyncBookmark(logger) ?: return@mapNotNull null
+            RemoteModelMutation(
+                model = bookmark,
+                remoteID = resourceId,
+                mutation = mutation.mutation
+            )
+        }
+    }
+
+    private fun toSyncMutation(localMutation: LocalModelMutation<SyncBookmark>): SyncMutation {
+        return SyncMutation(
+            resource = resourceName,
+            resourceId = localMutation.remoteID,
+            mutation = localMutation.mutation,
+            data = if (localMutation.mutation == Mutation.DELETED) null else localMutation.model.toResourceData(),
+            timestamp = null
+        )
+    }
+
+    private fun preprocessLocalMutations(
+        mutations: List<LocalModelMutation<SyncBookmark>>
+    ): List<LocalModelMutation<SyncBookmark>> {
+        val preprocessor = LocalMutationsPreprocessor()
+        return preprocessor.preprocess(mutations)
+    }
+
+    private suspend fun preprocessRemoteMutations(
+        mutations: List<RemoteModelMutation<SyncBookmark>>
+    ): List<RemoteModelMutation<SyncBookmark>> {
+        val preprocessor = RemoteMutationsPreprocessor { remoteIds ->
+            configurations.localDataFetcher.checkLocalExistence(remoteIds)
+        }
+        return preprocessor.preprocess(mutations)
+    }
+
+    private fun detectConflicts(
+        remote: List<RemoteModelMutation<SyncBookmark>>,
+        local: List<LocalModelMutation<SyncBookmark>>
+    ): ConflictDetectionResult<SyncBookmark> {
+        val conflictDetector = ConflictDetector(remote, local)
+        return conflictDetector.getConflicts()
+    }
+
+    private fun resolveConflicts(
+        conflicts: List<ResourceConflict<SyncBookmark>>
+    ): ConflictResolutionResult<SyncBookmark> {
+        val resolver = ConflictResolver(conflicts)
+        return resolver.resolve()
+    }
+
+    private inner class BookmarksResourceSyncPlan(
+        private val localMutationsToClear: List<LocalModelMutation<SyncBookmark>>,
+        private val remoteMutationsToPersist: List<RemoteModelMutation<SyncBookmark>>,
+        private val localMutationsToPush: List<LocalModelMutation<SyncBookmark>>
+    ) : ResourceSyncPlan {
+        override val resourceName: String = this@BookmarksSyncAdapter.resourceName
+
+        override fun mutationsToPush(): List<SyncMutation> {
+            return localMutationsToPush.map { toSyncMutation(it) }
+        }
+
+        override suspend fun complete(newToken: Long, pushedMutations: List<SyncMutation>) {
+            val parsedPushed = parseRemoteMutations(pushedMutations)
+            val preprocessedPushed = preprocessRemoteMutations(parsedPushed)
+            val finalRemoteMutations = remoteMutationsToPersist + preprocessedPushed
+            configurations.resultNotifier.didSucceed(
+                newToken,
+                finalRemoteMutations,
+                localMutationsToClear
+            )
+        }
+    }
+}
+
+private fun SyncMutation.toSyncBookmark(logger: Logger): SyncBookmark? {
+    val data = data ?: return null
+    val id = resourceId ?: return null
+    val normalizedType = data.stringOrNull("bookmarkType") ?: data.stringOrNull("type")
+    val lastModified = Instant.fromEpochSeconds(timestamp ?: 0)
+    return when (normalizedType?.lowercase()) {
+        "page" -> {
+            val page = data.intOrNull("key")
+            if (page == null) {
+                logger.w { "Skipping bookmark mutation without page key: resourceId=$resourceId" }
+                null
+            } else {
+                SyncBookmark.PageBookmark(
+                    id = id,
+                    page = page,
+                    lastModified = lastModified
+                )
+            }
+        }
+        "ayah" -> {
+            val sura = data.intOrNull("key")
+            val ayah = data.intOrNull("verseNumber")
+            if (sura != null && ayah != null) {
+                SyncBookmark.AyahBookmark(
+                    id = id,
+                    sura = sura,
+                    ayah = ayah,
+                    lastModified = lastModified
+                )
+            } else {
+                null
+            }
+        }
+        else -> {
+            logger.w { "Skipping bookmark mutation with unsupported type=$normalizedType: resourceId=$resourceId" }
+            null
+        }
+    }
+}
+
+private fun SyncBookmark.toResourceData(): JsonObject {
+    return when (this) {
+        is SyncBookmark.PageBookmark ->
+            buildJsonObject {
+                put("type", "page")
+                put("key", page)
+                put("mushaf", 1)
+            }
+        is SyncBookmark.AyahBookmark ->
+            buildJsonObject {
+                put("type", "ayah")
+                put("key", sura)
+                put("verseNumber", ayah)
+                put("mushaf", 1)
+            }
+    }
+}
+
+private fun JsonObject.stringOrNull(key: String): String? =
+    this[key]?.jsonPrimitive?.contentOrNull
+
+private fun JsonObject.intOrNull(key: String): Int? =
+    this[key]?.jsonPrimitive?.intOrNull

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/BookmarksSynchronizationExecutor.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/BookmarksSynchronizationExecutor.kt
@@ -115,8 +115,6 @@ class BookmarksSynchronizationExecutor {
         return preprocessor.preprocess(remoteMutations)
     }
     
-
-
     private fun detectConflicts(
         remoteMutations: List<RemoteModelMutation<SyncBookmark>>,
         localMutations: List<LocalModelMutation<SyncBookmark>>

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SyncMutation.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SyncMutation.kt
@@ -1,0 +1,12 @@
+package com.quran.shared.syncengine
+
+import com.quran.shared.mutations.Mutation
+import kotlinx.serialization.json.JsonObject
+
+data class SyncMutation(
+    val resource: String,
+    val resourceId: String?,
+    val mutation: Mutation,
+    val data: JsonObject?,
+    val timestamp: Long?
+)

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SyncResourceAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SyncResourceAdapter.kt
@@ -1,0 +1,21 @@
+package com.quran.shared.syncengine
+
+interface SyncResourceAdapter {
+    val resourceName: String
+    val localModificationDateFetcher: LocalModificationDateFetcher
+
+    suspend fun buildPlan(
+        lastModificationDate: Long,
+        remoteMutations: List<SyncMutation>
+    ): ResourceSyncPlan
+
+    suspend fun didFail(message: String)
+}
+
+interface ResourceSyncPlan {
+    val resourceName: String
+
+    fun mutationsToPush(): List<SyncMutation>
+
+    suspend fun complete(newToken: Long, pushedMutations: List<SyncMutation>)
+}

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClient.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClient.kt
@@ -62,10 +62,11 @@ object SynchronizationClientBuilder {
         bookmarksConfigurations: BookmarksSynchronizationConfigurations,
         httpClient: HttpClient? = null
     ): SynchronizationClient {
+        val adapters = listOf(BookmarksSyncAdapter(bookmarksConfigurations))
         return SynchronizationClientImpl(
             environment,
             httpClient ?: HttpClientFactory.createHttpClient(),
-            bookmarksConfigurations,
+            adapters,
             authFetcher
         )
     }

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClientImpl.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClientImpl.kt
@@ -1,8 +1,6 @@
 package com.quran.shared.syncengine
 
 import co.touchlab.kermit.Logger
-import com.quran.shared.mutations.LocalModelMutation
-import com.quran.shared.syncengine.model.SyncBookmark
 import com.quran.shared.syncengine.network.GetMutationsRequest
 import com.quran.shared.syncengine.network.MutationsResponse
 import com.quran.shared.syncengine.network.PostMutationsRequest
@@ -14,7 +12,7 @@ import io.ktor.client.HttpClient
 internal class SynchronizationClientImpl(
     private val environment: SynchronizationEnvironment,
     private val httpClient: HttpClient,
-    private val bookmarksConfigurations: BookmarksSynchronizationConfigurations,
+    private val resourceAdapters: List<SyncResourceAdapter>,
     private val authenticationDataFetcher: AuthenticationDataFetcher): SynchronizationClient {
 
     private val logger = Logger.withTag("SynchronizationClient")
@@ -22,8 +20,11 @@ internal class SynchronizationClientImpl(
     private val scheduler: Scheduler = createScheduler(
         taskFunction = ::startSyncOperation,
         reachedMaximumFailureRetries = { exception ->
-            logger.e(exception) { "Sync operation failed after maximum retries: ${exception.message}" }
-            bookmarksConfigurations.resultNotifier.didFail("Sync operation failed after maximum retries: ${exception.message}")
+            val message = "Sync operation failed after maximum retries: ${exception.message}"
+            logger.e(exception) { message }
+            resourceAdapters.forEach { adapter ->
+                adapter.didFail(message)
+            }
         }
     )
 
@@ -38,34 +39,47 @@ internal class SynchronizationClientImpl(
     }
 
     private suspend fun startSyncOperation() {
-        logger.i { "Starting sync operation" }
-        
-        val pipeline = BookmarksSynchronizationExecutor()
-        val result = pipeline.executePipeline(
-            fetchLocal = { initializePipeline() },
-            fetchRemote = { lastModificationDate -> fetchRemoteModificationsPipeline(lastModificationDate) },
-            checkLocalExistence = { remoteIDs -> checkLocalExistence(remoteIDs) },
-            pushLocal = { mutations, lastModificationDate -> pushMutationsPipeline(mutations, lastModificationDate) }
-        )
-        
-        logger.i { "Sync operation completed successfully with ${result.remoteMutations.size} remote mutations to persist and ${result.localMutations.size} local mutations to clear." }
-        bookmarksConfigurations.resultNotifier.didSucceed(
-            result.lastModificationDate,
-            result.remoteMutations,
-            result.localMutations
-        )
+        if (resourceAdapters.isEmpty()) {
+            logger.w { "No sync resources configured, skipping sync operation" }
+            return
+        }
+
+        logger.i { "Starting sync operation for ${resourceAdapters.size} resource(s)" }
+
+        val authHeaders = getAuthHeaders()
+        // Assume a shared sync token across resources.
+        val lastModificationDate = resourceAdapters.first()
+            .localModificationDateFetcher
+            .localLastModificationDate() ?: 0L
+
+        val resources = resourceAdapters.map { it.resourceName }.distinct()
+        val remoteResponse = fetchRemoteMutations(lastModificationDate, authHeaders, resources)
+
+        val plans = resourceAdapters.map { adapter ->
+            adapter.buildPlan(lastModificationDate, remoteResponse.mutations)
+        }
+
+        val mutationsToPush = plans.flatMap { it.mutationsToPush() }
+        val pushResponse = pushMutations(mutationsToPush, remoteResponse.lastModificationDate, authHeaders)
+
+        val pushedMutationsByResource = pushResponse.mutations.groupBy { it.resource.uppercase() }
+        plans.forEach { plan ->
+            val pushedForResource = pushedMutationsByResource[plan.resourceName.uppercase()].orEmpty()
+            plan.complete(pushResponse.lastModificationDate, pushedForResource)
+        }
     }
 
-    private suspend fun pushLocalMutations(
-        mutations: List<LocalModelMutation<SyncBookmark>>,
-        lastModificationDate: Long): MutationsResponse {
+    private suspend fun pushMutations(
+        mutations: List<SyncMutation>,
+        lastModificationDate: Long,
+        authHeaders: Map<String, String>
+    ): MutationsResponse {
         if (mutations.isEmpty()) {
             logger.d { "No local mutations to push, skipping network request" }
             return MutationsResponse(lastModificationDate, listOf())
         }
         
         logger.i { "Pushing ${mutations.size} local mutations" }
-        val authHeaders = getAuthHeaders()
         val url = environment.endPointURL
         val request = PostMutationsRequest(httpClient, url)
         val response = request.postMutations(mutations, lastModificationDate, authHeaders)
@@ -80,38 +94,17 @@ internal class SynchronizationClientImpl(
         return headers
     }
 
-    // Pipeline Step Methods (now simplified to work with BookmarksSynchronizationExecutor)
-    private suspend fun initializePipeline(): BookmarksSynchronizationExecutor.PipelineInitData {
-        logger.d { "Fetching local data from repository" }
-        val lastModificationDate = bookmarksConfigurations.localModificationDateFetcher
-            .localLastModificationDate() ?: 0L
-        val localMutations = bookmarksConfigurations.localDataFetcher
-            .fetchLocalMutations(lastModificationDate)
-        logger.i { "Local data fetched: lastModificationDate=$lastModificationDate, localMutations=${localMutations.size}" }
-        return BookmarksSynchronizationExecutor.PipelineInitData(lastModificationDate, localMutations)
-    }
-
-    private suspend fun fetchRemoteModificationsPipeline(lastModificationDate: Long): BookmarksSynchronizationExecutor.FetchedRemoteData {
-        logger.d { "Fetching remote modifications from ${environment.endPointURL} with lastModificationDate=$lastModificationDate" }
-        val authHeaders = getAuthHeaders()
+    private suspend fun fetchRemoteMutations(
+        lastModificationDate: Long,
+        authHeaders: Map<String, String>,
+        resources: List<String>
+    ): MutationsResponse {
+        logger.d {
+            "Fetching remote modifications from ${environment.endPointURL} with " +
+                "lastModificationDate=$lastModificationDate, resources=${resources.joinToString(",")}"
+        }
         val url = environment.endPointURL
         val request = GetMutationsRequest(httpClient, url)
-        val result = request.getMutations(lastModificationDate, authHeaders)
-        return BookmarksSynchronizationExecutor.FetchedRemoteData(result.mutations, result.lastModificationDate)
-    }
-
-    private suspend fun checkLocalExistence(remoteIDs: List<String>): Map<String, Boolean> {
-        logger.d { "Checking local existence for ${remoteIDs.size} remote IDs" }
-        return bookmarksConfigurations.localDataFetcher.checkLocalExistence(remoteIDs)
-    }
-
-    private suspend fun pushMutationsPipeline(
-        localMutations: List<LocalModelMutation<SyncBookmark>>,
-        lastModificationDate: Long
-    ): BookmarksSynchronizationExecutor.PushResultData {
-        logger.d { "Executing push mutations for ${localMutations.size} mutations" }
-        val result = pushLocalMutations(localMutations, lastModificationDate)
-        logger.i { "Push mutations completed: ${result.mutations.size} pushed remote mutations received" }
-        return BookmarksSynchronizationExecutor.PushResultData(result.mutations, result.lastModificationDate)
+        return request.getMutations(lastModificationDate, authHeaders, resources)
     }
 }

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/MutationsResponse.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/MutationsResponse.kt
@@ -1,9 +1,8 @@
 package com.quran.shared.syncengine.network
 
-import com.quran.shared.mutations.RemoteModelMutation
-import com.quran.shared.syncengine.model.SyncBookmark
+import com.quran.shared.syncengine.SyncMutation
 
 data class MutationsResponse(
     val lastModificationDate: Long,
-    val mutations: List<RemoteModelMutation<SyncBookmark>>
+    val mutations: List<SyncMutation>
 )


### PR DESCRIPTION
The synchronization to the backend should be 2 api calls - one to get
the mutations, and one to persist changes. This should be global and not
per resource. This pr updates it to make it as such.
