### PR TITLE
Use milliseconds instead of seconds

### DIFF
--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/extension/BookmarkQueriesExtensions.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/extension/BookmarkQueriesExtensions.kt
@@ -14,7 +14,7 @@ import kotlin.time.Instant
 internal fun DatabasePageBookmark.toBookmark(): Bookmark.PageBookmark {
     return Bookmark.PageBookmark(
         page = page.toInt(),
-        lastUpdated = Instant.fromEpochSeconds(created_at).toPlatform(),
+        lastUpdated = Instant.fromEpochMilliseconds(created_at).toPlatform(),
         localId = local_id.toString()
     )
 }
@@ -31,7 +31,7 @@ internal fun DatabaseAyahBookmark.toBookmark(): Bookmark.AyahBookmark {
     return Bookmark.AyahBookmark(
         sura = sura.toInt(),
         ayah = ayah.toInt(),
-        lastUpdated = Instant.fromEpochSeconds(modified_at).toPlatform(),
+        lastUpdated = Instant.fromEpochMilliseconds(modified_at).toPlatform(),
         localId = local_id.toString()
     )
 }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
@@ -33,8 +33,8 @@ class BookmarksRepositoryImpl(
             // TODO - sort options - ex sort by location, by date added (default)
             (pageBookmarks + ayahBookmarks).sortedByDescending { bookmark ->
                 when (bookmark) {
-                    is Bookmark.AyahBookmark -> bookmark.lastUpdated.fromPlatform().epochSeconds
-                    is Bookmark.PageBookmark -> bookmark.lastUpdated.fromPlatform().epochSeconds
+                    is Bookmark.AyahBookmark -> bookmark.lastUpdated.fromPlatform().toEpochMilliseconds()
+                    is Bookmark.PageBookmark -> bookmark.lastUpdated.fromPlatform().toEpochMilliseconds()
                 }
             }
         }
