### PR TITLE
Fix sync ordering for dependent resources

### DIFF
--- a/sync-pipelines/build.gradle.kts
+++ b/sync-pipelines/build.gradle.kts
@@ -43,6 +43,7 @@ kotlin {
 
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncEnginePipeline.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncEnginePipeline.kt
@@ -267,7 +267,7 @@ private class ReadingSessionsRepositoryDataFetcher(
     }
 }
 
-private class ResultReceiver(
+internal class ResultReceiver(
     val bookmarksRepository: BookmarksSynchronizationRepository,
     val readingBookmarksRepository: ReadingBookmarksSynchronizationRepository,
     val callback: SyncEngineCallback
@@ -275,6 +275,10 @@ private class ResultReceiver(
 
     override suspend fun didFail(message: String) {
         callback.encounteredError(message)
+    }
+
+    override suspend fun didCompleteSync(newToken: Long) {
+        callback.synchronizationDone(newToken)
     }
 
     override suspend fun didSucceed(
@@ -325,7 +329,6 @@ private class ResultReceiver(
 
         bookmarksRepository.applyRemoteChanges(mappedBookmarkRemotes, mappedBookmarkLocals)
         readingBookmarksRepository.applyRemoteChanges(mappedReadingRemotes, mappedReadingLocals)
-        callback.synchronizationDone(newToken)
     }
 }
 
@@ -365,7 +368,6 @@ private class CollectionsResultReceiver(
         }
 
         repository.applyRemoteChanges(mappedRemotes, mappedLocals)
-        callback.synchronizationDone(newToken)
     }
 }
 
@@ -405,7 +407,6 @@ private class CollectionBookmarksResultReceiver(
         }
 
         repository.applyRemoteChanges(mappedRemotes, mappedLocals)
-        callback.synchronizationDone(newToken)
     }
 }
 
@@ -468,7 +469,6 @@ private class NotesResultReceiver(
         }
 
         repository.applyRemoteChanges(mappedRemotes, mappedLocals)
-        callback.synchronizationDone(newToken)
     }
 }
 
@@ -500,7 +500,6 @@ private class ReadingSessionsResultReceiver(
         }
 
         repository.applyRemoteChanges(mappedRemotes, processedLocalMutations.map { it.localID })
-        callback.synchronizationDone(newToken)
     }
 }
 

--- a/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/ResultReceiverTest.kt
+++ b/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/ResultReceiverTest.kt
@@ -1,0 +1,90 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.quran.shared.pipeline
+
+import com.quran.shared.mutations.LocalModelMutation
+import com.quran.shared.mutations.RemoteModelMutation
+import com.quran.shared.persistence.input.RemoteBookmark
+import com.quran.shared.persistence.model.AyahBookmark
+import com.quran.shared.persistence.model.ReadingBookmark
+import com.quran.shared.persistence.repository.bookmark.repository.BookmarksSynchronizationRepository
+import com.quran.shared.persistence.repository.readingbookmark.repository.ReadingBookmarksSynchronizationRepository
+import com.quran.shared.syncengine.model.SyncBookmark
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ResultReceiverTest {
+
+    @Test
+    fun `sync completion callback is deferred until resource changes are applied`() = runTest {
+        val events = mutableListOf<String>()
+        val receiver = ResultReceiver(
+            bookmarksRepository = RecordingBookmarksRepository(events),
+            readingBookmarksRepository = RecordingReadingBookmarksRepository(events),
+            callback = object : SyncEngineCallback {
+                override fun synchronizationDone(newLastModificationDate: Long) {
+                    events += "done-$newLastModificationDate"
+                }
+
+                override fun encounteredError(errorMsg: String) {
+                    events += "error-$errorMsg"
+                }
+            }
+        )
+
+        receiver.didSucceed(
+            newToken = 11L,
+            newRemoteMutations = emptyList<RemoteModelMutation<SyncBookmark>>(),
+            processedLocalMutations = emptyList<LocalModelMutation<SyncBookmark>>()
+        )
+
+        assertEquals(
+            listOf("bookmarks-applied", "reading-bookmarks-applied"),
+            events
+        )
+
+        receiver.didCompleteSync(10L)
+
+        assertEquals(
+            listOf("bookmarks-applied", "reading-bookmarks-applied", "done-10"),
+            events
+        )
+    }
+}
+
+private class RecordingBookmarksRepository(
+    private val events: MutableList<String>
+) : BookmarksSynchronizationRepository {
+    override suspend fun fetchMutatedBookmarks(): List<LocalModelMutation<AyahBookmark>> = emptyList()
+
+    override suspend fun applyRemoteChanges(
+        updatesToPersist: List<RemoteModelMutation<RemoteBookmark.Ayah>>,
+        localMutationsToClear: List<LocalModelMutation<AyahBookmark>>
+    ) {
+        events += "bookmarks-applied"
+    }
+
+    override suspend fun remoteResourcesExist(remoteIDs: List<String>): Map<String, Boolean> =
+        remoteIDs.associateWith { false }
+
+    override suspend fun fetchBookmarkByRemoteId(remoteId: String): AyahBookmark? = null
+}
+
+private class RecordingReadingBookmarksRepository(
+    private val events: MutableList<String>
+) : ReadingBookmarksSynchronizationRepository {
+    override suspend fun fetchMutatedReadingBookmarks(): List<LocalModelMutation<ReadingBookmark>> = emptyList()
+
+    override suspend fun applyRemoteChanges(
+        updatesToPersist: List<RemoteModelMutation<RemoteBookmark.Ayah>>,
+        localMutationsToClear: List<LocalModelMutation<ReadingBookmark>>
+    ) {
+        events += "reading-bookmarks-applied"
+    }
+
+    override suspend fun remoteResourcesExist(remoteIDs: List<String>): Map<String, Boolean> =
+        remoteIDs.associateWith { false }
+
+    override suspend fun fetchReadingBookmarkByRemoteId(remoteId: String): ReadingBookmark? = null
+}

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/BookmarksSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/BookmarksSyncAdapter.kt
@@ -81,6 +81,10 @@ internal class BookmarksSyncAdapter(
         configurations.resultNotifier.didFail(message)
     }
 
