### PR TITLE
fix refresh token logic to avoid token expiry

### DIFF
--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/model/AuthConfig.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/model/AuthConfig.kt
@@ -6,7 +6,7 @@ data class AuthConfig(
     val clientSecret: String? = null,
     val redirectUri: String = "com.quran.oauth://callback",
     val postLogoutRedirectUri: String = "com.quran.oauth://callback",
-    val scopes: List<String> = listOf("openid","content", "user", "bookmark")
+    val scopes: List<String> = listOf("openid", "offline_access", "content", "user", "bookmark", "sync", "collection", "reading_session", "preference")
 ) {
     val baseUrl: String = if (usePreProduction) {
         "https://prelive-oauth2.quran.foundation"

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/model/TokenResponse.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/model/TokenResponse.kt
@@ -15,7 +15,11 @@ data class TokenResponse(
     @SerialName("expires_in")
     val expiresIn: Long,
     @SerialName("token_type")
-    val tokenType: String
+    val tokenType: String,
+    @SerialName("scope")
+    val scope: String? = null,
+    @SerialName("expires_at")
+    val expiresAt: String? = null
 ) {
     companion object {
         fun fromOidc(response: AccessTokenResponse): TokenResponse {
@@ -24,7 +28,8 @@ data class TokenResponse(
                 refreshToken = response.refresh_token,
                 idToken = response.id_token,
                 expiresIn = response.expires_in?.toLong() ?: 3600L,
-                tokenType = response.token_type ?: "Bearer"
+                tokenType = response.token_type ?: "Bearer",
+                scope = response.scope
             )
         }
     }

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/repository/AuthRepository.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/repository/AuthRepository.kt
@@ -44,7 +44,7 @@ interface AuthRepository {
     fun getCurrentUser(): UserInfo?
 
     /**
-     * Provides the headers required for authorized requests
+     * Provides the headers required for authorized requests, refreshing the token if needed.
      * */
-    fun getAuthHeaders(): Map<String, String>
+    suspend fun getAuthHeaders(): Map<String, String>
 }

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/repository/OidcAuthRepository.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/repository/OidcAuthRepository.kt
@@ -37,7 +37,8 @@ class OidcAuthRepository(
         }
     }
 
-    override fun getAuthHeaders(): Map<String, String> {
+    override suspend fun getAuthHeaders(): Map<String, String> {
+        refreshTokensIfNeeded()
         val token = getAccessToken()
         return if (token != null) {
             mapOf(

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/service/AuthService.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/service/AuthService.kt
@@ -63,9 +63,7 @@ class AuthService(
         }
     }
 
-    /**
-     * Initiates the OAuth login flow.
-     */
+
     @NativeCoroutines
     suspend fun login() {
         try {
@@ -83,9 +81,7 @@ class AuthService(
         }
     }
 
-    /**
-     * Signs out the user and clears all tokens.
-     */
+
     @NativeCoroutines
     suspend fun logout() {
         try {
@@ -97,27 +93,18 @@ class AuthService(
         }
     }
 
-    /**
-     * Refreshes access tokens if necessary.
-     */
     @NativeCoroutines
     suspend fun refreshAccessTokenIfNeeded(): Boolean {
         return authRepository.refreshTokensIfNeeded()
     }
 
-    /**
-     * Check if user is currently logged in.
-     */
     fun isLoggedIn(): Boolean = authRepository.isLoggedIn()
 
-    /**
-     * Get current access token.
-     */
     fun getAccessToken(): String? = authRepository.getAccessToken()
 
-    /**
-     * Resets the error state.
-     */
+    suspend fun getAuthHeaders(): Map<String, String> = authRepository.getAuthHeaders()
+
+
     fun clearError() {
         if (_authState.value is AuthState.Error) {
             _authState.value = AuthState.Idle


### PR DESCRIPTION
- fix scopes and token response body and refresh logic
- logic relies first on servers `expires_at`
- falls back to local calculations using `expires_in`