@@ -154,7 +154,7 @@ class BookmarksRepositoryImpl(
         when (val model = remote.model) {
             is Bookmark.AyahBookmark -> {
                 val ayahId = getAyahId(model.sura, model.ayah)
-                val updatedAt = model.lastUpdated.fromPlatform().epochSeconds
+                val updatedAt = model.lastUpdated.fromPlatform().toEpochMilliseconds()
                 ayahBookmarkQueries.value.persistRemoteBookmark(
                     remote_id = remote.remoteID,
                     ayah_id = ayahId.toLong(),
@@ -168,7 +168,7 @@ class BookmarksRepositoryImpl(
                 pageBookmarkQueries.value.persistRemoteBookmark(
                     remote_id = remote.remoteID,
                     page = model.page.toLong(),
-                    created_at = model.lastUpdated.fromPlatform().epochSeconds
+                    created_at = model.lastUpdated.fromPlatform().toEpochMilliseconds()
                 )
         }
     }

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/ayah_bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/ayah_bookmarks.sq
@@ -4,8 +4,8 @@ CREATE TABLE IF NOT EXISTS ayah_bookmark(
   ayah_id INTEGER NOT NULL,
   sura INTEGER NOT NULL,
   ayah INTEGER NOT NULL,
-  created_at INTEGER DEFAULT (strftime('%s', 'now')) NOT NULL,
-  modified_at INTEGER DEFAULT (strftime('%s', 'now')) NOT NULL,
+  created_at INTEGER DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000) NOT NULL,
+  modified_at INTEGER DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000) NOT NULL,
   -- Ensure deleted is either 0 or 1
   deleted INTEGER NOT NULL DEFAULT 0,
   CHECK (deleted IN (0, 1)),
@@ -23,7 +23,7 @@ addNewBookmark {
   VALUES (NULL, :ayah_id, :sura, :ayah, 0);
   UPDATE ayah_bookmark
   SET deleted = 0,
-    modified_at = strftime('%s', 'now')
+    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
   WHERE sura = :sura AND ayah = :ayah;
 }
 
@@ -42,7 +42,7 @@ clearLocalMutationFor {
   DELETE FROM ayah_bookmark WHERE remote_id IS NULL AND local_id = :id;
   UPDATE ayah_bookmark
   SET deleted = 0,
-    modified_at = strftime('%s', 'now')
+    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
   WHERE local_id = :id;
 }
 
@@ -54,6 +54,6 @@ deleteBookmark {
   DELETE FROM ayah_bookmark WHERE sura=:sura AND ayah=:ayah AND remote_id IS NULL;
   UPDATE ayah_bookmark
   SET deleted = 1,
-    modified_at = strftime('%s', 'now')
+    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
   WHERE sura=:sura AND ayah=:ayah AND remote_id IS NOT NULL;
 }

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/page_bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/page_bookmarks.sq
@@ -2,8 +2,8 @@ CREATE TABLE IF NOT EXISTS page_bookmark(
   local_id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
   remote_id TEXT,
   page INTEGER NOT NULL UNIQUE,
-  created_at INTEGER DEFAULT (strftime('%s', 'now')) NOT NULL,
-  modified_at INTEGER DEFAULT (strftime('%s', 'now')) NOT NULL,
+  created_at INTEGER DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000) NOT NULL,
+  modified_at INTEGER DEFAULT (CAST(strftime('%s', 'now') AS INTEGER) * 1000) NOT NULL,
   deleted INTEGER NOT NULL DEFAULT 0,
   -- Ensure deleted is either 0 or 1
   CHECK (deleted IN (0, 1))
@@ -28,7 +28,7 @@ addNewBookmark {
   VALUES (NULL, :page, 0);
   UPDATE page_bookmark
   SET deleted = 0,
-    modified_at = strftime('%s', 'now')
+    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
   WHERE page = :page;
 }
 
@@ -39,13 +39,13 @@ getUnsyncedBookmarks:
 setDeleted:
   UPDATE page_bookmark
   SET deleted = 1,
-    modified_at = strftime('%s', 'now')
+    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
   WHERE local_id = ?;
 
 resetDeleted:
   UPDATE page_bookmark
   SET deleted = 0,
-    modified_at = strftime('%s', 'now')
+    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
   WHERE local_id = ?;
 
 -- Removes the record of a local bookmark or marks it as deleted if it's remote.
@@ -53,7 +53,7 @@ deleteBookmark {
   DELETE FROM page_bookmark WHERE page=:page AND remote_id IS NULL;
   UPDATE page_bookmark
   SET deleted = 1,
-    modified_at = strftime('%s', 'now')
+    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
   WHERE page=:page AND remote_id IS NOT NULL;
 }
 
@@ -68,14 +68,14 @@ clearLocalMutations {
   DELETE FROM page_bookmark WHERE remote_id IS NULL;
   UPDATE page_bookmark
   SET deleted = 0,
-    modified_at = strftime('%s', 'now');
+    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000;
 }
 
 clearLocalMutationFor {
   DELETE FROM page_bookmark WHERE remote_id IS NULL AND local_id = :id;
   UPDATE page_bookmark
   SET deleted = 0,
-    modified_at = strftime('%s', 'now')
+    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
   WHERE local_id = :id;
 }
 

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryTest.kt
@@ -219,12 +219,12 @@ class BookmarksRepositoryTest {
         val bookmarks = listOf(
             Bookmark.PageBookmark(
                 page = 1,
-                lastUpdated = Instant.fromEpochSeconds(1000).toPlatform(),
+                lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform(),
                 localId = null
             ),
             Bookmark.PageBookmark(
                 page = 2,
-                lastUpdated = Instant.fromEpochSeconds(1001).toPlatform(),
+                lastUpdated = Instant.fromEpochMilliseconds(1001).toPlatform(),
                 localId = null
             )
         )
@@ -248,7 +248,7 @@ class BookmarksRepositoryTest {
         val bookmarks = listOf(
             Bookmark.PageBookmark(
                 page = 1,
-                lastUpdated = Instant.fromEpochSeconds(1000).toPlatform(),
+                lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform(),
                 localId = null
             )
         )
@@ -264,7 +264,7 @@ class BookmarksRepositoryTest {
         val bookmarks = listOf(
             Bookmark.PageBookmark(
                 page = 1,
-                lastUpdated = Instant.fromEpochSeconds(1000).toPlatform(),
+                lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform(),
                 localId = null
             )
         )
@@ -319,7 +319,7 @@ class BookmarksRepositoryTest {
             RemoteModelMutation(
                 model = Bookmark.PageBookmark(
                     page = 10,
-                    lastUpdated = Instant.fromEpochSeconds(1000).toPlatform(),
+                    lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform(),
                     localId = null
                 ),
                 remoteID = "remote-10",
@@ -328,7 +328,7 @@ class BookmarksRepositoryTest {
             RemoteModelMutation(
                 model = Bookmark.PageBookmark(
                     page = 20,
-                    lastUpdated = Instant.fromEpochSeconds(1001).toPlatform(),
+                    lastUpdated = Instant.fromEpochMilliseconds(1001).toPlatform(),
                     localId = null
                 ),
                 remoteID = "remote-20",
@@ -337,7 +337,7 @@ class BookmarksRepositoryTest {
             RemoteModelMutation(
                 model = Bookmark.PageBookmark(
                     page = 30,
-                    lastUpdated = Instant.fromEpochSeconds(1002).toPlatform(),
+                    lastUpdated = Instant.fromEpochMilliseconds(1002).toPlatform(),
                     localId = null
                 ),
                 remoteID = "remote-30",
@@ -383,7 +383,7 @@ class BookmarksRepositoryTest {
             RemoteModelMutation(
                 model = Bookmark.PageBookmark(
                     page = 10,
-                    lastUpdated = Instant.fromEpochSeconds(1000).toPlatform(),
+                    lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform(),
                     localId = null
                 ),
                 remoteID = "remote-10",
@@ -392,7 +392,7 @@ class BookmarksRepositoryTest {
             RemoteModelMutation(
                 model = Bookmark.PageBookmark(
                     page = 30,
-                    lastUpdated = Instant.fromEpochSeconds(1001).toPlatform(),
+                    lastUpdated = Instant.fromEpochMilliseconds(1001).toPlatform(),
                     localId = null
                 ),
                 remoteID = "remote-30",
@@ -436,7 +436,7 @@ class BookmarksRepositoryTest {
             RemoteModelMutation(
                 model = Bookmark.PageBookmark(
                     page = 10,
-                    lastUpdated = Instant.fromEpochSeconds(1000).toPlatform(),
+                    lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform(),
                     localId = null
                 ),
                 remoteID = "remote-10",
@@ -445,7 +445,7 @@ class BookmarksRepositoryTest {
             RemoteModelMutation(
                 model = Bookmark.PageBookmark(
                     page = 20,
-                    lastUpdated = Instant.fromEpochSeconds(1001).toPlatform(),
+                    lastUpdated = Instant.fromEpochMilliseconds(1001).toPlatform(),
                     localId = null
                 ),
                 remoteID = "remote-20",
@@ -455,7 +455,7 @@ class BookmarksRepositoryTest {
             RemoteModelMutation(
                 model = Bookmark.PageBookmark(
                     page = 30,
-                    lastUpdated = Instant.fromEpochSeconds(1002).toPlatform(),
+                    lastUpdated = Instant.fromEpochMilliseconds(1002).toPlatform(),
                     localId = null
                 ),
                 remoteID = "remote-30",
@@ -464,7 +464,7 @@ class BookmarksRepositoryTest {
             RemoteModelMutation(
                 model = Bookmark.PageBookmark(
                     page = 40,
-                    lastUpdated = Instant.fromEpochSeconds(1003).toPlatform(),
+                    lastUpdated = Instant.fromEpochMilliseconds(1003).toPlatform(),
                     localId = null
                 ),
                 remoteID = "remote-40",
@@ -530,7 +530,7 @@ class BookmarksRepositoryTest {
             RemoteModelMutation(
                 model = Bookmark.PageBookmark(
                     page = 40,
-                    lastUpdated = Instant.fromEpochSeconds(1000).toPlatform(),
+                    lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform(),
                     localId = null
                 ),
                 remoteID = "remote-40",
@@ -539,7 +539,7 @@ class BookmarksRepositoryTest {
             RemoteModelMutation(
                 model = Bookmark.PageBookmark(
                     page = 20,
-                    lastUpdated = Instant.fromEpochSeconds(1001).toPlatform(),
+                    lastUpdated = Instant.fromEpochMilliseconds(1001).toPlatform(),
                     localId = null
                 ),
                 remoteID = "remote-20",
@@ -592,12 +592,12 @@ class BookmarksRepositoryTest {
         // Simulate remote bookmarks by directly persisting them
         // Note: In a real scenario, these would come from applyRemoteChanges
         val remoteBookmark1: RemoteModelMutation<Bookmark> = RemoteModelMutation(
-            model = Bookmark.PageBookmark(3, Instant.fromEpochSeconds(1000).toPlatform(), null),
+            model = Bookmark.PageBookmark(3, Instant.fromEpochMilliseconds(1000).toPlatform(), null),
             remoteID = "remote-1",
             mutation = Mutation.CREATED
         )
         val remoteBookmark2: RemoteModelMutation<Bookmark> = RemoteModelMutation(
-            model = Bookmark.PageBookmark(4, Instant.fromEpochSeconds(1000).toPlatform(), null),
+            model = Bookmark.PageBookmark(4, Instant.fromEpochMilliseconds(1000).toPlatform(), null),
             remoteID = "remote-2",
             mutation = Mutation.CREATED
         )

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/BookmarksSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/BookmarksSyncAdapter.kt
@@ -171,7 +171,7 @@ private fun SyncMutation.toSyncBookmark(logger: Logger): SyncBookmark? {
     val data = data ?: return null
     val id = resourceId ?: return null
     val normalizedType = data.stringOrNull("bookmarkType") ?: data.stringOrNull("type")
-    val lastModified = Instant.fromEpochSeconds(timestamp ?: 0)
+    val lastModified = Instant.fromEpochMilliseconds(timestamp ?: 0)
     return when (normalizedType?.lowercase()) {
         "page" -> {
             val page = data.intOrNull("key")

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClient.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClient.kt
@@ -10,7 +10,7 @@ import io.ktor.client.HttpClient
 
 interface LocalDataFetcher<Model> {
     /**
-     * Fetches local mutations that have occurred since the given timestamp.
+     * Fetches local mutations that have occurred since the given timestamp (epoch milliseconds).
      */
     suspend fun fetchLocalMutations(lastModified: Long): List<LocalModelMutation<Model>>
 
@@ -33,6 +33,9 @@ interface ResultNotifier<Model> {
 }
 
 interface LocalModificationDateFetcher {
+    /**
+     * Returns the last local modification timestamp in epoch milliseconds.
+     */
     suspend fun localLastModificationDate(): Long?
 }
 

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/BookmarksSynchronizationExecutorTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/BookmarksSynchronizationExecutorTest.kt
@@ -23,17 +23,17 @@ class BookmarksSynchronizationExecutorTest {
         // Given: Remote and local mutations on different pages (no conflicts)
         val remoteMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote1", page = 10, lastModified = Instant.fromEpochSeconds(1000)),
+                model = PageBookmark(id = "remote1", page = 10, lastModified = Instant.fromEpochMilliseconds(1000)),
                 remoteID = "remote1",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote2", page = 20, lastModified = Instant.fromEpochSeconds(1001)),
+                model = PageBookmark(id = "remote2", page = 20, lastModified = Instant.fromEpochMilliseconds(1001)),
                 remoteID = "remote2",
                 mutation = Mutation.MODIFIED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote3", page = 30, lastModified = Instant.fromEpochSeconds(1002)),
+                model = PageBookmark(id = "remote3", page = 30, lastModified = Instant.fromEpochMilliseconds(1002)),
                 remoteID = "remote3",
                 mutation = Mutation.DELETED
             )
@@ -41,13 +41,13 @@ class BookmarksSynchronizationExecutorTest {
         
         val localMutations = listOf(
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local1", page = 15, lastModified = Instant.fromEpochSeconds(1002)),
+                model = PageBookmark(id = "local1", page = 15, lastModified = Instant.fromEpochMilliseconds(1002)),
                 remoteID = null,
                 localID = "local1",
                 mutation = Mutation.CREATED
             ),
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local2", page = 25, lastModified = Instant.fromEpochSeconds(1003)),
+                model = PageBookmark(id = "local2", page = 25, lastModified = Instant.fromEpochMilliseconds(1003)),
                 remoteID = "remote2",
                 localID = "local2",
                 mutation = Mutation.MODIFIED
@@ -93,17 +93,17 @@ class BookmarksSynchronizationExecutorTest {
         // Given: Multiple conflicts between remote and local mutations
         val remoteMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote1", page = 10, lastModified = Instant.fromEpochSeconds(1000)),
+                model = PageBookmark(id = "remote1", page = 10, lastModified = Instant.fromEpochMilliseconds(1000)),
                 remoteID = "remote1",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote2", page = 20, lastModified = Instant.fromEpochSeconds(1001)),
+                model = PageBookmark(id = "remote2", page = 20, lastModified = Instant.fromEpochMilliseconds(1001)),
                 remoteID = "remote2",
                 mutation = Mutation.MODIFIED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote3", page = 30, lastModified = Instant.fromEpochSeconds(1002)),
+                model = PageBookmark(id = "remote3", page = 30, lastModified = Instant.fromEpochMilliseconds(1002)),
                 remoteID = "remote3",
                 mutation = Mutation.DELETED
             )
@@ -112,28 +112,28 @@ class BookmarksSynchronizationExecutorTest {
         val localMutations = listOf(
             // Conflict 1: Same page as remote1
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local1", page = 10, lastModified = Instant.fromEpochSeconds(1003)),
+                model = PageBookmark(id = "local1", page = 10, lastModified = Instant.fromEpochMilliseconds(1003)),
                 remoteID = null,
                 localID = "local1",
                 mutation = Mutation.CREATED
             ),
             // Conflict 2: Same page as remote2
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local2", page = 20, lastModified = Instant.fromEpochSeconds(1004)),
+                model = PageBookmark(id = "local2", page = 20, lastModified = Instant.fromEpochMilliseconds(1004)),
                 remoteID = null,
                 localID = "local2",
                 mutation = Mutation.MODIFIED
             ),
             // Conflict 3: Local deletion of remote3
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local3", page = 30, lastModified = Instant.fromEpochSeconds(1005)),
+                model = PageBookmark(id = "local3", page = 30, lastModified = Instant.fromEpochMilliseconds(1005)),
                 remoteID = "remote3",
                 localID = "local3",
                 mutation = Mutation.DELETED
             ),
             // No conflict
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local4", page = 40, lastModified = Instant.fromEpochSeconds(1006)),
+                model = PageBookmark(id = "local4", page = 40, lastModified = Instant.fromEpochMilliseconds(1006)),
                 remoteID = null,
                 localID = "local4",
                 mutation = Mutation.CREATED
@@ -176,19 +176,19 @@ class BookmarksSynchronizationExecutorTest {
         val localMutations = listOf(
             // 3 mutations for the same page
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local1", page = 10, lastModified = Instant.fromEpochSeconds(1000)),
+                model = PageBookmark(id = "local1", page = 10, lastModified = Instant.fromEpochMilliseconds(1000)),
                 remoteID = null,
                 localID = "local1",
                 mutation = Mutation.CREATED
             ),
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local2", page = 10, lastModified = Instant.fromEpochSeconds(1001)),
+                model = PageBookmark(id = "local2", page = 10, lastModified = Instant.fromEpochMilliseconds(1001)),
                 remoteID = null,
                 localID = "local2",
                 mutation = Mutation.CREATED
             ),
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local3", page = 10, lastModified = Instant.fromEpochSeconds(1002)),
+                model = PageBookmark(id = "local3", page = 10, lastModified = Instant.fromEpochMilliseconds(1002)),
                 remoteID = "remote1",
                 localID = "local3",
                 mutation = Mutation.DELETED
@@ -232,7 +232,7 @@ class BookmarksSynchronizationExecutorTest {
     fun `test illogical scenario - deletion without remote ID`() = runTest {
         val localMutations = listOf(
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local1", page = 10, lastModified = Instant.fromEpochSeconds(1000)),
+                model = PageBookmark(id = "local1", page = 10, lastModified = Instant.fromEpochMilliseconds(1000)),
                 remoteID = null, // This should cause an error
                 localID = "local1",
                 mutation = Mutation.DELETED
@@ -272,12 +272,12 @@ class BookmarksSynchronizationExecutorTest {
         // Given: Remote mutations including DELETE for non-existent resource
         val remoteMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote1", page = 10, lastModified = Instant.fromEpochSeconds(1000)),
+                model = PageBookmark(id = "remote1", page = 10, lastModified = Instant.fromEpochMilliseconds(1000)),
                 remoteID = "remote1",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote2", page = 20, lastModified = Instant.fromEpochSeconds(1001)),
+                model = PageBookmark(id = "remote2", page = 20, lastModified = Instant.fromEpochMilliseconds(1001)),
                 remoteID = "remote2",
                 mutation = Mutation.DELETED  // This should be filtered out if it doesn't exist locally
             )

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/conflict/ConflictDetectorTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/conflict/ConflictDetectorTest.kt
@@ -31,14 +31,14 @@ class ConflictDetectorTest {
         // Given
         val remoteModelMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochSeconds(1000)),
+                model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1000)),
                 remoteID = "remote-1",
                 mutation = Mutation.CREATED
             )
         )
         val localModelMutations = listOf(
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local-1", page = 20, lastModified = Instant.fromEpochSeconds(1001)),
+                model = PageBookmark(id = "local-1", page = 20, lastModified = Instant.fromEpochMilliseconds(1001)),
                 remoteID = null,
                 localID = "local-1",
                 mutation = Mutation.CREATED
@@ -60,25 +60,25 @@ class ConflictDetectorTest {
         // Given
         val remoteModelMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochSeconds(1000)),
+                model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1000)),
                 remoteID = "remote-1",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote-2", page = 20, lastModified = Instant.fromEpochSeconds(1001)),
+                model = PageBookmark(id = "remote-2", page = 20, lastModified = Instant.fromEpochMilliseconds(1001)),
                 remoteID = "remote-2",
                 mutation = Mutation.CREATED
             )
         )
         val localModelMutations = listOf(
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochSeconds(1003)),
+                model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1003)),
                 remoteID = null,
                 localID = "local-1",
                 mutation = Mutation.CREATED
             ),
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local-2", page = 40, lastModified = Instant.fromEpochSeconds(1004)),
+                model = PageBookmark(id = "local-2", page = 40, lastModified = Instant.fromEpochMilliseconds(1004)),
                 remoteID = null,
                 localID = "local-2",
                 mutation = Mutation.CREATED
@@ -107,24 +107,24 @@ class ConflictDetectorTest {
         // Given
         val remoteModelMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochSeconds(1000)),
+                model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1000)),
                 remoteID = "remote-1",
                 mutation = Mutation.DELETED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote-2", page = 10, lastModified = Instant.fromEpochSeconds(1001)),
+                model = PageBookmark(id = "remote-2", page = 10, lastModified = Instant.fromEpochMilliseconds(1001)),
                 remoteID = "remote-2",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote-3", page = 20, lastModified = Instant.fromEpochSeconds(1002)),
+                model = PageBookmark(id = "remote-3", page = 20, lastModified = Instant.fromEpochMilliseconds(1002)),
                 remoteID = "remote-3",
                 mutation = Mutation.CREATED
             )
         )
         val localModelMutations = listOf(
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochSeconds(200)),
+                model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochMilliseconds(200)),
                 remoteID = null,
                 localID = "local-1",
                 mutation = Mutation.CREATED
@@ -156,36 +156,36 @@ class ConflictDetectorTest {
         // Given
         val remoteModelMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochSeconds(1000)),
+                model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1000)),
                 remoteID = "remote-1",
                 mutation = Mutation.DELETED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote-2", page = 10, lastModified = Instant.fromEpochSeconds(1001)),
+                model = PageBookmark(id = "remote-2", page = 10, lastModified = Instant.fromEpochMilliseconds(1001)),
                 remoteID = "remote-2",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote-3", page = 20, lastModified = Instant.fromEpochSeconds(1002)),
+                model = PageBookmark(id = "remote-3", page = 20, lastModified = Instant.fromEpochMilliseconds(1002)),
                 remoteID = "remote-3",
                 mutation = Mutation.CREATED
             )
         )
         val localModelMutations = listOf(
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochSeconds(1003)),
+                model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1003)),
                 remoteID = "remote-1",
                 localID = "local-1",
                 mutation = Mutation.DELETED
             ),
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local-2", page = 10, lastModified = Instant.fromEpochSeconds(1004)),
+                model = PageBookmark(id = "local-2", page = 10, lastModified = Instant.fromEpochMilliseconds(1004)),
                 remoteID = null,
                 localID = "local-2",
                 mutation = Mutation.CREATED
             ),
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local-3", page = 30, lastModified = Instant.fromEpochSeconds(1005)),
+                model = PageBookmark(id = "local-3", page = 30, lastModified = Instant.fromEpochMilliseconds(1005)),
                 remoteID = null,
                 localID = "local-3",
                 mutation = Mutation.CREATED
@@ -213,31 +213,31 @@ class ConflictDetectorTest {
         // Given
         val remoteModelMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochSeconds(1000)),
+                model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1000)),
                 remoteID = "remote-1",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote-2", page = 20, lastModified = Instant.fromEpochSeconds(1001)),
+                model = PageBookmark(id = "remote-2", page = 20, lastModified = Instant.fromEpochMilliseconds(1001)),
                 remoteID = "remote-2",
                 mutation = Mutation.CREATED
             )
         )
         val localModelMutations = listOf(
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochSeconds(1002)),
+                model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1002)),
                 remoteID = "remote-1",
                 localID = "local-1",
                 mutation = Mutation.DELETED
             ),
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local-2", page = 10, lastModified = Instant.fromEpochSeconds(1003)),
+                model = PageBookmark(id = "local-2", page = 10, lastModified = Instant.fromEpochMilliseconds(1003)),
                 remoteID = null,
                 localID = "local-2",
                 mutation = Mutation.CREATED
             ),
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local-3", page = 30, lastModified = Instant.fromEpochSeconds(1004)),
+                model = PageBookmark(id = "local-3", page = 30, lastModified = Instant.fromEpochMilliseconds(1004)),
                 remoteID = null,
                 localID = "local-3",
                 mutation = Mutation.CREATED
@@ -269,25 +269,25 @@ class ConflictDetectorTest {
         // Given
         val remoteModelMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote-1", page = 0, lastModified = Instant.fromEpochSeconds(0)), // Zeroed properties for DELETE
+                model = PageBookmark(id = "remote-1", page = 0, lastModified = Instant.fromEpochMilliseconds(0)), // Zeroed properties for DELETE
                 remoteID = "remote-1",
                 mutation = Mutation.DELETED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "remote-2", page = 20, lastModified = Instant.fromEpochSeconds(1001)),
+                model = PageBookmark(id = "remote-2", page = 20, lastModified = Instant.fromEpochMilliseconds(1001)),
                 remoteID = "remote-2",
                 mutation = Mutation.CREATED
             )
         )
         val localModelMutations = listOf(
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochSeconds(1002)), // Original page info for local DELETE
+                model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1002)), // Original page info for local DELETE
                 remoteID = "remote-1", // Same remote ID as remote mutation
                 localID = "local-1",
                 mutation = Mutation.DELETED
             ),
             LocalModelMutation<SyncBookmark>(
-                model = PageBookmark(id = "local-2", page = 30, lastModified = Instant.fromEpochSeconds(1002)),
+                model = PageBookmark(id = "local-2", page = 30, lastModified = Instant.fromEpochMilliseconds(1002)),
                 remoteID = null,
                 localID = "local-2",
                 mutation = Mutation.CREATED
@@ -315,9 +315,9 @@ class ConflictDetectorTest {
         
         // Verify that the local mutation retains original page info while remote mutation has zeroed properties
         assertEquals(10, localMutation.model.pageOrThrow(), "Page number of local mutation")
-        assertEquals(Instant.fromEpochSeconds(1002), localMutation.model.lastModifiedOrThrow(), "Last modified of local mutation")
+        assertEquals(Instant.fromEpochMilliseconds(1002), localMutation.model.lastModifiedOrThrow(), "Last modified of local mutation")
         assertEquals(0, remoteMutation.model.pageOrThrow(), "Page number of remote mutation")
-        assertEquals(Instant.fromEpochSeconds(0), remoteMutation.model.lastModifiedOrThrow(), "Last modified of remote mutation")
+        assertEquals(Instant.fromEpochMilliseconds(0), remoteMutation.model.lastModifiedOrThrow(), "Last modified of remote mutation")
         
         // Verify other mutations
         assertEquals(1, result.nonConflictingRemoteMutations.size, "Number of other remote mutations")

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/conflict/ConflictResolverTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/conflict/ConflictResolverTest.kt
@@ -31,12 +31,12 @@ class ConflictResolverTest {
     fun `resolve with single page created locally and remotely should persist remote mutation`() {
         // Given
         val remoteMutation = RemoteModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochSeconds(1000)),
+            model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1000)),
             remoteID = "remote-1",
             mutation = Mutation.CREATED
         )
         val localMutation = LocalModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochSeconds(1001)),