+    override suspend fun didCompleteSync(newToken: Long) {
+        configurations.resultNotifier.didCompleteSync(newToken)
+    }
+
     private suspend fun parseRemoteMutations(
         mutations: List<SyncMutation>
     ): List<RemoteModelMutation<SyncBookmark>> {

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapter.kt
@@ -76,6 +76,10 @@ internal class CollectionBookmarksSyncAdapter(
         configurations.resultNotifier.didFail(message)
     }
 
+    override suspend fun didCompleteSync(newToken: Long) {
+        configurations.resultNotifier.didCompleteSync(newToken)
+    }
+
     private suspend fun parseRemoteMutations(
         mutations: List<SyncMutation>
     ): List<RemoteModelMutation<SyncCollectionBookmark>> {

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionsSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionsSyncAdapter.kt
@@ -80,6 +80,10 @@ internal class CollectionsSyncAdapter(
         configurations.resultNotifier.didFail(message)
     }
 
+    override suspend fun didCompleteSync(newToken: Long) {
+        configurations.resultNotifier.didCompleteSync(newToken)
+    }
+
     private fun parseRemoteMutations(
         mutations: List<SyncMutation>
     ): List<RemoteModelMutation<SyncCollection>> {

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/NotesSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/NotesSyncAdapter.kt
@@ -85,6 +85,10 @@ internal class NotesSyncAdapter(
         configurations.resultNotifier.didFail(message)
     }
 
+    override suspend fun didCompleteSync(newToken: Long) {
+        configurations.resultNotifier.didCompleteSync(newToken)
+    }
+
     private fun parseRemoteMutations(
         mutations: List<SyncMutation>
     ): List<RemoteModelMutation<SyncNote>> {

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/ReadingSessionsSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/ReadingSessionsSyncAdapter.kt
@@ -48,6 +48,10 @@ internal class ReadingSessionsSyncAdapter(
         configurations.resultNotifier.didFail(message)
     }
 
+    override suspend fun didCompleteSync(newToken: Long) {
+        configurations.resultNotifier.didCompleteSync(newToken)
+    }
+
     private suspend fun parseRemoteMutations(
         mutations: List<SyncMutation>
     ): List<RemoteModelMutation<SyncReadingSession>> {

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SyncResourceAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SyncResourceAdapter.kt
@@ -9,6 +9,8 @@ interface SyncResourceAdapter {
         remoteMutations: List<SyncMutation>
     ): ResourceSyncPlan
 
+    suspend fun didCompleteSync(newToken: Long) = Unit
+
     suspend fun didFail(message: String)
 }
 

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClient.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClient.kt
@@ -34,11 +34,22 @@ interface LocalDataFetcher<Model> {
 }
 
 interface ResultNotifier<Model> {
+    /**
+     * Applies completed resource changes. For multi-resource sync runs, store the shared sync token from
+     * [didCompleteSync] instead of this callback.
+     */
     suspend fun didSucceed(
         newToken: Long,
         newRemoteMutations: List<RemoteModelMutation<Model>>,
         processedLocalMutations: List<LocalModelMutation<Model>>
     )
+
+    /**
+     * Called after every configured resource phase completes successfully. In multi-resource sync runs,
+     * this token is capped at the initial remote fetch token so later syncs can still observe remote
+     * changes created while local phase POSTs were in progress.
+     */
+    suspend fun didCompleteSync(newToken: Long) = Unit
 
     suspend fun didFail(message: String)
 }

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClientImpl.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClientImpl.kt
@@ -78,17 +78,12 @@ internal class SynchronizationClientImpl(
         val resources = resourceAdapters.map { it.resourceName }.distinct()
         val remoteResponse = fetchRemoteMutations(lastModificationDate, authHeaders, resources)
 
-        val plans = resourceAdapters.map { adapter ->
-            adapter.buildPlan(lastModificationDate, remoteResponse.mutations)
-        }
-
-        val mutationsToPush = plans.flatMap { it.mutationsToPush() }
-        val pushResponse = pushMutations(mutationsToPush, remoteResponse.lastModificationDate, authHeaders)
-
-        val pushedMutationsByResource = pushResponse.mutations.groupBy { it.resource.uppercase() }
-        plans.forEach { plan ->
-            val pushedForResource = pushedMutationsByResource[plan.resourceName.uppercase()].orEmpty()
-            plan.complete(pushResponse.lastModificationDate, pushedForResource)
+        executeDependencyAwareSync(
+            resourceAdapters = resourceAdapters,
+            initialLastModificationDate = lastModificationDate,
+            remoteResponse = remoteResponse
+        ) { mutations, mutationToken ->
+            pushMutations(mutations, mutationToken, authHeaders)
         }
     }
 
@@ -129,5 +124,67 @@ internal class SynchronizationClientImpl(
         val url = environment.endPointURL
         val request = GetMutationsRequest(httpClient, url)
         return request.getMutations(lastModificationDate, authHeaders, resources)
+    }
+}
+
+private val PRIMARY_SYNC_RESOURCES = setOf("BOOKMARK", "COLLECTION")
+private const val COLLECTION_BOOKMARK_SYNC_RESOURCE = "COLLECTION_BOOKMARK"
+
+internal fun List<SyncResourceAdapter>.dependencyAwareSyncPhases(): List<List<SyncResourceAdapter>> {
+    val remainingAdapters = toMutableList()
+    val phases = mutableListOf<List<SyncResourceAdapter>>()
+
+    fun addPhase(resourceNames: Set<String>) {
+        val phase = remainingAdapters.filter { adapter ->
+            adapter.resourceName.uppercase() in resourceNames
+        }
+        if (phase.isNotEmpty()) {
+            phases += phase
+            remainingAdapters.removeAll(phase)
+        }
+    }
+
+    addPhase(PRIMARY_SYNC_RESOURCES)
+    addPhase(setOf(COLLECTION_BOOKMARK_SYNC_RESOURCE))
+
+    if (remainingAdapters.isNotEmpty()) {
+        phases += remainingAdapters
+    }
+
+    return phases
+}
+
+internal suspend fun executeDependencyAwareSync(
+    resourceAdapters: List<SyncResourceAdapter>,
+    initialLastModificationDate: Long,
+    remoteResponse: MutationsResponse,
+    pushMutations: suspend (List<SyncMutation>, Long) -> MutationsResponse
+) {
+    var mutationToken = remoteResponse.lastModificationDate
+    val safeCompletionToken = remoteResponse.lastModificationDate
+    val phases = resourceAdapters.dependencyAwareSyncPhases()
+    val totalPlans = phases.sumOf { it.size }
+
+    phases.forEach { phaseAdapters ->
+        val plans = phaseAdapters.map { adapter ->
+            adapter.buildPlan(initialLastModificationDate, remoteResponse.mutations)
+        }
+
+        val mutationsToPush = plans.flatMap { it.mutationsToPush() }
+        val pushResponse = pushMutations(mutationsToPush, mutationToken)
+        mutationToken = pushResponse.lastModificationDate
+
+        val pushedMutationsByResource = pushResponse.mutations.groupBy { it.resource.uppercase() }
+        plans.forEach { plan ->
+            val pushedForResource = pushedMutationsByResource[plan.resourceName.uppercase()].orEmpty()
+            val completionToken = if (totalPlans == 1) mutationToken else initialLastModificationDate
+            plan.complete(completionToken, pushedForResource)
+        }
+    }
+
+    if (totalPlans > 1) {
+        resourceAdapters.forEach { adapter ->
+            adapter.didCompleteSync(safeCompletionToken)
+        }
     }
 }

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/SynchronizationClientPhasingTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/SynchronizationClientPhasingTest.kt
@@ -1,0 +1,216 @@
+package com.quran.shared.syncengine
+
+import com.quran.shared.mutations.Mutation
+import com.quran.shared.syncengine.network.MutationsResponse
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class SynchronizationClientPhasingTest {
+
+    @Test
+    fun `collection bookmark plan is built after primary resources complete`() = runTest {
+        val events = mutableListOf<String>()
+        var completedPrimaryResources = 0
+        val pushedTokens = mutableListOf<Long>()
+
+        val bookmarkAdapter = RecordingAdapter(
+            resourceName = "BOOKMARK",
+            events = events,
+            onComplete = {
+                completedPrimaryResources += 1
+            },
+            onSyncComplete = { token -> events += "sync-complete-BOOKMARK-$token" }
+        )
+        val collectionAdapter = RecordingAdapter(
+            resourceName = "COLLECTION",
+            events = events,
+            onComplete = {
+                completedPrimaryResources += 1
+            },
+            onSyncComplete = { token -> events += "sync-complete-COLLECTION-$token" }
+        )
+        val collectionBookmarkAdapter = RecordingAdapter(
+            resourceName = "COLLECTION_BOOKMARK",
+            events = events,
+            onBuild = {
+                assertEquals(
+                    2,
+                    completedPrimaryResources,
+                    "Collection bookmark planning should see remote IDs persisted by primary resources."
+                )
+            },
+            onSyncComplete = { token -> events += "sync-complete-COLLECTION_BOOKMARK-$token" }
+        )
+        val notesAdapter = RecordingAdapter(
+            resourceName = "NOTE",
+            events = events,
+            onSyncComplete = { token -> events += "sync-complete-NOTE-$token" }
+        )
+
+        executeDependencyAwareSync(
+            resourceAdapters = listOf(
+                bookmarkAdapter,
+                collectionAdapter,
+                collectionBookmarkAdapter,
+                notesAdapter
+            ),
+            initialLastModificationDate = 1L,
+            remoteResponse = MutationsResponse(
+                lastModificationDate = 10L,
+                mutations = emptyList()
+            ),
+            pushMutations = { mutations, mutationToken ->
+                pushedTokens += mutationToken
+                MutationsResponse(
+                    lastModificationDate = mutationToken + 1,
+                    mutations = mutations.mapIndexed { index, mutation ->
+                        mutation.copy(resourceId = "${mutation.resource.lowercase()}-$index")
+                    }
+                )
+            }
+        )
+
+        assertEquals(
+            listOf(
+                "build-BOOKMARK",
+                "build-COLLECTION",
+                "complete-BOOKMARK-1",
+                "complete-COLLECTION-1",
+                "build-COLLECTION_BOOKMARK",
+                "complete-COLLECTION_BOOKMARK-1",
+                "build-NOTE",
+                "complete-NOTE-1",
+                "sync-complete-BOOKMARK-10",
+                "sync-complete-COLLECTION-10",
+                "sync-complete-COLLECTION_BOOKMARK-10",
+                "sync-complete-NOTE-10"
+            ),
+            events
+        )
+        assertEquals(listOf(10L, 11L, 12L), pushedTokens)
+    }
+
+    @Test
+    fun `shared token is not completed when later phase fails`() = runTest {
+        val events = mutableListOf<String>()
+
+        val bookmarkAdapter = RecordingAdapter(
+            resourceName = "BOOKMARK",
+            events = events,
+            onSyncComplete = { token -> events += "sync-complete-BOOKMARK-$token" }
+        )
+        val collectionBookmarkAdapter = RecordingAdapter(
+            resourceName = "COLLECTION_BOOKMARK",
+            events = events,
+            onBuild = {
+                throw IllegalStateException("later phase failed")
+            }
+        )
+
+        assertFailsWith<IllegalStateException> {
+            executeDependencyAwareSync(
+                resourceAdapters = listOf(
+                    bookmarkAdapter,
+                    collectionBookmarkAdapter
+                ),
+                initialLastModificationDate = 1L,
+                remoteResponse = MutationsResponse(
+                    lastModificationDate = 10L,
+                    mutations = emptyList()
+                ),
+                pushMutations = { mutations, mutationToken ->
+                    MutationsResponse(
+                        lastModificationDate = mutationToken + 1,
+                        mutations = mutations.mapIndexed { index, mutation ->
+                            mutation.copy(resourceId = "${mutation.resource.lowercase()}-$index")
+                        }
+                    )
+                }
+            )
+        }
+
+        assertEquals(
+            listOf(
+                "build-BOOKMARK",
+                "complete-BOOKMARK-1",
+                "build-COLLECTION_BOOKMARK"
+            ),
+            events
+        )
+    }
+
+    @Test
+    fun `dependency aware phases preserve adapter order inside each phase`() {
+        val adapters = listOf(
+            RecordingAdapter("READING_SESSION", mutableListOf()),
+            RecordingAdapter("COLLECTION_BOOKMARK", mutableListOf()),
+            RecordingAdapter("BOOKMARK", mutableListOf()),
+            RecordingAdapter("NOTE", mutableListOf()),
+            RecordingAdapter("COLLECTION", mutableListOf())
+        )
+
+        val phases = adapters.dependencyAwareSyncPhases()
+            .map { phase -> phase.map { it.resourceName } }
+
+        assertEquals(
+            listOf(
+                listOf("BOOKMARK", "COLLECTION"),
+                listOf("COLLECTION_BOOKMARK"),
+                listOf("READING_SESSION", "NOTE")
+            ),
+            phases
+        )
+    }
+}
+
+private class RecordingAdapter(
+    override val resourceName: String,
+    private val events: MutableList<String>,
+    private val onBuild: () -> Unit = {},
+    private val onComplete: () -> Unit = {},
+    private val onSyncComplete: (Long) -> Unit = {}
+) : SyncResourceAdapter {
+    override val localModificationDateFetcher: LocalModificationDateFetcher =
+        object : LocalModificationDateFetcher {
+            override suspend fun localLastModificationDate(): Long = 0L
+        }
+
+    override suspend fun buildPlan(
+        lastModificationDate: Long,
+        remoteMutations: List<SyncMutation>
+    ): ResourceSyncPlan {
+        events += "build-$resourceName"
+        onBuild()
+        return RecordingPlan(resourceName, events, onComplete)
+    }
+
+    override suspend fun didFail(message: String) = Unit
+
+    override suspend fun didCompleteSync(newToken: Long) {
+        onSyncComplete(newToken)
+    }
+}
+
+private class RecordingPlan(
+    override val resourceName: String,
+    private val events: MutableList<String>,
+    private val onComplete: () -> Unit
+) : ResourceSyncPlan {
+    override fun mutationsToPush(): List<SyncMutation> =
+        listOf(
+            SyncMutation(
+                resource = resourceName,
+                resourceId = null,
+                mutation = Mutation.CREATED,
+                data = null,
+                timestamp = null
+            )
+        )
+
+    override suspend fun complete(newToken: Long, pushedMutations: List<SyncMutation>) {
+        events += "complete-$resourceName-$newToken"
+        onComplete()
+    }
+}


### PR DESCRIPTION
Build and apply sync plans in dependency-aware phases so bookmarks and
collections are synced before collection-bookmark links are planned.
This lets collection-bookmark links use the remote IDs returned for
their dependencies in the same sync run.

Defer shared sync-token publication until all phases complete, and cap
the published token at the initial fetch watermark so changes made
remotely during phase POSTs are picked up by the next sync.
