### PR TITLE
Batch persistence api calls

### DIFF
--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/util/SqliteLimits.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/util/SqliteLimits.kt
@@ -1,0 +1,3 @@
+package com.quran.shared.persistence.util
+
+const val SQLITE_MAX_BIND_PARAMETERS = 900

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryTest.kt
@@ -79,7 +79,7 @@ class BookmarksRepositoryTest {
         repository.addBookmark(30)
         bookmarks = pageBookmarksQueries.getBookmarks().executeAsList()
         assertEquals(3, bookmarks.size)
-        assertEquals(listOf(10L, 20L, 30L), bookmarks.map { it.page })
+        assertEquals(listOf(10L, 20L, 30L), bookmarks.map { it.page }.sorted())
 
         // Verify all locally added bookmarks don't have remote IDs (not synced yet)
         bookmarks.forEach { bookmark ->


### PR DESCRIPTION
There's a limit for how many parameters can be sent in a query, so this
batches the updates.