+            model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1001)),
             remoteID = null,
             localID = "local-1",
             mutation = Mutation.CREATED
@@ -60,12 +60,12 @@ class ConflictResolverTest {
     fun `resolve with single resource deleted locally and remotely should persist remote mutation`() {
         // Given
         val remoteMutation = RemoteModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochSeconds(1000)),
+            model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1000)),
             remoteID = "remote-1",
             mutation = Mutation.DELETED
         )
         val localMutation = LocalModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochSeconds(1001)),
+            model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1001)),
             remoteID = "remote-1",
             localID = "local-1",
             mutation = Mutation.DELETED
@@ -89,17 +89,17 @@ class ConflictResolverTest {
     fun `resolve with remote delete and create vs local delete should persist both remote mutations`() {
         // Given
         val remoteDeleteMutation = RemoteModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "remote-1", page = 0, lastModified = Instant.fromEpochSeconds(1000)),
+            model = PageBookmark(id = "remote-1", page = 0, lastModified = Instant.fromEpochMilliseconds(1000)),
             remoteID = "remote-1",
             mutation = Mutation.DELETED
         )
         val remoteCreateMutation = RemoteModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "remote-2", page = 10, lastModified = Instant.fromEpochSeconds(1001)),
+            model = PageBookmark(id = "remote-2", page = 10, lastModified = Instant.fromEpochMilliseconds(1001)),
             remoteID = "remote-2",
             mutation = Mutation.CREATED
         )
         val localDeleteMutation = LocalModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochSeconds(1002)),
