### PR TITLE
Separate input and general usage models

### DIFF
--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/input/BookmarkMigration.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/input/BookmarkMigration.kt
@@ -1,0 +1,6 @@
+package com.quran.shared.persistence.input
+
+sealed class BookmarkMigration {
+    data class Page(val page: Int) : BookmarkMigration()
+    data class Ayah(val sura: Int, val ayah: Int) : BookmarkMigration()
+}

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/input/CollectionMigration.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/input/CollectionMigration.kt
@@ -1,0 +1,3 @@
+package com.quran.shared.persistence.input
+
+data class CollectionMigration(val name: String)

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/input/RemoteBookmark.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/input/RemoteBookmark.kt
@@ -1,0 +1,12 @@
+package com.quran.shared.persistence.input
+
+import com.quran.shared.persistence.util.PlatformDateTime
+
+sealed class RemoteBookmark {
+    data class Page(val page: Int, val lastUpdated: PlatformDateTime) : RemoteBookmark()
+    data class Ayah(
+        val sura: Int,
+        val ayah: Int,
+        val lastUpdated: PlatformDateTime
+    ) : RemoteBookmark()
+}

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/input/RemoteCollection.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/input/RemoteCollection.kt
@@ -1,0 +1,8 @@
+package com.quran.shared.persistence.input
+
+import com.quran.shared.persistence.util.PlatformDateTime
+
+data class RemoteCollection(
+    val name: String?,
+    val lastUpdated: PlatformDateTime
+)

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/Bookmark.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/Bookmark.kt
@@ -7,13 +7,13 @@ sealed class Bookmark {
     data class PageBookmark(
         val page: Int,
         val lastUpdated: PlatformDateTime,
-        val localId: String?
+        val localId: String
     ) : Bookmark()
 
     data class AyahBookmark(
         val sura: Int,
         val ayah: Int,
         val lastUpdated: PlatformDateTime,
-        val localId: String?
+        val localId: String
     ) : Bookmark()
 }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/Collection.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/Collection.kt
@@ -3,7 +3,7 @@ package com.quran.shared.persistence.model
 import com.quran.shared.persistence.util.PlatformDateTime
 
 data class Collection(
-    val name: String?,
+    val name: String,
     val lastUpdated: PlatformDateTime,
-    val localId: String?
+    val localId: String
 )

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepository.kt
@@ -1,6 +1,7 @@
 package com.quran.shared.persistence.repository.bookmark.repository
 
 import com.quran.shared.persistence.model.Bookmark
+import com.quran.shared.persistence.input.BookmarkMigration
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
 import kotlinx.coroutines.flow.Flow
 
@@ -50,9 +51,9 @@ interface BookmarksRepository {
      * This method should only be called once during app initialization, after
      * bookmarks are added and before any changes by the user are handled.
      *
-     * @param bookmarks List of page bookmarks to migrate
+     * @param bookmarks List of bookmarks to migrate
      * @throws IllegalStateException if either bookmarks or mutations tables are not empty
      */
     @NativeCoroutines
-    suspend fun migrateBookmarks(bookmarks: List<Bookmark>)
+    suspend fun migrateBookmarks(bookmarks: List<BookmarkMigration>)
 }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksSynchronizationRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksSynchronizationRepository.kt
@@ -2,6 +2,7 @@ package com.quran.shared.persistence.repository.bookmark.repository
 
 import com.quran.shared.mutations.LocalModelMutation
 import com.quran.shared.mutations.RemoteModelMutation
