### PR TITLE
fix: note insert lookup on iOS

### DIFF
--- a/demo/android/src/main/kotlin/com/quran/shared/demo/android/ui/SyncViewModel.kt
+++ b/demo/android/src/main/kotlin/com/quran/shared/demo/android/ui/SyncViewModel.kt
@@ -76,8 +76,7 @@ class SyncViewModel(
     }
 
     suspend fun addAyahBookmarkToCollection(collectionId: String, sura: Int, ayah: Int) {
-        val bookmark = service.addBookmark(sura, ayah)
-        service.addBookmarkToCollection(collectionId, bookmark)
+        service.addAyahBookmarkToCollection(collectionId, sura, ayah)
     }
 
     suspend fun removeBookmarkFromCollection(collectionId: String, bookmark: Bookmark) {

--- a/demo/apple/QuranSyncDemo/QuranSyncDemo/SyncViewModel.swift
+++ b/demo/apple/QuranSyncDemo/QuranSyncDemo/SyncViewModel.swift
@@ -191,8 +191,7 @@ class SyncViewModel: ObservableObject {
 
     func addAyahBookmarkToCollection(collectionId: String, sura: Int32, ayah: Int32) async {
         do {
-            let bookmark = try await asyncFunction(for: syncService.addBookmark(sura: sura, ayah: ayah))
-            try await asyncFunction(for: syncService.addBookmarkToCollection(collectionLocalId: collectionId, bookmark: bookmark))
+            try await asyncFunction(for: syncService.addAyahBookmarkToCollection(collectionLocalId: collectionId, sura: sura, ayah: ayah))
         } catch {
             print("SyncViewModel: Failed to add random bookmark to collection: \(error)")
         }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/CollectionBookmark.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/CollectionBookmark.kt
@@ -6,6 +6,7 @@ sealed class CollectionBookmark {
     abstract val collectionLocalId: String
     abstract val collectionRemoteId: String?
     abstract val bookmarkLocalId: String
+    abstract val bookmarkRemoteId: String?
     abstract val lastUpdated: PlatformDateTime
     abstract val localId: String
 
@@ -13,6 +14,7 @@ sealed class CollectionBookmark {
         override val collectionLocalId: String,
         override val collectionRemoteId: String?,
         override val bookmarkLocalId: String,
+        override val bookmarkRemoteId: String?,
         val sura: Int,
         val ayah: Int,
         override val lastUpdated: PlatformDateTime,

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepository.kt
@@ -17,6 +17,16 @@ interface CollectionBookmarksRepository {
     suspend fun addBookmarkToCollection(collectionLocalId: String, bookmark: Bookmark): CollectionBookmark
 
     /**
+     * Atomically creates an ayah bookmark (if missing) and links it to a collection.
+     * This operation must not leave partial state if linking fails.
+     */
+    suspend fun addAyahBookmarkToCollection(
+        collectionLocalId: String,
+        sura: Int,
+        ayah: Int
+    ): CollectionBookmark
+
+    /**
      * Removes a bookmark from a collection locally.
      */
     suspend fun removeBookmarkFromCollection(collectionLocalId: String, bookmark: Bookmark): Boolean

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
@@ -189,10 +189,6 @@ class CollectionBookmarksRepositoryImpl(
                     }
                     val mutation = if (record.deleted == 1L) Mutation.DELETED else Mutation.CREATED
                     val bookmarkRemoteId = record.bookmark_remote_id
-                    if (mutation == Mutation.DELETED && bookmarkRemoteId.isNullOrEmpty()) {
-                        logger.w { "Skipping deleted collection bookmark without remote bookmark ID: localId=${record.local_id}" }
-                        return@mapNotNull null
-                    }
                     val collectionBookmark = toCollectionBookmark(
                         bookmarkType = record.bookmark_type,
                         bookmarkLocalId = record.bookmark_local_id,

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
@@ -45,6 +45,7 @@ class CollectionBookmarksRepositoryImpl(
                     toCollectionBookmark(
                         bookmarkType = record.bookmark_type,
                         bookmarkLocalId = record.bookmark_local_id,
+                        bookmarkRemoteId = record.bookmark_remote_id,
                         sura = record.sura,
                         ayah = record.ayah,
                         collectionLocalId = record.collection_local_id,
@@ -67,6 +68,7 @@ class CollectionBookmarksRepositoryImpl(
                     toCollectionBookmark(
                         bookmarkType = record.bookmark_type,
                         bookmarkLocalId = record.bookmark_local_id,
+                        bookmarkRemoteId = record.bookmark_remote_id,
                         sura = record.sura,
                         ayah = record.ayah,
                         collectionLocalId = record.collection_local_id,
@@ -99,9 +101,14 @@ class CollectionBookmarksRepositoryImpl(
             val collection = collectionQueries.value
                 .getCollectionByLocalId(collectionLocalId.toLong())
                 .executeAsOneOrNull()
+            val bookmarkRemoteId = ayahBookmarkQueries.value
+                .getBookmarkByLocalId(bookmark.localId.toLong())
+                .executeAsOneOrNull()
+                ?.remote_id
             record.toCollectionBookmark(
                 collectionRemoteId = collection?.remote_id,
-                bookmark = bookmark
+                bookmark = bookmark,
+                bookmarkRemoteId = bookmarkRemoteId
             )
         }
     }
@@ -129,10 +136,16 @@ class CollectionBookmarksRepositoryImpl(
                         logger.w { "Skipping collection bookmark without remote collection ID: localId=${record.local_id}" }
                         return@mapNotNull null
                     }
+                    val bookmarkRemoteId = record.bookmark_remote_id
+                    if (bookmarkRemoteId.isNullOrEmpty()) {
+                        logger.w { "Skipping collection bookmark without remote bookmark ID: localId=${record.local_id}" }
+                        return@mapNotNull null
+                    }
                     val mutation = if (record.deleted == 1L) Mutation.DELETED else Mutation.CREATED
                     val collectionBookmark = toCollectionBookmark(
                         bookmarkType = record.bookmark_type,
                         bookmarkLocalId = record.bookmark_local_id,
+                        bookmarkRemoteId = bookmarkRemoteId,
                         sura = record.sura,
                         ayah = record.ayah,
                         collectionLocalId = record.collection_local_id,
@@ -231,12 +244,26 @@ class CollectionBookmarksRepositoryImpl(
                 val existingBookmark = ayahBookmarkQueries.value.getBookmarkForAyah(sura, ayah)
                     .executeAsOneOrNull()
                 if (createIfMissing && existingBookmark == null) {
-                    val ayahId = getAyahId(bookmark.sura, bookmark.ayah)
-                    ayahBookmarkQueries.value.insertBookmarkIfMissing(
-                        ayah_id = ayahId.toLong(),
-                        sura = sura,
-                        ayah = ayah,
-                    )
+                    val bookmarkRemoteId = bookmark.bookmarkId
+                    if (bookmarkRemoteId.isNullOrEmpty()) {
+                        val ayahId = getAyahId(bookmark.sura, bookmark.ayah)
+                        ayahBookmarkQueries.value.insertBookmarkIfMissing(
+                            ayah_id = ayahId.toLong(),
+                            sura = sura,
+                            ayah = ayah,
+                        )
+                    } else {
+                        val ayahId = getAyahId(bookmark.sura, bookmark.ayah)
+                        val updatedAt = bookmark.lastUpdated.fromPlatform().toEpochMilliseconds()
+                        ayahBookmarkQueries.value.persistRemoteBookmark(
+                            remote_id = bookmarkRemoteId,
+                            ayah_id = ayahId.toLong(),
+                            sura = sura,
+                            ayah = ayah,
+                            created_at = updatedAt,
+                            modified_at = updatedAt
+                        )
+                    }
                 }
                 (existingBookmark
                     ?: ayahBookmarkQueries.value.getBookmarkForAyah(sura, ayah).executeAsOneOrNull())
@@ -248,6 +275,7 @@ class CollectionBookmarksRepositoryImpl(
     private fun toCollectionBookmark(
         bookmarkType: String,
         bookmarkLocalId: String,
+        bookmarkRemoteId: String?,
         sura: Long?,
         ayah: Long?,
         collectionLocalId: Long,
@@ -275,6 +303,7 @@ class CollectionBookmarksRepositoryImpl(
                         collectionLocalId = collectionLocalId.toString(),
                         collectionRemoteId = collectionRemoteId,
                         bookmarkLocalId = bookmarkLocalId,
+                        bookmarkRemoteId = bookmarkRemoteId,
                         sura = suraValue,
                         ayah = ayahValue,
                         lastUpdated = updatedAt,
@@ -289,7 +318,8 @@ class CollectionBookmarksRepositoryImpl(
 
     private fun DatabaseBookmarkCollection.toCollectionBookmark(
         collectionRemoteId: String?,
-        bookmark: Bookmark
+        bookmark: Bookmark,
+        bookmarkRemoteId: String?
     ): CollectionBookmark {
         val updatedAt = Instant.fromEpochMilliseconds(modified_at).toPlatform()
         return when (bookmark) {
@@ -298,6 +328,7 @@ class CollectionBookmarksRepositoryImpl(
                     collectionLocalId = collection_local_id.toString(),
                     collectionRemoteId = collectionRemoteId,
                     bookmarkLocalId = bookmark.localId,
+                    bookmarkRemoteId = bookmarkRemoteId,
                     sura = bookmark.sura,
                     ayah = bookmark.ayah,
                     lastUpdated = updatedAt,

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
@@ -187,12 +187,12 @@ class CollectionBookmarksRepositoryImpl(
                         logger.w { "Skipping collection bookmark without remote collection ID: localId=${record.local_id}" }
                         return@mapNotNull null
                     }
+                    val mutation = if (record.deleted == 1L) Mutation.DELETED else Mutation.CREATED
                     val bookmarkRemoteId = record.bookmark_remote_id
-                    if (bookmarkRemoteId.isNullOrEmpty()) {
-                        logger.w { "Skipping collection bookmark without remote bookmark ID: localId=${record.local_id}" }
+                    if (mutation == Mutation.DELETED && bookmarkRemoteId.isNullOrEmpty()) {
+                        logger.w { "Skipping deleted collection bookmark without remote bookmark ID: localId=${record.local_id}" }
                         return@mapNotNull null
                     }
-                    val mutation = if (record.deleted == 1L) Mutation.DELETED else Mutation.CREATED
                     val collectionBookmark = toCollectionBookmark(
                         bookmarkType = record.bookmark_type,
                         bookmarkLocalId = record.bookmark_local_id,

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.quran.shared.persistence.input.RemoteCollectionBookmark
 import com.quran.shared.persistence.model.Bookmark
 import com.quran.shared.persistence.model.CollectionBookmark
 import com.quran.shared.persistence.model.DatabaseBookmarkCollection
+import com.quran.shared.persistence.repository.bookmark.extension.toBookmark
 import com.quran.shared.persistence.util.QuranData
 import com.quran.shared.persistence.util.SQLITE_MAX_BIND_PARAMETERS
 import com.quran.shared.persistence.util.fromPlatform
@@ -110,6 +111,56 @@ class CollectionBookmarksRepositoryImpl(
                 bookmark = bookmark,
                 bookmarkRemoteId = bookmarkRemoteId
             )
+        }
+    }
+
+    override suspend fun addAyahBookmarkToCollection(
+        collectionLocalId: String,
+        sura: Int,
+        ayah: Int
+    ): CollectionBookmark {
+        return withContext(Dispatchers.IO) {
+            var created: CollectionBookmark? = null
+            database.transaction {
+                val collectionLocalIdLong = collectionLocalId.toLong()
+                val ayahId = getAyahId(sura, ayah)
+                ayahBookmarkQueries.value.addNewBookmark(
+                    ayah_id = ayahId.toLong(),
+                    sura = sura.toLong(),
+                    ayah = ayah.toLong()
+                )
+                val bookmarkRecord = ayahBookmarkQueries.value
+                    .getBookmarkForAyah(sura.toLong(), ayah.toLong())
+                    .executeAsOneOrNull()
+                requireNotNull(bookmarkRecord) {
+                    "Expected ayah bookmark for $sura:$ayah after insert."
+                }
+                val collection = collectionQueries.value
+                    .getCollectionByLocalId(collectionLocalIdLong)
+                    .executeAsOneOrNull()
+                requireNotNull(collection) {
+                    "Collection not found for localId=$collectionLocalId."
+                }
+
+                bookmarkCollectionQueries.value.addBookmarkToCollection(
+                    bookmark_local_id = bookmarkRecord.local_id.toString(),
+                    bookmark_type = "AYAH",
+                    collection_local_id = collectionLocalIdLong
+                )
+
+                val collectionRecord = bookmarkCollectionQueries.value
+                    .getCollectionBookmarkFor(bookmarkRecord.local_id.toString(), collectionLocalIdLong)
+                    .executeAsOneOrNull()
+                requireNotNull(collectionRecord) {
+                    "Expected collection bookmark for collection=$collectionLocalId and ayah=$sura:$ayah."
+                }
+                created = collectionRecord.toCollectionBookmark(
+                    collectionRemoteId = collection.remote_id,
+                    bookmark = bookmarkRecord.toBookmark(),
+                    bookmarkRemoteId = bookmarkRecord.remote_id
+                )
+            }
+            requireNotNull(created)
         }
     }
 

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
@@ -265,6 +265,16 @@ class CollectionBookmarksRepositoryImpl(
                         )
                     }
                 }
+                if (
+                    existingBookmark != null &&
+                    !bookmark.bookmarkId.isNullOrEmpty() &&
+                    existingBookmark.remote_id.isNullOrEmpty()
+                ) {
+                    ayahBookmarkQueries.value.backfillRemoteBookmarkId(
+                        remote_id = bookmark.bookmarkId,
+                        local_id = existingBookmark.local_id
+                    )
+                }
                 (existingBookmark
                     ?: ayahBookmarkQueries.value.getBookmarkForAyah(sura, ayah).executeAsOneOrNull())
                     ?.local_id

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/note/repository/NotesRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/note/repository/NotesRepositoryImpl.kt
@@ -56,7 +56,11 @@ class NotesRepositoryImpl(
                 start_ayah_id = startAyahId,
                 end_ayah_id = endAyahId
             )
-            val record = notesQueries.value.getLastInsertedNote()
+            val record = notesQueries.value.getNoteByContent(
+                note = body,
+                start_ayah_id = startAyahId,
+                end_ayah_id = endAyahId
+            )
                 .executeAsOneOrNull()
             requireNotNull(record) { "Expected note after insert." }
             record.toNote()

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/note/repository/NotesRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/note/repository/NotesRepositoryImpl.kt
@@ -51,19 +51,18 @@ class NotesRepositoryImpl(
     override suspend fun addNote(body: String, startAyahId: Long, endAyahId: Long): Note {
         logger.i { "Adding note for range=$startAyahId-$endAyahId" }
         return withContext(Dispatchers.IO) {
-            var insertedNote: Note? = null
+            var inserted: Note? = null
             database.transaction {
                 notesQueries.value.addNewNote(
                     note = body,
                     start_ayah_id = startAyahId,
                     end_ayah_id = endAyahId
                 )
-                val insertedId = notesQueries.value.lastInsertedRowId().executeAsOne()
-                val record = notesQueries.value.getNoteByLocalId(insertedId).executeAsOneOrNull()
-                requireNotNull(record) { "Expected note localId=$insertedId after insert." }
-                insertedNote = record.toNote()
+                val record = notesQueries.value.getLastInsertedNote().executeAsOneOrNull()
+                requireNotNull(record) { "Expected note after insert." }
+                inserted = record.toNote()
             }
-            requireNotNull(insertedNote)
+            requireNotNull(inserted)
         }
     }
 

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/note/repository/NotesRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/note/repository/NotesRepositoryImpl.kt
@@ -51,19 +51,19 @@ class NotesRepositoryImpl(
     override suspend fun addNote(body: String, startAyahId: Long, endAyahId: Long): Note {
         logger.i { "Adding note for range=$startAyahId-$endAyahId" }
         return withContext(Dispatchers.IO) {
-            notesQueries.value.addNewNote(
-                note = body,
-                start_ayah_id = startAyahId,
-                end_ayah_id = endAyahId
-            )
-            val record = notesQueries.value.getNoteByContent(
-                note = body,
-                start_ayah_id = startAyahId,
-                end_ayah_id = endAyahId
-            )
-                .executeAsOneOrNull()
-            requireNotNull(record) { "Expected note after insert." }
-            record.toNote()
+            var insertedNote: Note? = null
+            database.transaction {
+                notesQueries.value.addNewNote(
+                    note = body,
+                    start_ayah_id = startAyahId,
+                    end_ayah_id = endAyahId
+                )
+                val insertedId = notesQueries.value.lastInsertedRowId().executeAsOne()
+                val record = notesQueries.value.getNoteByLocalId(insertedId).executeAsOneOrNull()
+                requireNotNull(record) { "Expected note localId=$insertedId after insert." }
+                insertedNote = record.toNote()
+            }
+            requireNotNull(insertedNote)
         }
     }
 

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/ayah_bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/ayah_bookmarks.sq
@@ -58,6 +58,13 @@ persistRemoteBookmark {
   WHERE sura = :sura AND ayah = :ayah;
 }
 
+backfillRemoteBookmarkId {
+  UPDATE ayah_bookmark
+  SET remote_id = :remote_id
+  WHERE local_id = :local_id
+    AND remote_id IS NULL;
+}
+
 hardDeleteBookmarkFor {
   DELETE FROM ayah_bookmark WHERE remote_id=:remoteID;
 }

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmark_collections.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmark_collections.sq
@@ -35,6 +35,7 @@ getCollectionBookmarksWithDetails:
     bc.deleted,
     c.remote_id AS collection_remote_id,
     c.name AS collection_name,
+    ab.remote_id AS bookmark_remote_id,
     ab.sura AS sura,
     ab.ayah AS ayah
   FROM bookmark_collection bc
@@ -57,6 +58,7 @@ getCollectionBookmarksForCollectionWithDetails:
     bc.deleted,
     c.remote_id AS collection_remote_id,
     c.name AS collection_name,
+    ab.remote_id AS bookmark_remote_id,
     ab.sura AS sura,
     ab.ayah AS ayah
   FROM bookmark_collection bc
@@ -80,6 +82,7 @@ getUnsyncedCollectionBookmarksWithDetails:
     bc.deleted,
     c.remote_id AS collection_remote_id,
     c.name AS collection_name,
+    ab.remote_id AS bookmark_remote_id,
     ab.sura AS sura,
     ab.ayah AS ayah
   FROM bookmark_collection bc

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/notes.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/notes.sq
@@ -23,17 +23,12 @@ getNotes:
 getNoteByLocalId:
   SELECT * FROM note WHERE local_id = ? LIMIT 1;
 
-getNoteByContent:
-  SELECT * FROM note
-  WHERE note = :note
-    AND start_ayah_id = :start_ayah_id
-    AND end_ayah_id = :end_ayah_id
-  ORDER BY local_id DESC
-  LIMIT 1;
-
 addNewNote:
   INSERT INTO note (remote_id, note, start_ayah_id, end_ayah_id, deleted)
   VALUES (NULL, :note, :start_ayah_id, :end_ayah_id, 0);
+
+lastInsertedRowId:
+  SELECT last_insert_rowid();
 
 updateNote:
   UPDATE note

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/notes.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/notes.sq
@@ -23,8 +23,13 @@ getNotes:
 getNoteByLocalId:
   SELECT * FROM note WHERE local_id = ? LIMIT 1;
 
-getLastInsertedNote:
-  SELECT * FROM note WHERE local_id = last_insert_rowid() LIMIT 1;
+getNoteByContent:
+  SELECT * FROM note
+  WHERE note = :note
+    AND start_ayah_id = :start_ayah_id
+    AND end_ayah_id = :end_ayah_id
+  ORDER BY local_id DESC
+  LIMIT 1;
 
 addNewNote:
   INSERT INTO note (remote_id, note, start_ayah_id, end_ayah_id, deleted)

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/notes.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/notes.sq
@@ -23,12 +23,12 @@ getNotes:
 getNoteByLocalId:
   SELECT * FROM note WHERE local_id = ? LIMIT 1;
 
+getLastInsertedNote:
+  SELECT * FROM note WHERE local_id = last_insert_rowid() LIMIT 1;
+
 addNewNote:
   INSERT INTO note (remote_id, note, start_ayah_id, end_ayah_id, deleted)
   VALUES (NULL, :note, :start_ayah_id, :end_ayah_id, 0);
-
-lastInsertedRowId:
-  SELECT last_insert_rowid();
 
 updateNote:
   UPDATE note

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionBookmarksRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionBookmarksRepositoryTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -55,6 +56,53 @@ class CollectionBookmarksRepositoryTest {
         assertEquals(bookmark.localId, records.single().bookmark_local_id)
         assertEquals(2L, records.single().sura)
         assertEquals(255L, records.single().ayah)
+    }
+
+    @Test
+    fun `addAyahBookmarkToCollection atomically stores bookmark and link`() = runTest {
+        database.collectionsQueries.addNewCollection(name = "AtomicRecents")
+        val collection = database.collectionsQueries.getCollectionByName("AtomicRecents").executeAsOne()
+        val collectionRemoteId = "remote-atomic-collection-id"
+        database.collectionsQueries.updateRemoteCollectionByLocalId(
+            remote_id = collectionRemoteId,
+            name = collection.name,
+            modified_at = 1L,
+            local_id = collection.local_id
+        )
+
+        repository.addAyahBookmarkToCollection(
+            collectionLocalId = collection.local_id.toString(),
+            sura = 5,
+            ayah = 6
+        )
+
+        val bookmark = database.ayah_bookmarksQueries.getBookmarkForAyah(5L, 6L).executeAsOneOrNull()
+        assertNotNull(bookmark)
+
+        val records = database.bookmark_collectionsQueries
+            .getCollectionBookmarksForCollectionWithDetails(collection_local_id = collection.local_id)
+            .executeAsList()
+
+        assertEquals(1, records.size)
+        assertEquals(bookmark.local_id.toString(), records.single().bookmark_local_id)
+        assertEquals(5L, records.single().sura)
+        assertEquals(6L, records.single().ayah)
+    }
+
+    @Test
+    fun `addAyahBookmarkToCollection rolls back bookmark when collection is missing`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            repository.addAyahBookmarkToCollection(
+                collectionLocalId = "999999",
+                sura = 7,
+                ayah = 8
+            )
+        }
+
+        assertNull(
+            database.ayah_bookmarksQueries.getBookmarkForAyah(7L, 8L).executeAsOneOrNull(),
+            "Bookmark insert should be rolled back when collection linking fails"
+        )
     }
 
     @Test

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionBookmarksRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionBookmarksRepositoryTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Instant
@@ -94,6 +95,48 @@ class CollectionBookmarksRepositoryTest {
         assertEquals("remote-collection-bookmark-id", records.single().remote_id)
         assertEquals("AYAH", records.single().bookmark_type)
         assertEquals(bookmark.localId, records.single().bookmark_local_id)
+    }
+
+    @Test
+    fun `applyRemoteChanges backfills remote bookmark id for existing local ayah bookmark`() = runTest {
+        database.collectionsQueries.addNewCollection(name = "BackfillRemoteBookmarkId")
+        val collection = database.collectionsQueries.getCollectionByName("BackfillRemoteBookmarkId").executeAsOne()
+        database.collectionsQueries.updateRemoteCollectionByLocalId(
+            remote_id = "remote-collection-id-backfill",
+            name = collection.name,
+            modified_at = 1L,
+            local_id = collection.local_id
+        )
+
+        val localBookmark = bookmarksRepository.addBookmark(4, 4)
+
+        repository.applyRemoteChanges(
+            updatesToPersist = listOf(
+                RemoteModelMutation(
+                    model = RemoteCollectionBookmark.Ayah(
+                        collectionId = "remote-collection-id-backfill",
+                        sura = 4,
+                        ayah = 4,
+                        lastUpdated = Instant.fromEpochMilliseconds(300L).toPlatform(),
+                        bookmarkId = "remote-bookmark-id-backfill"
+                    ),
+                    remoteID = "remote-collection-bookmark-id-backfill",
+                    mutation = Mutation.CREATED
+                )
+            ),
+            localMutationsToClear = emptyList()
+        )
+
+        val bookmark = database.ayah_bookmarksQueries.getBookmarkForAyah(4L, 4L).executeAsOneOrNull()
+        assertNotNull(bookmark)
+        assertEquals("remote-bookmark-id-backfill", bookmark.remote_id)
+        assertEquals(localBookmark.localId.toLong(), bookmark.local_id)
+
+        val records = database.bookmark_collectionsQueries
+            .getCollectionBookmarksForCollectionWithDetails(collection_local_id = collection.local_id)
+            .executeAsList()
+        assertEquals(1, records.size)
+        assertEquals("remote-bookmark-id-backfill", records.single().bookmark_remote_id)
     }
 
     @Test

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionBookmarksRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionBookmarksRepositoryTest.kt
@@ -223,7 +223,7 @@ class CollectionBookmarksRepositoryTest {
     }
 
     @Test
-    fun `fetchMutatedCollectionBookmarks skips links without remote bookmark ids`() = runTest {
+    fun `fetchMutatedCollectionBookmarks includes created links without remote bookmark ids`() = runTest {
         database.collectionsQueries.addNewCollection(name = "NeedsBookmarkRemoteId")
         val collection = database.collectionsQueries.getCollectionByName("NeedsBookmarkRemoteId").executeAsOne()
         database.collectionsQueries.updateRemoteCollectionByLocalId(
@@ -238,10 +238,11 @@ class CollectionBookmarksRepositoryTest {
 
         val mutations = repository.fetchMutatedCollectionBookmarks()
 
-        assertTrue(
-            mutations.isEmpty(),
-            "Collection bookmarks should not sync until the linked bookmark has a remote id"
-        )
+        assertEquals(1, mutations.size)
+        assertEquals(Mutation.CREATED, mutations.single().mutation)
+        val model = mutations.single().model
+        assertEquals(collection.local_id.toString(), model.collectionLocalId)
+        assertNull(model.bookmarkRemoteId)
     }
 
     @Test

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionBookmarksRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionBookmarksRepositoryTest.kt
@@ -246,6 +246,39 @@ class CollectionBookmarksRepositoryTest {
     }
 
     @Test
+    fun `fetchMutatedCollectionBookmarks includes deletion when link has remote id but bookmark remote id is null`() = runTest {
+        database.collectionsQueries.addNewCollection(name = "DeleteWithoutBookmarkRemoteId")
+        val collection = database.collectionsQueries.getCollectionByName("DeleteWithoutBookmarkRemoteId").executeAsOne()
+        database.collectionsQueries.updateRemoteCollectionByLocalId(
+            remote_id = "remote-collection-id-delete",
+            name = collection.name,
+            modified_at = 1L,
+            local_id = collection.local_id
+        )
+
+        val bookmark = bookmarksRepository.addBookmark(2, 2)
+        repository.addBookmarkToCollection(collection.local_id.toString(), bookmark)
+
+        // Simulate server-created collection bookmark ID while the bookmark itself is still local-only.
+        database.bookmark_collectionsQueries.persistRemoteBookmarkCollection(
+            remote_id = "remote-collection-bookmark-id-delete",
+            bookmark_local_id = bookmark.localId,
+            bookmark_type = "AYAH",
+            collection_local_id = collection.local_id,
+            created_at = 10L,
+            modified_at = 10L
+        )
+
+        repository.removeBookmarkFromCollection(collection.local_id.toString(), bookmark)
+        val mutations = repository.fetchMutatedCollectionBookmarks()
+
+        assertEquals(1, mutations.size)
+        assertEquals(Mutation.DELETED, mutations.single().mutation)
+        assertEquals("remote-collection-bookmark-id-delete", mutations.single().remoteID)
+        assertNull(mutations.single().model.bookmarkRemoteId)
+    }
+
+    @Test
     fun `applyRemoteChanges ignores remote page collection bookmarks`() = runTest {
         database.collectionsQueries.addNewCollection(name = "IgnorePages")
         val collection = database.collectionsQueries.getCollectionByName("IgnorePages").executeAsOne()

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionBookmarksRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionBookmarksRepositoryTest.kt
@@ -132,6 +132,28 @@ class CollectionBookmarksRepositoryTest {
     }
 
     @Test
+    fun `fetchMutatedCollectionBookmarks skips links without remote bookmark ids`() = runTest {
+        database.collectionsQueries.addNewCollection(name = "NeedsBookmarkRemoteId")
+        val collection = database.collectionsQueries.getCollectionByName("NeedsBookmarkRemoteId").executeAsOne()
+        database.collectionsQueries.updateRemoteCollectionByLocalId(
+            remote_id = "remote-collection-id-4",
+            name = collection.name,
+            modified_at = 1L,
+            local_id = collection.local_id
+        )
+
+        val bookmark = bookmarksRepository.addBookmark(1, 1)
+        repository.addBookmarkToCollection(collection.local_id.toString(), bookmark)
+
+        val mutations = repository.fetchMutatedCollectionBookmarks()
+
+        assertTrue(
+            mutations.isEmpty(),
+            "Collection bookmarks should not sync until the linked bookmark has a remote id"
+        )
+    }
+
+    @Test
     fun `applyRemoteChanges ignores remote page collection bookmarks`() = runTest {
         database.collectionsQueries.addNewCollection(name = "IgnorePages")
         val collection = database.collectionsQueries.getCollectionByName("IgnorePages").executeAsOne()

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/NotesRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/NotesRepositoryTest.kt
@@ -1,0 +1,33 @@
+package com.quran.shared.persistence.repository
+
+import com.quran.shared.persistence.QuranDatabase
+import com.quran.shared.persistence.TestDatabaseDriver
+import com.quran.shared.persistence.repository.note.repository.NotesRepositoryImpl
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NotesRepositoryTest {
+    private lateinit var database: QuranDatabase
+    private lateinit var repository: NotesRepositoryImpl
+
+    @BeforeTest
+    fun setup() {
+        database = QuranDatabase(TestDatabaseDriver().createDriver())
+        repository = NotesRepositoryImpl(database)
+    }
+
+    @Test
+    fun `addNote returns inserted note`() = runTest {
+        val note = repository.addNote(
+            body = "test note",
+            startAyahId = 20L,
+            endAyahId = 20L
+        )
+
+        assertEquals("test note", note.body)
+        assertEquals(20L, note.startAyahId)
+        assertEquals(20L, note.endAyahId)
+    }
+}

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncEnginePipeline.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncEnginePipeline.kt
@@ -591,7 +591,8 @@ private fun CollectionBookmark.toSyncEngine(): SyncCollectionBookmark {
                 collectionId = collectionId,
                 sura = this.sura,
                 ayah = this.ayah,
-                lastModified = this.lastUpdated.fromPlatform()
+                lastModified = this.lastUpdated.fromPlatform(),
+                bookmarkId = this.bookmarkRemoteId
             )
     }
 }
@@ -604,6 +605,7 @@ private fun SyncCollectionBookmark.toPersistence(localId: String): CollectionBoo
                 collectionLocalId = "",
                 collectionRemoteId = collectionId,
                 bookmarkLocalId = "",
+                bookmarkRemoteId = bookmarkId,
                 sura = sura,
                 ayah = ayah,
                 lastUpdated = updatedAt,

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncService.kt
@@ -274,6 +274,24 @@ class SyncService(
     }
 
     @NativeCoroutines
+    suspend fun addAyahBookmarkToCollection(
+        collectionLocalId: String,
+        sura: Int,
+        ayah: Int
+    ): CollectionBookmark {
+        try {
+            val bookmark = bookmarksRepository.addBookmark(sura, ayah)
+            val collectionBookmark =
+                collectionBookmarksRepository.addBookmarkToCollection(collectionLocalId, bookmark)
+            triggerSync()
+            return collectionBookmark
+        } catch (e: Exception) {
+            Logger.e(e) { "Failed to add ayah bookmark to collection" }
+            throw e
+        }
+    }
+
+    @NativeCoroutines
     suspend fun removeBookmarkFromCollection(collectionLocalId: String, bookmark: Bookmark): Unit {
         try {
             collectionBookmarksRepository.removeBookmarkFromCollection(collectionLocalId, bookmark)

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncService.kt
@@ -280,9 +280,8 @@ class SyncService(
         ayah: Int
     ): CollectionBookmark {
         try {
-            val bookmark = bookmarksRepository.addBookmark(sura, ayah)
-            val collectionBookmark =
-                collectionBookmarksRepository.addBookmarkToCollection(collectionLocalId, bookmark)
+            val collectionBookmark = collectionBookmarksRepository
+                .addAyahBookmarkToCollection(collectionLocalId, sura, ayah)
             triggerSync()
             return collectionBookmark
         } catch (e: Exception) {

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapter.kt
@@ -9,6 +9,8 @@ import com.quran.shared.syncengine.conflict.ConflictDetectionResult
 import com.quran.shared.syncengine.conflict.ConflictResolutionResult
 import com.quran.shared.syncengine.conflict.ResourceConflict
 import com.quran.shared.syncengine.model.SyncCollectionBookmark
+import com.quran.shared.syncengine.model.collectionBookmarkRemoteId
+import com.quran.shared.syncengine.model.remoteIdOrNull
 import com.quran.shared.syncengine.preprocessing.CollectionBookmarksRemoteMutationsPreprocessor
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
@@ -81,16 +83,17 @@ internal class CollectionBookmarksSyncAdapter(
             if (!mutation.resource.equals(resourceName, ignoreCase = true)) {
                 return@mapNotNull null
             }
+            val collectionId = mutation.data?.stringOrNull("collectionId")
             val bookmarkId = mutation.data?.stringOrNull("bookmarkId")
-            val resourceId = mutation.resourceId ?: bookmarkId
-            if (resourceId == null) {
-                logger.w { "Skipping collection bookmark mutation without resourceId" }
+                ?: mutation.data?.stringOrNull("bookmark_id")
+            if (collectionId.isNullOrEmpty() || bookmarkId.isNullOrEmpty()) {
+                logger.w { "Skipping collection bookmark mutation without collectionId/bookmarkId" }
                 return@mapNotNull null
             }
             val collectionBookmark = mutation.toSyncCollectionBookmark(logger, configurations.localDataFetcher) ?: return@mapNotNull null
             RemoteModelMutation(
                 model = collectionBookmark,
-                remoteID = resourceId,
+                remoteID = collectionBookmarkRemoteId(collectionId, bookmarkId),
                 mutation = mutation.mutation
             )
         }
@@ -99,7 +102,7 @@ internal class CollectionBookmarksSyncAdapter(
     private fun toSyncMutation(localMutation: LocalModelMutation<SyncCollectionBookmark>): SyncMutation {
         return SyncMutation(
             resource = resourceName,
-            resourceId = localMutation.remoteID,
+            resourceId = null,
             mutation = localMutation.mutation,
             data = localMutation.model.toResourceData(),
             timestamp = null
@@ -148,9 +151,9 @@ internal class CollectionBookmarksSyncAdapter(
                 logger.e { message }
                 throw IllegalStateException(message)
             }
-            val remoteId = pushedMutation.resourceId
+            val remoteId = localMutation.model.remoteIdOrNull() ?: pushedMutation.resourceId
             if (remoteId == null) {
-                val message = "Missing resourceId for pushed mutation at index=$index for $resourceName"
+                val message = "Missing composite remote ID for pushed mutation at index=$index for $resourceName"
                 logger.e { message }
                 throw IllegalStateException(message)
             }
@@ -207,18 +210,21 @@ private suspend fun SyncMutation.toSyncCollectionBookmark(
     val lastModified = Instant.fromEpochMilliseconds(timestamp ?: 0)
     val bookmarkId = data.stringOrNull("bookmarkId")
         ?: data.stringOrNull("bookmark_id")
-        ?: parseBookmarkId(resourceId, collectionId) ?: return null
+    if (bookmarkId.isNullOrEmpty()) {
+        logger.w { "Skipping collection bookmark mutation without bookmarkId: resourceId=$resourceId" }
+        return null
+    }
     return when (normalizedType?.lowercase()) {
         "ayah" -> {
             val sura = data.intOrNull("key")
             val ayah = data.intOrNull("verseNumber")
             if (sura != null && ayah != null) {
                 SyncCollectionBookmark.AyahBookmark(
-                    collectionId = collectionId,
-                    sura = sura,
-                    ayah = ayah,
-                    lastModified = lastModified,
-                    bookmarkId = bookmarkId
+                        collectionId = collectionId,
+                        sura = sura,
+                        ayah = ayah,
+                        lastModified = lastModified,
+                        bookmarkId = bookmarkId
                 )
             } else {
                 null
@@ -255,18 +261,6 @@ private fun SyncCollectionBookmark.toResourceData(): JsonObject {
             put("mushaf", 1)
             bookmarkId?.let { put("bookmarkId", it) }
         }
-    }
-}
-
-private fun parseBookmarkId(resourceId: String?, collectionId: String): String? {
-    if (resourceId.isNullOrEmpty()) {
-        return null
-    }
-    val prefix = "$collectionId-"
-    return if (resourceId.startsWith(prefix)) {
-        resourceId.removePrefix(prefix)
-    } else {
-        null
     }
 }
 

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapter.kt
@@ -79,6 +79,11 @@ internal class CollectionBookmarksSyncAdapter(
     private suspend fun parseRemoteMutations(
         mutations: List<SyncMutation>
     ): List<RemoteModelMutation<SyncCollectionBookmark>> {
+        val remoteAyahBookmarksById = mutations
+            .asSequence()
+            .mapNotNull { it.toRemoteAyahBookmarkLookup() }
+            .associateBy { it.id }
+
         return mutations.mapNotNull { mutation ->
             if (!mutation.resource.equals(resourceName, ignoreCase = true)) {
                 return@mapNotNull null
@@ -95,7 +100,11 @@ internal class CollectionBookmarksSyncAdapter(
                 logger.w { "Skipping collection bookmark mutation without resourceId" }
                 return@mapNotNull null
             }
-            val collectionBookmark = mutation.toSyncCollectionBookmark(logger, configurations.localDataFetcher) ?: return@mapNotNull null
+            val collectionBookmark = mutation.toSyncCollectionBookmark(
+                logger = logger,
+                localDataFetcher = configurations.localDataFetcher,
+                remoteAyahBookmarksById = remoteAyahBookmarksById
+            ) ?: return@mapNotNull null
             RemoteModelMutation(
                 model = collectionBookmark,
                 remoteID = resourceId,
@@ -203,7 +212,8 @@ internal class CollectionBookmarksSyncAdapter(
 
 private suspend fun SyncMutation.toSyncCollectionBookmark(
     logger: Logger,
-    localDataFetcher: LocalDataFetcher<SyncCollectionBookmark>
+    localDataFetcher: LocalDataFetcher<SyncCollectionBookmark>,
+    remoteAyahBookmarksById: Map<String, RemoteAyahBookmarkLookup>
 ): SyncCollectionBookmark? {
     val data = data ?: return null
     val collectionId = data.stringOrNull("collectionId")
@@ -238,7 +248,7 @@ private suspend fun SyncMutation.toSyncCollectionBookmark(
         }
         else -> {
             val localModel = localDataFetcher.fetchLocalModel(bookmarkId)
-            if(localModel != null) {
+            if (localModel != null) {
                 logger.d { "Mapped unknown collection bookmark type using local data: resourceId=$localModel" }
                 when (localModel) {
                     is SyncCollectionBookmark.AyahBookmark -> SyncCollectionBookmark.AyahBookmark(
@@ -250,8 +260,24 @@ private suspend fun SyncMutation.toSyncCollectionBookmark(
                     )
                 }
             } else {
-                logger.w { "Skipping collection bookmark mutation with unsupported type=$normalizedType: resourceId=$resourceId" }
-                null
+                val remoteBookmark = remoteAyahBookmarksById[bookmarkId]
+                if (remoteBookmark != null) {
+                    logger.d {
+                        "Mapped collection bookmark using same-batch remote bookmark payload: bookmarkId=$bookmarkId"
+                    }
+                    SyncCollectionBookmark.AyahBookmark(
+                        collectionId = collectionId,
+                        sura = remoteBookmark.sura,
+                        ayah = remoteBookmark.ayah,
+                        lastModified = lastModified,
+                        bookmarkId = bookmarkId
+                    )
+                } else {
+                    logger.w {
+                        "Skipping collection bookmark mutation with unsupported type=$normalizedType: resourceId=$resourceId"
+                    }
+                    null
+                }
             }
         }
     }
@@ -286,3 +312,23 @@ private fun JsonObject.stringOrNull(key: String): String? =
 
 private fun JsonObject.intOrNull(key: String): Int? =
     this[key]?.jsonPrimitive?.intOrNull
+
+private data class RemoteAyahBookmarkLookup(
+    val id: String,
+    val sura: Int,
+    val ayah: Int
+)
+
+private fun SyncMutation.toRemoteAyahBookmarkLookup(): RemoteAyahBookmarkLookup? {
+    if (!resource.equals("BOOKMARK", ignoreCase = true)) {
+        return null
+    }
+    val id = resourceId ?: return null
+    val bookmarkType = data?.stringOrNull("bookmarkType") ?: data?.stringOrNull("type")
+    if (!bookmarkType.equals("ayah", ignoreCase = true)) {
+        return null
+    }
+    val sura = data?.intOrNull("key") ?: return null
+    val ayah = data.intOrNull("verseNumber") ?: return null
+    return RemoteAyahBookmarkLookup(id = id, sura = sura, ayah = ayah)
+}

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapter.kt
@@ -86,14 +86,19 @@ internal class CollectionBookmarksSyncAdapter(
             val collectionId = mutation.data?.stringOrNull("collectionId")
             val bookmarkId = mutation.data?.stringOrNull("bookmarkId")
                 ?: mutation.data?.stringOrNull("bookmark_id")
-            if (collectionId.isNullOrEmpty() || bookmarkId.isNullOrEmpty()) {
-                logger.w { "Skipping collection bookmark mutation without collectionId/bookmarkId" }
+            val resourceId = mutation.resourceId ?: if (!collectionId.isNullOrEmpty() && !bookmarkId.isNullOrEmpty()) {
+                collectionBookmarkRemoteId(collectionId, bookmarkId)
+            } else {
+                null
+            }
+            if (resourceId == null) {
+                logger.w { "Skipping collection bookmark mutation without resourceId" }
                 return@mapNotNull null
             }
             val collectionBookmark = mutation.toSyncCollectionBookmark(logger, configurations.localDataFetcher) ?: return@mapNotNull null
             RemoteModelMutation(
                 model = collectionBookmark,
-                remoteID = collectionBookmarkRemoteId(collectionId, bookmarkId),
+                remoteID = resourceId,
                 mutation = mutation.mutation
             )
         }
@@ -102,7 +107,7 @@ internal class CollectionBookmarksSyncAdapter(
     private fun toSyncMutation(localMutation: LocalModelMutation<SyncCollectionBookmark>): SyncMutation {
         return SyncMutation(
             resource = resourceName,
-            resourceId = null,
+            resourceId = localMutation.remoteID,
             mutation = localMutation.mutation,
             data = localMutation.model.toResourceData(),
             timestamp = null
@@ -210,6 +215,7 @@ private suspend fun SyncMutation.toSyncCollectionBookmark(
     val lastModified = Instant.fromEpochMilliseconds(timestamp ?: 0)
     val bookmarkId = data.stringOrNull("bookmarkId")
         ?: data.stringOrNull("bookmark_id")
+        ?: parseBookmarkId(resourceId, collectionId)
     if (bookmarkId.isNullOrEmpty()) {
         logger.w { "Skipping collection bookmark mutation without bookmarkId: resourceId=$resourceId" }
         return null
@@ -259,8 +265,19 @@ private fun SyncCollectionBookmark.toResourceData(): JsonObject {
             put("key", sura)
             put("verseNumber", ayah)
             put("mushaf", 1)
-            bookmarkId?.let { put("bookmarkId", it) }
         }
+    }
+}
+
+private fun parseBookmarkId(resourceId: String?, collectionId: String): String? {
+    if (resourceId.isNullOrEmpty()) {
+        return null
+    }
+    val prefix = "$collectionId-"
+    return if (resourceId.startsWith(prefix)) {
+        resourceId.removePrefix(prefix)
+    } else {
+        null
     }
 }
 

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/model/SyncCollectionBookmark.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/model/SyncCollectionBookmark.kt
@@ -16,7 +16,7 @@ sealed class SyncCollectionBookmark {
 }
 
 fun collectionBookmarkRemoteId(collectionId: String, bookmarkId: String): String {
-    return "$collectionId::$bookmarkId"
+    return "$collectionId-$bookmarkId"
 }
 
 fun SyncCollectionBookmark.remoteIdOrNull(): String? {

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/model/SyncCollectionBookmark.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/model/SyncCollectionBookmark.kt
@@ -15,6 +15,17 @@ sealed class SyncCollectionBookmark {
     ) : SyncCollectionBookmark()
 }
 
+fun collectionBookmarkRemoteId(collectionId: String, bookmarkId: String): String {
+    return "$collectionId::$bookmarkId"
+}
+
+fun SyncCollectionBookmark.remoteIdOrNull(): String? {
+    return when (this) {
+        is SyncCollectionBookmark.AyahBookmark ->
+            bookmarkId?.let { collectionBookmarkRemoteId(collectionId, it) }
+    }
+}
+
 internal sealed class SyncCollectionBookmarkKey {
     data class Ayah(val collectionId: String, val sura: Int, val ayah: Int) : SyncCollectionBookmarkKey() {
         override fun toString(): String = "collection=$collectionId, sura=$sura, ayah=$ayah"

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/BookmarksSynchronizationExecutorTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/BookmarksSynchronizationExecutorTest.kt
@@ -222,7 +222,7 @@ class BookmarksSynchronizationExecutorTest {
             "Error message should include illogical scenario details"
         )
         assertEquals(
-            exception.message?.contains("Bookmark page=10 has 3 mutations"),
+            exception.message?.contains("Bookmark sura=10, ayah=1, isReading=false has 3 mutations"),
             true,
             "Error message should include page and mutation count details"
         )

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapterTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapterTest.kt
@@ -174,4 +174,87 @@ class CollectionBookmarksSyncAdapterTest {
         assertEquals(1, remote.size)
         assertEquals("remote-collection-2-remote-bookmark-2", remote.single().remoteID)
     }
+
+    @Test
+    fun `remote collection bookmark can use same batch bookmark payload`() = runTest {
+        val localDataFetcher = object : LocalDataFetcher<SyncCollectionBookmark> {
+            override suspend fun fetchLocalMutations(lastModified: Long): List<LocalModelMutation<SyncCollectionBookmark>> =
+                emptyList()
+
+            override suspend fun checkLocalExistence(remoteIDs: List<String>): Map<String, Boolean> =
+                remoteIDs.associateWith { true }
+
+            override suspend fun fetchLocalModel(remoteId: String): SyncCollectionBookmark? = null
+        }
+
+        var capturedRemote: List<RemoteModelMutation<SyncCollectionBookmark>>? = null
+
+        val resultNotifier = object : ResultNotifier<SyncCollectionBookmark> {
+            override suspend fun didSucceed(
+                newToken: Long,
+                newRemoteMutations: List<RemoteModelMutation<SyncCollectionBookmark>>,
+                processedLocalMutations: List<LocalModelMutation<SyncCollectionBookmark>>
+            ) {
+                capturedRemote = newRemoteMutations
+            }
+
+            override suspend fun didFail(message: String) {
+                fail("didFail called: $message")
+            }
+        }
+
+        val localModificationDateFetcher = object : LocalModificationDateFetcher {
+            override suspend fun localLastModificationDate(): Long? = 0L
+        }
+
+        val adapter = CollectionBookmarksSyncAdapter(
+            CollectionBookmarksSynchronizationConfigurations(
+                localDataFetcher = localDataFetcher,
+                resultNotifier = resultNotifier,
+                localModificationDateFetcher = localModificationDateFetcher
+            )
+        )
+
+        val plan = adapter.buildPlan(
+            lastModificationDate = 0L,
+            remoteMutations = listOf(
+                SyncMutation(
+                    resource = "BOOKMARK",
+                    resourceId = "remote-bookmark-3",
+                    mutation = Mutation.CREATED,
+                    data = buildJsonObject {
+                        put("type", "ayah")
+                        put("key", 36)
+                        put("verseNumber", 58)
+                        put("mushaf", 4)
+                    },
+                    timestamp = 100L
+                ),
+                SyncMutation(
+                    resource = "COLLECTION_BOOKMARK",
+                    resourceId = null,
+                    mutation = Mutation.CREATED,
+                    data = buildJsonObject {
+                        put("collectionId", "remote-collection-3")
+                        put("bookmarkId", "remote-bookmark-3")
+                    },
+                    timestamp = 101L
+                )
+            )
+        )
+
+        plan.complete(newToken = 5L, pushedMutations = emptyList())
+
+        val remote = assertNotNull(capturedRemote)
+        assertEquals(1, remote.size)
+        val mutation = remote.single()
+        assertEquals(
+            collectionBookmarkRemoteId("remote-collection-3", "remote-bookmark-3"),
+            mutation.remoteID
+        )
+        val model = mutation.model as SyncCollectionBookmark.AyahBookmark
+        assertEquals(36, model.sura)
+        assertEquals(58, model.ayah)
+        assertEquals("remote-bookmark-3", model.bookmarkId)
+    }
 }

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapterTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapterTest.kt
@@ -21,7 +21,7 @@ import kotlin.time.Instant
 class CollectionBookmarksSyncAdapterTest {
 
     @Test
-    fun `mutations to push omit resourceId and include bookmarkId`() = runTest {
+    fun `mutations to push omit bookmarkId payload field`() = runTest {
         val localMutation = LocalModelMutation<SyncCollectionBookmark>(
             model = SyncCollectionBookmark.AyahBookmark(
                 collectionId = "remote-collection-1",
@@ -85,7 +85,7 @@ class CollectionBookmarksSyncAdapterTest {
         assertEquals("COLLECTION_BOOKMARK", pushedMutations.single().resource)
         assertNull(pushedMutations.single().resourceId)
         assertEquals("remote-collection-1", pushedMutations.single().data?.get("collectionId")?.jsonPrimitive?.content)
-        assertEquals("remote-bookmark-1", pushedMutations.single().data?.get("bookmarkId")?.jsonPrimitive?.content)
+        assertNull(pushedMutations.single().data?.get("bookmarkId"))
 
         plan.complete(
             newToken = 5L,
@@ -110,7 +110,7 @@ class CollectionBookmarksSyncAdapterTest {
     }
 
     @Test
-    fun `remote collection bookmark uses composite remote id`() = runTest {
+    fun `remote collection bookmark uses response resource id when present`() = runTest {
         val localDataFetcher = object : LocalDataFetcher<SyncCollectionBookmark> {
             override suspend fun fetchLocalMutations(lastModified: Long): List<LocalModelMutation<SyncCollectionBookmark>> =
                 emptyList()
@@ -154,11 +154,10 @@ class CollectionBookmarksSyncAdapterTest {
             remoteMutations = listOf(
                 SyncMutation(
                     resource = "COLLECTION_BOOKMARK",
-                    resourceId = null,
+                    resourceId = "remote-collection-2-remote-bookmark-2",
                     mutation = Mutation.CREATED,
                     data = buildJsonObject {
                         put("collectionId", "remote-collection-2")
-                        put("bookmarkId", "remote-bookmark-2")
                         put("type", "ayah")
                         put("key", 2)
                         put("verseNumber", 255)
@@ -173,6 +172,6 @@ class CollectionBookmarksSyncAdapterTest {
 
         val remote = assertNotNull(capturedRemote)
         assertEquals(1, remote.size)
-        assertEquals(collectionBookmarkRemoteId("remote-collection-2", "remote-bookmark-2"), remote.single().remoteID)
+        assertEquals("remote-collection-2-remote-bookmark-2", remote.single().remoteID)
     }
 }

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapterTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapterTest.kt
@@ -1,0 +1,178 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.quran.shared.syncengine
+
+import com.quran.shared.mutations.LocalModelMutation
+import com.quran.shared.mutations.Mutation
+import com.quran.shared.mutations.RemoteModelMutation
+import com.quran.shared.syncengine.model.SyncCollectionBookmark
+import com.quran.shared.syncengine.model.collectionBookmarkRemoteId
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertNotNull
+import kotlin.test.fail
+import kotlin.time.Instant
+
+class CollectionBookmarksSyncAdapterTest {
+
+    @Test
+    fun `mutations to push omit resourceId and include bookmarkId`() = runTest {
+        val localMutation = LocalModelMutation<SyncCollectionBookmark>(
+            model = SyncCollectionBookmark.AyahBookmark(
+                collectionId = "remote-collection-1",
+                sura = 2,
+                ayah = 255,
+                lastModified = Instant.fromEpochMilliseconds(1000),
+                bookmarkId = "remote-bookmark-1"
+            ),
+            remoteID = null,
+            localID = "local-1",
+            mutation = Mutation.CREATED
+        )
+
+        val localDataFetcher = object : LocalDataFetcher<SyncCollectionBookmark> {
+            override suspend fun fetchLocalMutations(lastModified: Long): List<LocalModelMutation<SyncCollectionBookmark>> =
+                listOf(localMutation)
+
+            override suspend fun checkLocalExistence(remoteIDs: List<String>): Map<String, Boolean> =
+                remoteIDs.associateWith { true }
+
+            override suspend fun fetchLocalModel(remoteId: String): SyncCollectionBookmark? = null
+        }
+
+        var capturedRemote: List<RemoteModelMutation<SyncCollectionBookmark>>? = null
+        var capturedLocal: List<LocalModelMutation<SyncCollectionBookmark>>? = null
+
+        val resultNotifier = object : ResultNotifier<SyncCollectionBookmark> {
+            override suspend fun didSucceed(
+                newToken: Long,
+                newRemoteMutations: List<RemoteModelMutation<SyncCollectionBookmark>>,
+                processedLocalMutations: List<LocalModelMutation<SyncCollectionBookmark>>
+            ) {
+                capturedRemote = newRemoteMutations
+                capturedLocal = processedLocalMutations
+            }
+
+            override suspend fun didFail(message: String) {
+                fail("didFail called: $message")
+            }
+        }
+
+        val localModificationDateFetcher = object : LocalModificationDateFetcher {
+            override suspend fun localLastModificationDate(): Long? = 0L
+        }
+
+        val adapter = CollectionBookmarksSyncAdapter(
+            CollectionBookmarksSynchronizationConfigurations(
+                localDataFetcher = localDataFetcher,
+                resultNotifier = resultNotifier,
+                localModificationDateFetcher = localModificationDateFetcher
+            )
+        )
+
+        val plan = adapter.buildPlan(
+            lastModificationDate = 0L,
+            remoteMutations = emptyList()
+        )
+
+        val pushedMutations = plan.mutationsToPush()
+        assertEquals(1, pushedMutations.size)
+        assertEquals("COLLECTION_BOOKMARK", pushedMutations.single().resource)
+        assertNull(pushedMutations.single().resourceId)
+        assertEquals("remote-collection-1", pushedMutations.single().data?.get("collectionId")?.jsonPrimitive?.content)
+        assertEquals("remote-bookmark-1", pushedMutations.single().data?.get("bookmarkId")?.jsonPrimitive?.content)
+
+        plan.complete(
+            newToken = 5L,
+            pushedMutations = listOf(
+                SyncMutation(
+                    resource = "COLLECTION_BOOKMARK",
+                    resourceId = null,
+                    mutation = Mutation.CREATED,
+                    data = null,
+                    timestamp = null
+                )
+            )
+        )
+
+        val remote = assertNotNull(capturedRemote)
+        assertEquals(1, remote.size)
+        assertEquals(collectionBookmarkRemoteId("remote-collection-1", "remote-bookmark-1"), remote.single().remoteID)
+
+        val local = assertNotNull(capturedLocal)
+        assertEquals(1, local.size)
+        assertEquals("local-1", local.single().localID)
+    }
+
+    @Test
+    fun `remote collection bookmark uses composite remote id`() = runTest {
+        val localDataFetcher = object : LocalDataFetcher<SyncCollectionBookmark> {
+            override suspend fun fetchLocalMutations(lastModified: Long): List<LocalModelMutation<SyncCollectionBookmark>> =
+                emptyList()
+
+            override suspend fun checkLocalExistence(remoteIDs: List<String>): Map<String, Boolean> =
+                remoteIDs.associateWith { true }
+
+            override suspend fun fetchLocalModel(remoteId: String): SyncCollectionBookmark? = null
+        }
+
+        var capturedRemote: List<RemoteModelMutation<SyncCollectionBookmark>>? = null
+
+        val resultNotifier = object : ResultNotifier<SyncCollectionBookmark> {
+            override suspend fun didSucceed(
+                newToken: Long,
+                newRemoteMutations: List<RemoteModelMutation<SyncCollectionBookmark>>,
+                processedLocalMutations: List<LocalModelMutation<SyncCollectionBookmark>>
+            ) {
+                capturedRemote = newRemoteMutations
+            }
+
+            override suspend fun didFail(message: String) {
+                fail("didFail called: $message")
+            }
+        }
+
+        val localModificationDateFetcher = object : LocalModificationDateFetcher {
+            override suspend fun localLastModificationDate(): Long? = 0L
+        }
+
+        val adapter = CollectionBookmarksSyncAdapter(
+            CollectionBookmarksSynchronizationConfigurations(
+                localDataFetcher = localDataFetcher,
+                resultNotifier = resultNotifier,
+                localModificationDateFetcher = localModificationDateFetcher
+            )
+        )
+
+        val plan = adapter.buildPlan(
+            lastModificationDate = 0L,
+            remoteMutations = listOf(
+                SyncMutation(
+                    resource = "COLLECTION_BOOKMARK",
+                    resourceId = null,
+                    mutation = Mutation.CREATED,
+                    data = buildJsonObject {
+                        put("collectionId", "remote-collection-2")
+                        put("bookmarkId", "remote-bookmark-2")
+                        put("type", "ayah")
+                        put("key", 2)
+                        put("verseNumber", 255)
+                        put("mushaf", 4)
+                    },
+                    timestamp = 123L
+                )
+            )
+        )
+
+        plan.complete(newToken = 5L, pushedMutations = emptyList())
+
+        val remote = assertNotNull(capturedRemote)
+        assertEquals(1, remote.size)
+        assertEquals(collectionBookmarkRemoteId("remote-collection-2", "remote-bookmark-2"), remote.single().remoteID)
+    }
+}

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/preprocessing/BookmarksLocalMutationsPreprocessorTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/preprocessing/BookmarksLocalMutationsPreprocessorTest.kt
@@ -40,7 +40,7 @@ class BookmarksLocalMutationsPreprocessorTest {
             preprocessor.preprocess(listOf(mutation1, mutation2))
         }
         
-        assertTrue(exception.message?.contains("Bookmark page=1 has 2 creations") == true)
+        assertTrue(exception.message?.contains("Bookmark sura=1, ayah=1, isReading=false has 2 creations") == true)
         assertTrue(exception.message?.contains("which is not allowed") == true)
     }
     
@@ -55,7 +55,7 @@ class BookmarksLocalMutationsPreprocessorTest {
             preprocessor.preprocess(listOf(mutation1, mutation2, mutation3, mutation4))
         }
         
-        assertTrue(exception.message?.contains("Bookmark page=1 has 4 mutations") == true) // After conversion, there are 4 mutations
+        assertTrue(exception.message?.contains("Bookmark sura=1, ayah=1, isReading=false has 4 mutations") == true) // After conversion, there are 4 mutations
         assertTrue(exception.message?.contains("exceeds logical limit of 2") == true)
     }
     
@@ -83,8 +83,8 @@ class BookmarksLocalMutationsPreprocessorTest {
             preprocessor.preprocess(allMutations)
         }
         
-        assertTrue(exception.message?.contains("Bookmark page=1 has 2 creations") == true ||
-                  exception.message?.contains("Bookmark page=3 has 2 creations") == true)
+        assertTrue(exception.message?.contains("Bookmark sura=1, ayah=1, isReading=false has 2 creations") == true ||
+                  exception.message?.contains("Bookmark sura=3, ayah=1, isReading=false has 2 creations") == true)
     }
     
     @Test
@@ -106,7 +106,7 @@ class BookmarksLocalMutationsPreprocessorTest {
             preprocessor.preprocess(allMutations)
         }
         
-        assertTrue(exception.message?.contains("Bookmark page=1 has 4 mutations") == true)
+        assertTrue(exception.message?.contains("Bookmark sura=1, ayah=1, isReading=false has 4 mutations") == true)
         assertTrue(exception.message?.contains("exceeds logical limit of 2") == true)
     }
     
@@ -128,8 +128,8 @@ class BookmarksLocalMutationsPreprocessorTest {
             preprocessor.preprocess(allMutations)
         }
         
-        assertTrue(exception.message?.contains("Bookmark page=1 has 2 creations") == true ||
-                  exception.message?.contains("Bookmark page=2 has 2 creations") == true)
+        assertTrue(exception.message?.contains("Bookmark sura=1, ayah=1, isReading=false has 2 creations") == true ||
+                  exception.message?.contains("Bookmark sura=2, ayah=1, isReading=false has 2 creations") == true)
     }
     
     @Test
@@ -141,7 +141,7 @@ class BookmarksLocalMutationsPreprocessorTest {
             preprocessor.preprocess(listOf(deletion1, deletion2))
         }
         
-        assertTrue(exception.message?.contains("Bookmark page=1 has 2 deletions") == true)
+        assertTrue(exception.message?.contains("Bookmark sura=1, ayah=1, isReading=false has 2 deletions") == true)
         assertTrue(exception.message?.contains("which is not allowed") == true)
     }
     
@@ -154,7 +154,7 @@ class BookmarksLocalMutationsPreprocessorTest {
             preprocessor.preprocess(listOf(creation1, creation2))
         }
         
-        assertTrue(exception.message?.contains("Bookmark page=1 has 2 creations") == true)
+        assertTrue(exception.message?.contains("Bookmark sura=1, ayah=1, isReading=false has 2 creations") == true)
         assertTrue(exception.message?.contains("which is not allowed") == true)
     }
     
@@ -224,7 +224,7 @@ class BookmarksLocalMutationsPreprocessorTest {
             preprocessor.preprocess(listOf(creation, modification))
         }
         
-        assertTrue(exception.message?.contains("Bookmark page=1 has 2 creations") == true)
+        assertTrue(exception.message?.contains("Bookmark sura=1, ayah=1, isReading=false has 2 creations") == true)
         assertTrue(exception.message?.contains("which is not allowed") == true)
     }
     

--- a/syncengine/src/iosMain/kotlin/com/quran/shared/syncengine/network/HttpClientFactory.apple.kt
+++ b/syncengine/src/iosMain/kotlin/com/quran/shared/syncengine/network/HttpClientFactory.apple.kt
@@ -5,13 +5,14 @@ import io.ktor.client.engine.darwin.Darwin
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
+import kotlinx.serialization.json.Json
 import io.ktor.serialization.kotlinx.json.json
 
 actual object HttpClientFactory {
     actual fun createHttpClient(): HttpClient {
         return HttpClient(Darwin) {
             install(ContentNegotiation) {
-                json()
+                json(Json { explicitNulls = false })
             }
             install(Logging) {
                 level = LogLevel.INFO

--- a/syncengine/src/jvmMain/kotlin/com/quran/shared/syncengine/network/HttpClientFactory.jvm.kt
+++ b/syncengine/src/jvmMain/kotlin/com/quran/shared/syncengine/network/HttpClientFactory.jvm.kt
@@ -5,13 +5,14 @@ import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
+import kotlinx.serialization.json.Json
 import io.ktor.serialization.kotlinx.json.json
 
 actual object HttpClientFactory {
     actual fun createHttpClient(): HttpClient {
         return HttpClient(OkHttp) {
             install(ContentNegotiation) {
-                json()
+                json(Json { explicitNulls = false })
             }
             install(Logging) {
                 level = LogLevel.INFO


### PR DESCRIPTION
- Fixes note insert/lookup edge case on iOS persistence path.
- Touches only note repository/schema/tests.
- Verification: `:persistence:jvmTest :syncengine:jvmTest :sync-pipelines:jvmTest`