+            model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1002)),
             remoteID = "remote-1",
             localID = "local-1",
             mutation = Mutation.DELETED
@@ -124,18 +124,18 @@ class ConflictResolverTest {
     fun `resolve with remote delete vs local delete and create should persist remote delete and push local create`() {
         // Given
         val remoteDeleteMutation = RemoteModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "remote-1", page = 0, lastModified = Instant.fromEpochSeconds(1000)),
+            model = PageBookmark(id = "remote-1", page = 0, lastModified = Instant.fromEpochMilliseconds(1000)),
             remoteID = "remote-1",
             mutation = Mutation.DELETED
         )
         val localDeleteMutation = LocalModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochSeconds(1001)),
+            model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1001)),
             remoteID = "remote-1",
             localID = "local-1",
             mutation = Mutation.DELETED
         )
         val localCreateMutation = LocalModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "local-2", page = 10, lastModified = Instant.fromEpochSeconds(1002)),
+            model = PageBookmark(id = "local-2", page = 10, lastModified = Instant.fromEpochMilliseconds(1002)),
             remoteID = null,
             localID = "local-2",
             mutation = Mutation.CREATED
@@ -160,23 +160,23 @@ class ConflictResolverTest {
     fun `resolve with delete and create on both sides should persist remote mutations only`() {
         // Given
         val remoteDeleteMutation = RemoteModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "remote-1", page = 0, lastModified = Instant.fromEpochSeconds(1000)),
+            model = PageBookmark(id = "remote-1", page = 0, lastModified = Instant.fromEpochMilliseconds(1000)),
             remoteID = "remote-1",
             mutation = Mutation.DELETED
         )
         val remoteCreateMutation = RemoteModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "remote-2", page = 10, lastModified = Instant.fromEpochSeconds(1001)),