+import com.quran.shared.persistence.input.RemoteBookmark
 import com.quran.shared.persistence.model.Bookmark
 
 interface BookmarksSynchronizationRepository {
@@ -15,15 +16,17 @@ interface BookmarksSynchronizationRepository {
      * Persists the remote state of bookmarks after a successful synchronization operation.
      * This method should be called after the remote server has confirmed the changes.
      *
-     * @param updatesToPersist List of bookmarks with their remote IDs and mutation states to be
-     * persisted. These must have a remoteID setup.
+     * @param updatesToPersist List of remote bookmark inputs with their remote IDs and mutation
+     * states to be persisted. These must have a remoteID setup.
      * @param localMutationsToClear List of local mutations to be cleared. An item of this list
      * denotes either a mutation that was committed remotely, or a mutation that overridden. If it
      * was committed, a counterpart is expected in `updatesToPersists` to persist it as a remote
      * bookmark. These must be input from the list returned by `fetchMutatedBookmarks`.
      */
-    suspend fun applyRemoteChanges(updatesToPersist: List<RemoteModelMutation<Bookmark>>,
-                                   localMutationsToClear: List<LocalModelMutation<Bookmark>>)
+    suspend fun applyRemoteChanges(
+        updatesToPersist: List<RemoteModelMutation<RemoteBookmark>>,
+        localMutationsToClear: List<LocalModelMutation<Bookmark>>
+    )
 
     suspend fun remoteResourcesExist(remoteIDs: List<String>): Map<String, Boolean>
 }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collection/repository/CollectionsRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collection/repository/CollectionsRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.quran.shared.mutations.LocalModelMutation
 import com.quran.shared.mutations.Mutation
 import com.quran.shared.mutations.RemoteModelMutation
 import com.quran.shared.persistence.QuranDatabase
+import com.quran.shared.persistence.input.RemoteCollection
 import com.quran.shared.persistence.model.Collection
 import com.quran.shared.persistence.repository.collection.extension.toCollection
 import com.quran.shared.persistence.repository.collection.extension.toCollectionMutation
@@ -67,7 +68,7 @@ class CollectionsRepositoryImpl(
     }
 
     override suspend fun applyRemoteChanges(
-        updatesToPersist: List<RemoteModelMutation<Collection>>,
+        updatesToPersist: List<RemoteModelMutation<RemoteCollection>>,
         localMutationsToClear: List<LocalModelMutation<Collection>>
     ) {
         logger.i {
@@ -90,7 +91,7 @@ class CollectionsRepositoryImpl(
         }
     }
 
-    private fun applyRemoteCollectionUpsert(remote: RemoteModelMutation<Collection>) {
+    private fun applyRemoteCollectionUpsert(remote: RemoteModelMutation<RemoteCollection>) {
         val name = remote.model.name
         if (name.isNullOrEmpty()) {
             logger.w { "Skipping remote collection mutation without name: remoteId=${remote.remoteID}" }
@@ -129,7 +130,7 @@ class CollectionsRepositoryImpl(
         }
     }
 
-    private fun applyRemoteCollectionDeletion(remote: RemoteModelMutation<Collection>) {
+    private fun applyRemoteCollectionDeletion(remote: RemoteModelMutation<RemoteCollection>) {
         collectionQueries.value.deleteRemoteCollection(remote_id = remote.remoteID)
     }
 

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collection/repository/CollectionsSynchronizationRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collection/repository/CollectionsSynchronizationRepository.kt
@@ -2,6 +2,7 @@ package com.quran.shared.persistence.repository.collection.repository
 
 import com.quran.shared.mutations.LocalModelMutation
 import com.quran.shared.mutations.RemoteModelMutation
+import com.quran.shared.persistence.input.RemoteCollection
 import com.quran.shared.persistence.model.Collection
 
 interface CollectionsSynchronizationRepository {
@@ -15,15 +16,15 @@ interface CollectionsSynchronizationRepository {
      * Persists the remote state of collections after a successful synchronization operation.
      * This method should be called after the remote server has confirmed the changes.
      *
-     * @param updatesToPersist List of collections with their remote IDs and mutation states to be
-     * persisted. These must have a remoteID setup.
+     * @param updatesToPersist List of remote collection inputs with their remote IDs and mutation
+     * states to be persisted. These must have a remoteID setup.
      * @param localMutationsToClear List of local mutations to be cleared. An item of this list
      * denotes either a mutation that was committed remotely, or a mutation that overridden. If it
      * was committed, a counterpart is expected in `updatesToPersist` to persist it as a remote
      * collection. These must be input from the list returned by `fetchMutatedCollections`.
      */
     suspend fun applyRemoteChanges(
-        updatesToPersist: List<RemoteModelMutation<Collection>>,
+        updatesToPersist: List<RemoteModelMutation<RemoteCollection>>,
         localMutationsToClear: List<LocalModelMutation<Collection>>
     )
 

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryTest.kt
@@ -6,6 +6,8 @@ import com.quran.shared.mutations.RemoteModelMutation
 import com.quran.shared.persistence.Page_bookmarksQueries
 import com.quran.shared.persistence.QuranDatabase
 import com.quran.shared.persistence.TestDatabaseDriver
+import com.quran.shared.persistence.input.BookmarkMigration
+import com.quran.shared.persistence.input.RemoteBookmark
 import com.quran.shared.persistence.model.Bookmark
 import com.quran.shared.persistence.repository.bookmark.repository.BookmarksRepository
 import com.quran.shared.persistence.repository.bookmark.repository.BookmarksRepositoryImpl
@@ -217,16 +219,8 @@ class BookmarksRepositoryTest {
     @Test
     fun `migrateBookmarks succeeds when table is empty`() = runTest {
         val bookmarks = listOf(
-            Bookmark.PageBookmark(
-                page = 1,
-                lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform(),
-                localId = null
-            ),
-            Bookmark.PageBookmark(
-                page = 2,
-                lastUpdated = Instant.fromEpochMilliseconds(1001).toPlatform(),
-                localId = null
-            )
+            BookmarkMigration.Page(page = 1),
+            BookmarkMigration.Page(page = 2)
         )
 
         repository.migrateBookmarks(bookmarks)
@@ -246,11 +240,7 @@ class BookmarksRepositoryTest {
     @Test
     fun `migrateBookmarks fails when table is not empty`() = runTest {
         val bookmarks = listOf(
-            Bookmark.PageBookmark(
-                page = 1,
-                lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform(),
-                localId = null
-            )
+            BookmarkMigration.Page(page = 1)
         )
 
         pageBookmarksQueries.createRemoteBookmark("existing-1", 1L)
@@ -262,11 +252,7 @@ class BookmarksRepositoryTest {
     @Test
     fun `migrateBookmarks succeeds with any bookmarks`() = runTest {
         val bookmarks = listOf(
-            Bookmark.PageBookmark(
-                page = 1,
-                lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform(),
-                localId = null
-            )
+            BookmarkMigration.Page(page = 1)
         )
         repository.migrateBookmarks(bookmarks)
 
@@ -315,30 +301,27 @@ class BookmarksRepositoryTest {
         assertEquals(3, localMutations.size)
 
         // Action: Apply remote changes - commit the local mutations
-        val updatesToPersist: List<RemoteModelMutation<Bookmark>> = listOf(
+        val updatesToPersist: List<RemoteModelMutation<RemoteBookmark>> = listOf(
             RemoteModelMutation(
-                model = Bookmark.PageBookmark(
+                model = RemoteBookmark.Page(
                     page = 10,
-                    lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform(),
-                    localId = null
+                    lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform()
                 ),
                 remoteID = "remote-10",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation(
-                model = Bookmark.PageBookmark(
+                model = RemoteBookmark.Page(
                     page = 20,
-                    lastUpdated = Instant.fromEpochMilliseconds(1001).toPlatform(),
-                    localId = null
+                    lastUpdated = Instant.fromEpochMilliseconds(1001).toPlatform()
                 ),
                 remoteID = "remote-20",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation(
-                model = Bookmark.PageBookmark(
+                model = RemoteBookmark.Page(
                     page = 30,
-                    lastUpdated = Instant.fromEpochMilliseconds(1002).toPlatform(),
-                    localId = null
+                    lastUpdated = Instant.fromEpochMilliseconds(1002).toPlatform()
                 ),
                 remoteID = "remote-30",
                 mutation = Mutation.DELETED
@@ -378,22 +361,20 @@ class BookmarksRepositoryTest {
         assertEquals(4, localMutations.size)
 
         // Action: Apply remote changes - mix of committed and overridden
-        val updatesToPersist = listOf<RemoteModelMutation<Bookmark>>(
+        val updatesToPersist = listOf<RemoteModelMutation<RemoteBookmark>>(
             // Committed mutations (local state matches remote)
             RemoteModelMutation(
-                model = Bookmark.PageBookmark(
+                model = RemoteBookmark.Page(
                     page = 10,
-                    lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform(),
-                    localId = null
+                    lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform()
                 ),
                 remoteID = "remote-10",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation(
-                model = Bookmark.PageBookmark(
+                model = RemoteBookmark.Page(
                     page = 30,
-                    lastUpdated = Instant.fromEpochMilliseconds(1001).toPlatform(),
-                    localId = null
+                    lastUpdated = Instant.fromEpochMilliseconds(1001).toPlatform()
                 ),
                 remoteID = "remote-30",
                 mutation = Mutation.DELETED
@@ -432,40 +413,36 @@ class BookmarksRepositoryTest {
         assertEquals(2, localMutations.size)
 
         // Action: Apply remote changes including new mutations not in local list
-        val updatesToPersist = listOf<RemoteModelMutation<Bookmark>>(
+        val updatesToPersist = listOf<RemoteModelMutation<RemoteBookmark>>(
             RemoteModelMutation(
-                model = Bookmark.PageBookmark(
+                model = RemoteBookmark.Page(
                     page = 10,
-                    lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform(),
-                    localId = null
+                    lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform()
                 ),
                 remoteID = "remote-10",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation(
-                model = Bookmark.PageBookmark(
+                model = RemoteBookmark.Page(
                     page = 20,
-                    lastUpdated = Instant.fromEpochMilliseconds(1001).toPlatform(),
-                    localId = null
+                    lastUpdated = Instant.fromEpochMilliseconds(1001).toPlatform()
                 ),
                 remoteID = "remote-20",
                 mutation = Mutation.DELETED
             ),
             // New remote mutations not in local mutations
             RemoteModelMutation(
-                model = Bookmark.PageBookmark(
+                model = RemoteBookmark.Page(
                     page = 30,
-                    lastUpdated = Instant.fromEpochMilliseconds(1002).toPlatform(),
-                    localId = null
+                    lastUpdated = Instant.fromEpochMilliseconds(1002).toPlatform()
                 ),
                 remoteID = "remote-30",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation(
-                model = Bookmark.PageBookmark(
+                model = RemoteBookmark.Page(
                     page = 40,
-                    lastUpdated = Instant.fromEpochMilliseconds(1003).toPlatform(),
-                    localId = null
+                    lastUpdated = Instant.fromEpochMilliseconds(1003).toPlatform()
                 ),
                 remoteID = "remote-40",
                 mutation = Mutation.DELETED
@@ -526,21 +503,19 @@ class BookmarksRepositoryTest {
         assertEquals(2, localMutations.size)
 
         // Action: Apply remote changes for local mutations only
-        val updatesToPersist = listOf<RemoteModelMutation<Bookmark>>(
+        val updatesToPersist = listOf<RemoteModelMutation<RemoteBookmark>>(
             RemoteModelMutation(
-                model = Bookmark.PageBookmark(
+                model = RemoteBookmark.Page(
                     page = 40,
-                    lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform(),
-                    localId = null
+                    lastUpdated = Instant.fromEpochMilliseconds(1000).toPlatform()
                 ),
                 remoteID = "remote-40",
                 mutation = Mutation.CREATED
             ),
             RemoteModelMutation(
-                model = Bookmark.PageBookmark(
+                model = RemoteBookmark.Page(
                     page = 20,
-                    lastUpdated = Instant.fromEpochMilliseconds(1001).toPlatform(),
-                    localId = null
+                    lastUpdated = Instant.fromEpochMilliseconds(1001).toPlatform()
                 ),
                 remoteID = "remote-20",
                 mutation = Mutation.DELETED
@@ -591,13 +566,13 @@ class BookmarksRepositoryTest {
 
         // Simulate remote bookmarks by directly persisting them
         // Note: In a real scenario, these would come from applyRemoteChanges
-        val remoteBookmark1: RemoteModelMutation<Bookmark> = RemoteModelMutation(
-            model = Bookmark.PageBookmark(3, Instant.fromEpochMilliseconds(1000).toPlatform(), null),
+        val remoteBookmark1: RemoteModelMutation<RemoteBookmark> = RemoteModelMutation(
+            model = RemoteBookmark.Page(3, Instant.fromEpochMilliseconds(1000).toPlatform()),
             remoteID = "remote-1",
             mutation = Mutation.CREATED
         )
-        val remoteBookmark2: RemoteModelMutation<Bookmark> = RemoteModelMutation(
-            model = Bookmark.PageBookmark(4, Instant.fromEpochMilliseconds(1000).toPlatform(), null),
+        val remoteBookmark2: RemoteModelMutation<RemoteBookmark> = RemoteModelMutation(
+            model = RemoteBookmark.Page(4, Instant.fromEpochMilliseconds(1000).toPlatform()),
             remoteID = "remote-2",
             mutation = Mutation.CREATED
         )


### PR DESCRIPTION
Today, when migrating bookmarks (or when the backend gives us a new
bookmark to persist), there is no local id, but in every other case,
there is always a local id. This patch splits out those models to make
things easier.