+            model = PageBookmark(id = "remote-2", page = 10, lastModified = Instant.fromEpochMilliseconds(1001)),
             remoteID = "remote-2",
             mutation = Mutation.CREATED
         )
         val localDeleteMutation = LocalModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochSeconds(1002)),
+            model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1002)),
             remoteID = "remote-1",
             localID = "local-1",
             mutation = Mutation.DELETED
         )
         val localCreateMutation = LocalModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "local-2", page = 10, lastModified = Instant.fromEpochSeconds(1003)),
+            model = PageBookmark(id = "local-2", page = 10, lastModified = Instant.fromEpochMilliseconds(1003)),
             remoteID = null,
             localID = "local-2",
             mutation = Mutation.CREATED
@@ -201,12 +201,12 @@ class ConflictResolverTest {
     fun `resolve with multiple conflict groups should handle each group independently`() {
         // Given - First conflict group: CREATE vs CREATE on page 10
         val remoteCreate1 = RemoteModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochSeconds(1000)),
+            model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1000)),
             remoteID = "remote-1",
             mutation = Mutation.CREATED
         )
         val localCreate1 = LocalModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochSeconds(1001)),
+            model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1001)),
             remoteID = null,
             localID = "local-1",
             mutation = Mutation.CREATED
@@ -218,12 +218,12 @@ class ConflictResolverTest {
         
         // Given - Second conflict group: DELETE vs DELETE on page 20
         val remoteDelete2 = RemoteModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "remote-2", page = 0, lastModified = Instant.fromEpochSeconds(1002)),
+            model = PageBookmark(id = "remote-2", page = 0, lastModified = Instant.fromEpochMilliseconds(1002)),
             remoteID = "remote-2",
             mutation = Mutation.DELETED
         )
         val localDelete2 = LocalModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "local-2", page = 20, lastModified = Instant.fromEpochSeconds(1003)),
+            model = PageBookmark(id = "local-2", page = 20, lastModified = Instant.fromEpochMilliseconds(1003)),
             remoteID = "remote-2",
             localID = "local-2",
             mutation = Mutation.DELETED
@@ -235,17 +235,17 @@ class ConflictResolverTest {
         
         // Given - Third conflict group: Remote delete+create vs local delete on page 30
         val remoteDelete3 = RemoteModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "remote-3", page = 0, lastModified = Instant.fromEpochSeconds(1004)),
+            model = PageBookmark(id = "remote-3", page = 0, lastModified = Instant.fromEpochMilliseconds(1004)),
             remoteID = "remote-3",
             mutation = Mutation.DELETED
         )
         val remoteCreate3 = RemoteModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "remote-4", page = 30, lastModified = Instant.fromEpochSeconds(1005)),
+            model = PageBookmark(id = "remote-4", page = 30, lastModified = Instant.fromEpochMilliseconds(1005)),
             remoteID = "remote-4",
             mutation = Mutation.CREATED
         )
         val localDelete3 = LocalModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "local-3", page = 30, lastModified = Instant.fromEpochSeconds(1006)),
+            model = PageBookmark(id = "local-3", page = 30, lastModified = Instant.fromEpochMilliseconds(1006)),
             remoteID = "remote-3",
             localID = "local-3",
             mutation = Mutation.DELETED
@@ -273,12 +273,12 @@ class ConflictResolverTest {
     fun `resolve with local creation vs remote deletion should throw error`() {
         // Given
         val remoteDeleteMutation = RemoteModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "remote-1", page = 0, lastModified = Instant.fromEpochSeconds(1000)),
+            model = PageBookmark(id = "remote-1", page = 0, lastModified = Instant.fromEpochMilliseconds(1000)),
             remoteID = "remote-1",
             mutation = Mutation.DELETED
         )
         val localCreateMutation = LocalModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochSeconds(1001)),
+            model = PageBookmark(id = "local-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1001)),
             remoteID = null,
             localID = "local-1",
             mutation = Mutation.CREATED
@@ -312,12 +312,12 @@ class ConflictResolverTest {
     fun `resolve with local deletion vs remote creation should throw error`() {
         // Given
         val remoteCreateMutation = RemoteModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochSeconds(1000)),
+            model = PageBookmark(id = "remote-1", page = 10, lastModified = Instant.fromEpochMilliseconds(1000)),
             remoteID = "remote-1",
             mutation = Mutation.CREATED
         )
         val localDeleteMutation = LocalModelMutation<SyncBookmark>(
-            model = PageBookmark(id = "local-1", page = 0, lastModified = Instant.fromEpochSeconds(1001)),
+            model = PageBookmark(id = "local-1", page = 0, lastModified = Instant.fromEpochMilliseconds(1001)),
             remoteID = "remote-1",
             localID = "local-1",
             mutation = Mutation.DELETED

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/preprocessing/LocalMutationsPreprocessorTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/preprocessing/LocalMutationsPreprocessorTest.kt
@@ -261,9 +261,9 @@ class LocalMutationsPreprocessorTest {
     }
     
     private fun createLocalMutation(page: Int, mutation: Mutation): LocalModelMutation<SyncBookmark> {
-        val timestamp = Instant.fromEpochSeconds(1000L + page * 100L)
+        val timestamp = Instant.fromEpochMilliseconds(1000L + page * 100L)
         val model = PageBookmark(
-            id = "local_${page}_${timestamp.epochSeconds}",
+            id = "local_${page}_${timestamp.toEpochMilliseconds()}",
             page = page,
             lastModified = timestamp
         )
@@ -276,9 +276,9 @@ class LocalMutationsPreprocessorTest {
     }
     
     private fun createLocalMutationWithRemoteID(page: Int, mutation: Mutation, remoteID: String?): LocalModelMutation<SyncBookmark> {
-        val timestamp = Instant.fromEpochSeconds(1000L + page * 100L)
+        val timestamp = Instant.fromEpochMilliseconds(1000L + page * 100L)
         val model = PageBookmark(
-            id = "local_${page}_${timestamp.epochSeconds}",
+            id = "local_${page}_${timestamp.toEpochMilliseconds()}",
             page = page,
             lastModified = timestamp
         )

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/preprocessing/RemoteMutationsPreprocessorTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/preprocessing/RemoteMutationsPreprocessorTest.kt
@@ -34,12 +34,12 @@ class RemoteMutationsPreprocessorTest {
         val preprocessor = RemoteMutationsPreprocessor(checkLocalExistence)
         val remoteMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("new-1", 10, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("new-1", 10, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "new-1",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("new-2", 20, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("new-2", 20, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "new-2",
                 mutation = Mutation.CREATED
             )
@@ -62,12 +62,12 @@ class RemoteMutationsPreprocessorTest {
         val preprocessor = RemoteMutationsPreprocessor(checkLocalExistence)
         val remoteMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("existing-1", 10, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("existing-1", 10, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "existing-1",
                 mutation = Mutation.DELETED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("non-existent-1", 20, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("non-existent-1", 20, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "non-existent-1",
                 mutation = Mutation.DELETED
             )
@@ -89,12 +89,12 @@ class RemoteMutationsPreprocessorTest {
         val preprocessor = RemoteMutationsPreprocessor(checkLocalExistence)
         val remoteMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("existing-1", 10, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("existing-1", 10, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "existing-1",
                 mutation = Mutation.MODIFIED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("non-existent-1", 20, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("non-existent-1", 20, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "non-existent-1",
                 mutation = Mutation.MODIFIED
             )
@@ -121,12 +121,12 @@ class RemoteMutationsPreprocessorTest {
         val preprocessor = RemoteMutationsPreprocessor(checkLocalExistence)
         val remoteMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("existing-1", 10, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("existing-1", 10, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "existing-1",
                 mutation = Mutation.MODIFIED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("existing-2", 20, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("existing-2", 20, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "existing-2",
                 mutation = Mutation.MODIFIED
             )
@@ -153,12 +153,12 @@ class RemoteMutationsPreprocessorTest {
         val preprocessor = RemoteMutationsPreprocessor(checkLocalExistence)
         val remoteMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("new-1", 10, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("new-1", 10, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "new-1",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("new-2", 20, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("new-2", 20, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "new-2",
                 mutation = Mutation.CREATED
             )
@@ -182,29 +182,29 @@ class RemoteMutationsPreprocessorTest {
         val remoteMutations = listOf(
             // CREATED mutations (should be kept)
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("new-1", 10, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("new-1", 10, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "new-1",
                 mutation = Mutation.CREATED
             ),
             // DELETE mutations (should be filtered based on existence)
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("existing-1", 20, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("existing-1", 20, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "existing-1",
                 mutation = Mutation.DELETED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("non-existent-1", 30, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("non-existent-1", 30, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "non-existent-1",
                 mutation = Mutation.DELETED
             ),
             // MODIFIED mutations (should ALL be converted to CREATED, regardless of existence)
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("existing-2", 40, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("existing-2", 40, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "existing-2",
                 mutation = Mutation.MODIFIED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("non-existent-2", 50, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("non-existent-2", 50, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "non-existent-2",
                 mutation = Mutation.MODIFIED
             )
@@ -239,12 +239,12 @@ class RemoteMutationsPreprocessorTest {
         val preprocessor = RemoteMutationsPreprocessor(checkLocalExistence)
         val remoteMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("any-id", 10, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("any-id", 10, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "any-id",
                 mutation = Mutation.DELETED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("any-id-2", 20, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("any-id-2", 20, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "any-id-2",
                 mutation = Mutation.MODIFIED
             )
@@ -267,17 +267,17 @@ class RemoteMutationsPreprocessorTest {
         val preprocessor = RemoteMutationsPreprocessor(checkLocalExistence)
         val remoteMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("existing-1", 10, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("existing-1", 10, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "existing-1",
                 mutation = Mutation.DELETED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("new-1", 20, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("new-1", 20, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "new-1",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("existing-2", 30, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("existing-2", 30, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "existing-2",
                 mutation = Mutation.MODIFIED
             )
@@ -308,27 +308,27 @@ class RemoteMutationsPreprocessorTest {
         // Create mutations in a specific order
         val remoteMutations = listOf(
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("non-existent-1", 30, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("non-existent-1", 30, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "non-existent-1",
                 mutation = Mutation.DELETED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("new-1", 20, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("new-1", 20, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "new-1",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("existing-1", 10, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("existing-1", 10, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "existing-1",
                 mutation = Mutation.DELETED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("existing-3", 40, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("existing-3", 40, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "existing-3",
                 mutation = Mutation.MODIFIED
             ),
             RemoteModelMutation<SyncBookmark>(
-                model = PageBookmark("new-2", 50, Instant.fromEpochSeconds(1000)),
+                model = PageBookmark("new-2", 50, Instant.fromEpochMilliseconds(1000)),
                 remoteID = "new-2",
                 mutation = Mutation.CREATED
             )


### PR DESCRIPTION
The backend expects timestamps in milliseconds, so use millis
everywhere.
