### PR TITLE
Add an import api

### DIFF
--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/di/PersistenceModule.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/di/PersistenceModule.kt
@@ -29,6 +29,8 @@ import com.quran.shared.persistence.repository.readingsession.repository.Reading
 import com.quran.shared.persistence.repository.readingsession.repository.ReadingSessionsSynchronizationRepository
 import com.quran.shared.persistence.repository.PersistenceResetRepository
 import com.quran.shared.persistence.repository.PersistenceResetRepositoryImpl
+import com.quran.shared.persistence.repository.importdata.PersistenceImportRepository
+import com.quran.shared.persistence.repository.importdata.PersistenceImportRepositoryImpl
 
 import dev.zacsweers.metro.Binds
 
@@ -82,4 +84,7 @@ abstract class PersistenceModule {
 
     @Binds
     abstract fun bindPersistenceResetRepository(impl: PersistenceResetRepositoryImpl): PersistenceResetRepository
+
+    @Binds
+    abstract fun bindPersistenceImportRepository(impl: PersistenceImportRepositoryImpl): PersistenceImportRepository
 }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/input/PersistenceImportData.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/input/PersistenceImportData.kt
@@ -1,0 +1,70 @@
+package com.quran.shared.persistence.input
+
+import com.quran.shared.persistence.util.PlatformDateTime
+
+data class PersistenceImportData(
+    val bookmarks: List<ImportAyahBookmark> = emptyList(),
+    val collections: List<ImportCollection> = emptyList(),
+    val collectionBookmarks: List<ImportCollectionAyahBookmark> = emptyList(),
+    val readingSessions: List<ImportReadingSession> = emptyList(),
+    val readingBookmark: ImportReadingBookmark? = null,
+    val notes: List<ImportNote> = emptyList()
+)
+
+data class ImportAyahBookmark(
+    val importId: String,
+    val sura: Int,
+    val ayah: Int,
+    val lastUpdated: PlatformDateTime
+)
+
+data class ImportCollection(
+    val importId: String,
+    val name: String,
+    val lastUpdated: PlatformDateTime
+)
+
+data class ImportCollectionAyahBookmark(
+    val collectionImportId: String,
+    val bookmarkImportId: String,
+    val lastUpdated: PlatformDateTime
+)
+
+data class ImportReadingSession(
+    val sura: Int,
+    val ayah: Int,
+    val lastUpdated: PlatformDateTime
+)
+
+sealed class ImportReadingBookmark {
+    abstract val lastUpdated: PlatformDateTime
+
+    data class Ayah(
+        val sura: Int,
+        val ayah: Int,
+        override val lastUpdated: PlatformDateTime
+    ) : ImportReadingBookmark()
+
+    data class Page(
+        val page: Int,
+        override val lastUpdated: PlatformDateTime
+    ) : ImportReadingBookmark()
+}
+
+data class ImportNote(
+    val body: String,
+    val startSura: Int,
+    val startAyah: Int,
+    val endSura: Int,
+    val endAyah: Int,
+    val lastUpdated: PlatformDateTime
+)
+
+data class PersistenceImportResult(
+    val bookmarksImported: Int,
+    val collectionsImported: Int,
+    val collectionBookmarksImported: Int,
+    val readingSessionsImported: Int,
+    val readingBookmarkImported: Boolean,
+    val notesImported: Int
+)

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/importdata/PersistenceImportRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/importdata/PersistenceImportRepository.kt
@@ -1,0 +1,16 @@
+package com.quran.shared.persistence.repository.importdata
+
+import com.quran.shared.persistence.input.PersistenceImportData
+import com.quran.shared.persistence.input.PersistenceImportResult
+import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
+
+interface PersistenceImportRepository {
+    /**
+     * Imports a complete local data set into an empty persistence database.
+     *
+     * The import is all-or-nothing. If any managed persistence table already has rows,
+     * or the payload is invalid, no import rows are persisted.
+     */
+    @NativeCoroutines
+    suspend fun importData(data: PersistenceImportData): PersistenceImportResult
+}

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/importdata/PersistenceImportRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/importdata/PersistenceImportRepositoryImpl.kt
@@ -1,0 +1,266 @@
+package com.quran.shared.persistence.repository.importdata
+
+import com.quran.shared.di.AppScope
+import com.quran.shared.persistence.QuranDatabase
+import com.quran.shared.persistence.input.ImportAyahBookmark
+import com.quran.shared.persistence.input.ImportCollection
+import com.quran.shared.persistence.input.ImportCollectionAyahBookmark
+import com.quran.shared.persistence.input.ImportNote
+import com.quran.shared.persistence.input.ImportReadingBookmark
+import com.quran.shared.persistence.input.ImportReadingSession
+import com.quran.shared.persistence.input.PersistenceImportData
+import com.quran.shared.persistence.input.PersistenceImportResult
+import com.quran.shared.persistence.util.PlatformDateTime
+import com.quran.shared.persistence.util.QuranData
+import com.quran.shared.persistence.util.fromPlatform
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+
+@Inject
+@SingleIn(AppScope::class)
+class PersistenceImportRepositoryImpl(
+    private val database: QuranDatabase
+) : PersistenceImportRepository {
+
+    override suspend fun importData(data: PersistenceImportData): PersistenceImportResult {
+        return withContext(Dispatchers.IO) {
+            validate(data)
+            var result: PersistenceImportResult? = null
+            database.transaction {
+                requireDatabaseEmpty()
+
+                val bookmarkLocalIds = importBookmarks(data.bookmarks)
+                val collectionLocalIds = importCollections(data.collections)
+                importReadingSessions(data.readingSessions)
+                importReadingBookmark(data.readingBookmark)
+                importNotes(data.notes)
+                importCollectionBookmarks(
+                    links = data.collectionBookmarks,
+                    bookmarkLocalIds = bookmarkLocalIds,
+                    collectionLocalIds = collectionLocalIds
+                )
+
+                result = PersistenceImportResult(
+                    bookmarksImported = data.bookmarks.size,
+                    collectionsImported = data.collections.size,
+                    collectionBookmarksImported = data.collectionBookmarks.size,
+                    readingSessionsImported = data.readingSessions.size,
+                    readingBookmarkImported = data.readingBookmark != null,
+                    notesImported = data.notes.size
+                )
+            }
+            requireNotNull(result)
+        }
+    }
+
+    private fun requireDatabaseEmpty() {
+        val nonEmptyTables = buildList {
+            if (database.ayah_bookmarksQueries.countAll().executeAsOne() > 0) add("ayah_bookmark")
+            if (database.reading_bookmarksQueries.countAll().executeAsOne() > 0) add("reading_bookmark")
+            if (database.collectionsQueries.countAll().executeAsOne() > 0) add("collection")
+            if (database.bookmark_collectionsQueries.countAll().executeAsOne() > 0) add("bookmark_collection")
+            if (database.notesQueries.countAll().executeAsOne() > 0) add("note")
+            if (database.reading_sessionsQueries.countAll().executeAsOne() > 0) add("reading_session")
+        }
+        check(nonEmptyTables.isEmpty()) {
+            "Cannot import into a non-empty persistence database. Non-empty tables: " +
+                nonEmptyTables.joinToString()
+        }
+    }
+
+    private fun validate(data: PersistenceImportData) {
+        requireUniqueNonBlank(
+            label = "bookmark importId",
+            values = data.bookmarks.map { it.importId }
+        )
+        requireUniqueNonBlank(
+            label = "collection importId",
+            values = data.collections.map { it.importId }
+        )
+        requireUnique(
+            label = "collection name",
+            values = data.collections.map { it.name }
+        )
+        data.collections.forEach { collection ->
+            require(collection.name.isNotBlank()) { "Collection name cannot be blank." }
+        }
+
+        val bookmarkCoordinates = data.bookmarks.map { bookmark ->
+            requireAyahId(bookmark.sura, bookmark.ayah, "bookmark ${bookmark.importId}")
+            bookmark.sura to bookmark.ayah
+        }
+        requireUnique("bookmark ayah", bookmarkCoordinates)
+
+        val readingSessionCoordinates = data.readingSessions.map { session ->
+            requireAyahId(session.sura, session.ayah, "reading session")
+            session.sura to session.ayah
+        }
+        requireUnique("reading session ayah", readingSessionCoordinates)
+
+        when (val readingBookmark = data.readingBookmark) {
+            is ImportReadingBookmark.Ayah ->
+                requireAyahId(readingBookmark.sura, readingBookmark.ayah, "reading bookmark")
+            is ImportReadingBookmark.Page ->
+                requirePage(readingBookmark.page, "reading bookmark")
+            null -> Unit
+        }
+
+        data.notes.forEach { note ->
+            require(note.body.isNotBlank()) { "Note body cannot be blank." }
+            requireAyahId(note.startSura, note.startAyah, "note start")
+            requireAyahId(note.endSura, note.endAyah, "note end")
+        }
+
+        val bookmarkIds = data.bookmarks.map { it.importId }.toSet()
+        val collectionIds = data.collections.map { it.importId }.toSet()
+        val linkPairs = data.collectionBookmarks.map { link ->
+            require(link.bookmarkImportId.isNotBlank()) { "Collection bookmark bookmarkImportId cannot be blank." }
+            require(link.collectionImportId.isNotBlank()) { "Collection bookmark collectionImportId cannot be blank." }
+            require(link.bookmarkImportId in bookmarkIds) {
+                "Collection bookmark references unknown bookmark importId=${link.bookmarkImportId}."
+            }
+            require(link.collectionImportId in collectionIds) {
+                "Collection bookmark references unknown collection importId=${link.collectionImportId}."
+            }
+            link.collectionImportId to link.bookmarkImportId
+        }
+        requireUnique("collection bookmark link", linkPairs)
+    }
+
+    private fun importBookmarks(bookmarks: List<ImportAyahBookmark>): Map<String, String> {
+        return bookmarks.associate { bookmark ->
+            val ayahId = requireAyahId(bookmark.sura, bookmark.ayah, "bookmark ${bookmark.importId}")
+            val timestamp = bookmark.lastUpdated.toImportTimestampMillis()
+            database.ayah_bookmarksQueries.insertImportedBookmark(
+                ayah_id = ayahId.toLong(),
+                sura = bookmark.sura.toLong(),
+                ayah = bookmark.ayah.toLong(),
+                created_at = timestamp,
+                modified_at = timestamp
+            )
+            val record = database.ayah_bookmarksQueries
+                .getBookmarkForAyah(bookmark.sura.toLong(), bookmark.ayah.toLong())
+                .executeAsOneOrNull()
+            requireNotNull(record) { "Expected imported bookmark ${bookmark.importId}." }
+            bookmark.importId to record.local_id.toString()
+        }
+    }
+
+    private fun importCollections(collections: List<ImportCollection>): Map<String, Long> {
+        return collections.associate { collection ->
+            val timestamp = collection.lastUpdated.toImportTimestampMillis()
+            database.collectionsQueries.insertImportedCollection(
+                name = collection.name,
+                created_at = timestamp,
+                modified_at = timestamp
+            )
+            val record = database.collectionsQueries
+                .getCollectionByName(collection.name)
+                .executeAsOneOrNull()
+            requireNotNull(record) { "Expected imported collection ${collection.importId}." }
+            collection.importId to record.local_id
+        }
+    }
+
+    private fun importReadingSessions(readingSessions: List<ImportReadingSession>) {
+        readingSessions.forEach { session ->
+            val timestamp = session.lastUpdated.toImportTimestampMillis()
+            database.reading_sessionsQueries.insertImportedReadingSession(
+                chapter_number = session.sura.toLong(),
+                verse_number = session.ayah.toLong(),
+                created_at = timestamp,
+                modified_at = timestamp
+            )
+        }
+    }
+
+    private fun importReadingBookmark(readingBookmark: ImportReadingBookmark?) {
+        when (readingBookmark) {
+            is ImportReadingBookmark.Ayah -> {
+                val timestamp = readingBookmark.lastUpdated.toImportTimestampMillis()
+                database.reading_bookmarksQueries.insertImportedAyahReadingBookmark(
+                    sura = readingBookmark.sura.toLong(),
+                    ayah = readingBookmark.ayah.toLong(),
+                    created_at = timestamp,
+                    modified_at = timestamp
+                )
+            }
+            is ImportReadingBookmark.Page -> {
+                val timestamp = readingBookmark.lastUpdated.toImportTimestampMillis()
+                database.reading_bookmarksQueries.insertImportedPageReadingBookmark(
+                    page = readingBookmark.page.toLong(),
+                    created_at = timestamp,
+                    modified_at = timestamp
+                )
+            }
+            null -> Unit
+        }
+    }
+
+    private fun importNotes(notes: List<ImportNote>) {
+        notes.forEach { note ->
+            val timestamp = note.lastUpdated.toImportTimestampMillis()
+            database.notesQueries.insertImportedNote(
+                note = note.body,
+                start_ayah_id = requireAyahId(note.startSura, note.startAyah, "note start").toLong(),
+                end_ayah_id = requireAyahId(note.endSura, note.endAyah, "note end").toLong(),
+                created_at = timestamp,
+                modified_at = timestamp
+            )
+        }
+    }
+
+    private fun importCollectionBookmarks(
+        links: List<ImportCollectionAyahBookmark>,
+        bookmarkLocalIds: Map<String, String>,
+        collectionLocalIds: Map<String, Long>
+    ) {
+        links.forEach { link ->
+            val bookmarkLocalId = requireNotNull(bookmarkLocalIds[link.bookmarkImportId]) {
+                "Missing local bookmark for importId=${link.bookmarkImportId}."
+            }
+            val collectionLocalId = requireNotNull(collectionLocalIds[link.collectionImportId]) {
+                "Missing local collection for importId=${link.collectionImportId}."
+            }
+            val timestamp = link.lastUpdated.toImportTimestampMillis()
+            database.bookmark_collectionsQueries.insertImportedBookmarkCollection(
+                bookmark_local_id = bookmarkLocalId,
+                bookmark_type = "AYAH",
+                collection_local_id = collectionLocalId,
+                created_at = timestamp,
+                modified_at = timestamp
+            )
+        }
+    }
+
+    private fun requireAyahId(sura: Int, ayah: Int, label: String): Int {
+        return requireNotNull(QuranData.getAyahIdOrNull(sura, ayah)) {
+            "Invalid ayah for $label: $sura:$ayah."
+        }
+    }
+
+    private fun requirePage(page: Int, label: String) {
+        require(page in 1..MUSHAF_PAGE_COUNT) { "Invalid page for $label: $page." }
+    }
+
+    private fun PlatformDateTime.toImportTimestampMillis(): Long {
+        return fromPlatform().toEpochMilliseconds()
+    }
+
+    private fun <T> requireUnique(label: String, values: List<T>) {
+        val duplicates = values.groupingBy { it }.eachCount().filterValues { it > 1 }.keys
+        require(duplicates.isEmpty()) { "Duplicate $label values: ${duplicates.joinToString()}." }
+    }
+
+    private fun requireUniqueNonBlank(label: String, values: List<String>) {
+        values.forEach { value ->
+            require(value.isNotBlank()) { "$label cannot be blank." }
+        }
+        requireUnique(label, values)
+    }
+}
+
+private const val MUSHAF_PAGE_COUNT = 604

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/ayah_bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/ayah_bookmarks.sq
@@ -18,6 +18,9 @@ CREATE INDEX IF NOT EXISTS ayah_bookmark_remote_id_idx ON ayah_bookmark(remote_i
 getBookmarks:
   SELECT * FROM ayah_bookmark WHERE deleted = 0 ORDER BY created_at DESC;
 
+countAll:
+  SELECT COUNT(*) FROM ayah_bookmark;
+
 getBookmarkForAyah:
   SELECT * FROM ayah_bookmark WHERE sura = ? AND ayah = ? LIMIT 1;
 
@@ -41,6 +44,28 @@ insertBookmarkIfMissing {
   INSERT OR IGNORE INTO ayah_bookmark (remote_id, ayah_id, sura, ayah, is_edited, deleted)
   VALUES (NULL, :ayah_id, :sura, :ayah, 0, 0);
 }
+
+insertImportedBookmark:
+  INSERT INTO ayah_bookmark (
+    remote_id,
+    ayah_id,
+    sura,
+    ayah,
+    is_edited,
+    created_at,
+    modified_at,
+    deleted
+  )
+  VALUES (
+    NULL,
+    :ayah_id,
+    :sura,
+    :ayah,
+    0,
+    :created_at,
+    :modified_at,
+    0
+  );
 
 getUnsyncedBookmarks:
   SELECT * FROM ayah_bookmark WHERE remote_id IS NULL OR is_edited = 1 OR deleted = 1 ORDER BY created_at DESC;

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmark_collections.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmark_collections.sq
@@ -18,6 +18,9 @@ CREATE INDEX IF NOT EXISTS bookmark_collection_remote_id_idx ON bookmark_collect
 getCollectionBookmarks:
   SELECT * FROM bookmark_collection WHERE deleted = 0 ORDER BY created_at DESC;
 
+countAll:
+  SELECT COUNT(*) FROM bookmark_collection;
+
 getCollectionBookmarksForCollection:
   SELECT * FROM bookmark_collection
   WHERE collection_local_id = ? AND deleted = 0
@@ -111,6 +114,26 @@ addBookmarkToCollection {
     modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
   WHERE bookmark_local_id = :bookmark_local_id AND collection_local_id = :collection_local_id;
 }
+
+insertImportedBookmarkCollection:
+  INSERT INTO bookmark_collection (
+    remote_id,
+    bookmark_local_id,
+    bookmark_type,
+    collection_local_id,
+    created_at,
+    modified_at,
+    deleted
+  )
+  VALUES (
+    NULL,
+    :bookmark_local_id,
+    :bookmark_type,
+    :collection_local_id,
+    :created_at,
+    :modified_at,
+    0
+  );
 
 deleteBookmarkFromCollection {
   DELETE FROM bookmark_collection

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/collections.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/collections.sq
@@ -15,6 +15,9 @@ CREATE INDEX IF NOT EXISTS collection_remote_id_idx ON collection(remote_id);
 getCollections:
   SELECT * FROM collection WHERE deleted = 0 ORDER BY created_at DESC;
 
+countAll:
+  SELECT COUNT(*) FROM collection;
+
 getCollectionByName:
   SELECT * FROM collection WHERE name = ? LIMIT 1;
 
@@ -33,6 +36,24 @@ addNewCollection {
     modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
   WHERE name = :name;
 }
+
+insertImportedCollection:
+  INSERT INTO collection (
+    remote_id,
+    name,
+    created_at,
+    modified_at,
+    deleted,
+    is_edited
+  )
+  VALUES (
+    NULL,
+    :name,
+    :created_at,
+    :modified_at,
+    0,
+    0
+  );
 
 updateCollectionName:
   UPDATE collection

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/notes.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/notes.sq
@@ -20,6 +20,9 @@ CREATE INDEX IF NOT EXISTS note_remote_id_idx ON note(remote_id);
 getNotes:
   SELECT * FROM note WHERE deleted = 0 ORDER BY created_at DESC;
 
+countAll:
+  SELECT COUNT(*) FROM note;
+
 getNoteByLocalId:
   SELECT * FROM note WHERE local_id = ? LIMIT 1;
 
@@ -29,6 +32,28 @@ getLastInsertedNote:
 addNewNote:
   INSERT INTO note (remote_id, note, start_ayah_id, end_ayah_id, deleted)
   VALUES (NULL, :note, :start_ayah_id, :end_ayah_id, 0);
+
+insertImportedNote:
+  INSERT INTO note (
+    remote_id,
+    note,
+    start_ayah_id,
+    end_ayah_id,
+    created_at,
+    modified_at,
+    deleted,
+    is_edited
+  )
+  VALUES (
+    NULL,
+    :note,
+    :start_ayah_id,
+    :end_ayah_id,
+    :created_at,
+    :modified_at,
+    0,
+    0
+  );
 
 updateNote:
   UPDATE note

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/reading_bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/reading_bookmarks.sq
@@ -26,6 +26,9 @@ CREATE INDEX IF NOT EXISTS reading_bookmark_remote_id_idx ON reading_bookmark(re
 getReadingBookmarks:
   SELECT * FROM reading_bookmark WHERE deleted = 0 ORDER BY modified_at DESC;
 
+countAll:
+  SELECT COUNT(*) FROM reading_bookmark;
+
 getReadingBookmarkForAyah:
   SELECT * FROM reading_bookmark WHERE bookmark_type = 'AYAH' AND sura = ? AND ayah = ? LIMIT 1;
 
@@ -71,6 +74,54 @@ addPageReadingBookmark {
       modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
     WHERE bookmark_type = 'PAGE' AND page = :page;
 }
+
+insertImportedAyahReadingBookmark:
+  INSERT INTO reading_bookmark (
+    remote_id,
+    bookmark_type,
+    sura,
+    ayah,
+    page,
+    is_edited,
+    created_at,
+    modified_at,
+    deleted
+  )
+  VALUES (
+    NULL,
+    'AYAH',
+    :sura,
+    :ayah,
+    NULL,
+    0,
+    :created_at,
+    :modified_at,
+    0
+  );
+
+insertImportedPageReadingBookmark:
+  INSERT INTO reading_bookmark (
+    remote_id,
+    bookmark_type,
+    sura,
+    ayah,
+    page,
+    is_edited,
+    created_at,
+    modified_at,
+    deleted
+  )
+  VALUES (
+    NULL,
+    'PAGE',
+    NULL,
+    NULL,
+    :page,
+    0,
+    :created_at,
+    :modified_at,
+    0
+  );
 
 deleteReadingBookmark {
   DELETE FROM reading_bookmark WHERE local_id = :id AND remote_id IS NULL;

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/reading_sessions.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/reading_sessions.sq
@@ -17,6 +17,9 @@ CREATE INDEX IF NOT EXISTS reading_session_remote_id_idx ON reading_session(remo
 getReadingSessions:
   SELECT * FROM reading_session WHERE deleted = 0 ORDER BY modified_at DESC;
 
+countAll:
+  SELECT COUNT(*) FROM reading_session;
+
 getReadingSessionForChapterVerse:
   SELECT * FROM reading_session WHERE chapter_number = ? AND verse_number = ? LIMIT 1;
 
@@ -37,6 +40,26 @@ addReadingSession {
     modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
   WHERE chapter_number = :chapter_number AND verse_number = :verse_number;
 }
+
+insertImportedReadingSession:
+  INSERT INTO reading_session (
+    remote_id,
+    chapter_number,
+    verse_number,
+    is_edited,
+    created_at,
+    modified_at,
+    deleted
+  )
+  VALUES (
+    NULL,
+    :chapter_number,
+    :verse_number,
+    0,
+    :created_at,
+    :modified_at,
+    0
+  );
 
 deleteReadingSession {
   DELETE FROM reading_session WHERE chapter_number = :chapter_number AND verse_number = :verse_number AND remote_id IS NULL;

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/PersistenceImportRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/PersistenceImportRepositoryTest.kt
@@ -1,0 +1,230 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.quran.shared.persistence.repository
+
+import com.quran.shared.mutations.Mutation
+import com.quran.shared.persistence.QuranDatabase
+import com.quran.shared.persistence.TestDatabaseDriver
+import com.quran.shared.persistence.input.ImportAyahBookmark
+import com.quran.shared.persistence.input.ImportCollection
+import com.quran.shared.persistence.input.ImportCollectionAyahBookmark
+import com.quran.shared.persistence.input.ImportNote
+import com.quran.shared.persistence.input.ImportReadingBookmark
+import com.quran.shared.persistence.input.ImportReadingSession
+import com.quran.shared.persistence.input.PersistenceImportData
+import com.quran.shared.persistence.model.PageReadingBookmark
+import com.quran.shared.persistence.repository.bookmark.repository.BookmarksRepositoryImpl
+import com.quran.shared.persistence.repository.collection.repository.CollectionsRepositoryImpl
+import com.quran.shared.persistence.repository.collectionbookmark.repository.CollectionBookmarksRepositoryImpl
+import com.quran.shared.persistence.repository.importdata.PersistenceImportRepositoryImpl
+import com.quran.shared.persistence.repository.note.repository.NotesRepositoryImpl
+import com.quran.shared.persistence.repository.readingbookmark.repository.ReadingBookmarksRepositoryImpl
+import com.quran.shared.persistence.repository.readingsession.repository.ReadingSessionsRepositoryImpl
+import com.quran.shared.persistence.util.toPlatform
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+class PersistenceImportRepositoryTest {
+    private lateinit var database: QuranDatabase
+    private lateinit var repository: PersistenceImportRepositoryImpl
+
+    @BeforeTest
+    fun setup() {
+        database = QuranDatabase(TestDatabaseDriver().createDriver())
+        repository = PersistenceImportRepositoryImpl(database)
+    }
+
+    @Test
+    fun `importData imports a complete data set into an empty database`() = runTest {
+        val result = repository.importData(
+            PersistenceImportData(
+                bookmarks = listOf(
+                    ImportAyahBookmark("bookmark-1", 2, 255, timestamp(1_000)),
+                    ImportAyahBookmark("bookmark-2", 3, 2, timestamp(2_000))
+                ),
+                collections = listOf(
+                    ImportCollection("collection-1", "Favorites", timestamp(3_000))
+                ),
+                collectionBookmarks = listOf(
+                    ImportCollectionAyahBookmark("collection-1", "bookmark-1", timestamp(4_000))
+                ),
+                readingSessions = listOf(
+                    ImportReadingSession(4, 1, timestamp(6_000)),
+                    ImportReadingSession(5, 1, timestamp(5_000))
+                ),
+                readingBookmark = ImportReadingBookmark.Page(
+                    page = 42,
+                    lastUpdated = timestamp(7_000)
+                ),
+                notes = listOf(
+                    ImportNote(
+                        body = "Important note",
+                        startSura = 2,
+                        startAyah = 255,
+                        endSura = 2,
+                        endAyah = 257,
+                        lastUpdated = timestamp(8_000)
+                    )
+                )
+            )
+        )
+
+        assertEquals(2, result.bookmarksImported)
+        assertEquals(1, result.collectionsImported)
+        assertEquals(1, result.collectionBookmarksImported)
+        assertEquals(2, result.readingSessionsImported)
+        assertTrue(result.readingBookmarkImported)
+        assertEquals(1, result.notesImported)
+
+        val bookmarksRepository = BookmarksRepositoryImpl(database)
+        val collectionsRepository = CollectionsRepositoryImpl(database)
+        val collectionBookmarksRepository = CollectionBookmarksRepositoryImpl(database)
+        val readingSessionsRepository = ReadingSessionsRepositoryImpl(database)
+        val readingBookmarksRepository = ReadingBookmarksRepositoryImpl(database)
+        val notesRepository = NotesRepositoryImpl(database)
+
+        val bookmarks = bookmarksRepository.getAllBookmarks()
+        assertEquals(2, bookmarks.size)
+        assertTrue(bookmarks.any { it.sura == 2 && it.ayah == 255 })
+        assertTrue(bookmarks.any { it.sura == 3 && it.ayah == 2 })
+
+        val collections = collectionsRepository.getAllCollections()
+        assertEquals(1, collections.size)
+        assertEquals("Favorites", collections.single().name)
+
+        val collectionBookmarks = collectionBookmarksRepository.getBookmarksForCollection(collections.single().localId)
+        assertEquals(1, collectionBookmarks.size)
+        assertEquals(2, collectionBookmarks.single().sura)
+        assertEquals(255, collectionBookmarks.single().ayah)
+
+        val readingSessions = readingSessionsRepository.getReadingSessions()
+        assertEquals(2, readingSessions.size)
+        assertEquals(4, readingSessions.first().sura)
+        assertEquals(1, readingSessions.first().ayah)
+
+        val readingBookmark = readingBookmarksRepository.getReadingBookmark() as PageReadingBookmark
+        assertEquals(42, readingBookmark.page)
+
+        val notes = notesRepository.getAllNotes()
+        assertEquals(1, notes.size)
+        assertEquals("Important note", notes.single().body)
+        assertEquals(2, notes.single().startSura)
+        assertEquals(255, notes.single().startAyah)
+    }
+
+    @Test
+    fun `importData exposes imported rows as local created mutations`() = runTest {
+        repository.importData(
+            PersistenceImportData(
+                bookmarks = listOf(ImportAyahBookmark("bookmark-1", 2, 255, timestamp(1_000))),
+                collections = listOf(ImportCollection("collection-1", "Favorites", timestamp(2_000))),
+                collectionBookmarks = listOf(
+                    ImportCollectionAyahBookmark("collection-1", "bookmark-1", timestamp(3_000))
+                ),
+                readingSessions = listOf(ImportReadingSession(3, 2, timestamp(4_000))),
+                readingBookmark = ImportReadingBookmark.Ayah(4, 4, timestamp(5_000)),
+                notes = listOf(
+                    ImportNote("Note", 2, 1, 2, 2, timestamp(6_000))
+                )
+            )
+        )
+
+        val bookmarkMutations = BookmarksRepositoryImpl(database).fetchMutatedBookmarks()
+        assertEquals(1, bookmarkMutations.size)
+        assertEquals(Mutation.CREATED, bookmarkMutations.single().mutation)
+
+        val collectionMutations = CollectionsRepositoryImpl(database).fetchMutatedCollections()
+        assertEquals(1, collectionMutations.size)
+        assertEquals(Mutation.CREATED, collectionMutations.single().mutation)
+
+        val readingSessionMutations = ReadingSessionsRepositoryImpl(database).fetchMutatedReadingSessions()
+        assertEquals(1, readingSessionMutations.size)
+        assertEquals(Mutation.CREATED, readingSessionMutations.single().mutation)
+
+        val readingBookmarkMutations = ReadingBookmarksRepositoryImpl(database).fetchMutatedReadingBookmarks()
+        assertEquals(1, readingBookmarkMutations.size)
+        assertEquals(Mutation.CREATED, readingBookmarkMutations.single().mutation)
+
+        val noteMutations = NotesRepositoryImpl(database).fetchMutatedNotes(0)
+        assertEquals(1, noteMutations.size)
+        assertEquals(Mutation.CREATED, noteMutations.single().mutation)
+
+        val collection = database.collectionsQueries.getCollectionByName("Favorites").executeAsOne()
+        database.collectionsQueries.updateRemoteCollectionByLocalId(
+            local_id = collection.local_id,
+            remote_id = "remote-collection-id",
+            name = collection.name,
+            modified_at = 7_000
+        )
+
+        val collectionBookmarkMutations = CollectionBookmarksRepositoryImpl(database)
+            .fetchMutatedCollectionBookmarks()
+        assertEquals(1, collectionBookmarkMutations.size)
+        assertEquals(Mutation.CREATED, collectionBookmarkMutations.single().mutation)
+    }
+
+    @Test
+    fun `importData fails when the database is not empty`() = runTest {
+        BookmarksRepositoryImpl(database).addBookmark(2, 255)
+
+        assertFailsWith<IllegalStateException> {
+            repository.importData(
+                PersistenceImportData(
+                    collections = listOf(ImportCollection("collection-1", "Favorites", timestamp(1_000)))
+                )
+            )
+        }
+
+        assertEquals(1L, database.ayah_bookmarksQueries.countAll().executeAsOne())
+        assertEquals(0L, database.collectionsQueries.countAll().executeAsOne())
+    }
+
+    @Test
+    fun `importData validates relationship targets before inserting rows`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            repository.importData(
+                PersistenceImportData(
+                    bookmarks = listOf(ImportAyahBookmark("bookmark-1", 2, 255, timestamp(1_000))),
+                    collections = listOf(ImportCollection("collection-1", "Favorites", timestamp(2_000))),
+                    collectionBookmarks = listOf(
+                        ImportCollectionAyahBookmark("collection-1", "missing-bookmark", timestamp(3_000))
+                    )
+                )
+            )
+        }
+
+        assertDatabaseEmpty()
+    }
+
+    @Test
+    fun `importData validates ayah values before inserting rows`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            repository.importData(
+                PersistenceImportData(
+                    bookmarks = listOf(
+                        ImportAyahBookmark("bookmark-1", 2, 255, timestamp(1_000)),
+                        ImportAyahBookmark("bookmark-2", 115, 1, timestamp(2_000))
+                    )
+                )
+            )
+        }
+
+        assertDatabaseEmpty()
+    }
+
+    private fun assertDatabaseEmpty() {
+        assertEquals(0L, database.ayah_bookmarksQueries.countAll().executeAsOne())
+        assertEquals(0L, database.reading_bookmarksQueries.countAll().executeAsOne())
+        assertEquals(0L, database.collectionsQueries.countAll().executeAsOne())
+        assertEquals(0L, database.bookmark_collectionsQueries.countAll().executeAsOne())
+        assertEquals(0L, database.notesQueries.countAll().executeAsOne())
+        assertEquals(0L, database.reading_sessionsQueries.countAll().executeAsOne())
+    }
+
+    private fun timestamp(milliseconds: Long) = Instant.fromEpochMilliseconds(milliseconds).toPlatform()
+}

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncService.kt
@@ -12,10 +12,13 @@ import com.quran.shared.persistence.model.Note
 import com.quran.shared.persistence.model.PageReadingBookmark
 import com.quran.shared.persistence.model.ReadingBookmark
 import com.quran.shared.persistence.model.ReadingSession
+import com.quran.shared.persistence.input.PersistenceImportData
+import com.quran.shared.persistence.input.PersistenceImportResult
 import com.quran.shared.persistence.repository.bookmark.repository.BookmarksRepository
 import com.quran.shared.persistence.repository.PersistenceResetRepository
 import com.quran.shared.persistence.repository.collection.repository.CollectionsRepository
 import com.quran.shared.persistence.repository.collectionbookmark.repository.CollectionBookmarksRepository
+import com.quran.shared.persistence.repository.importdata.PersistenceImportRepository
 import com.quran.shared.persistence.repository.note.repository.NotesRepository
 import com.quran.shared.persistence.repository.readingbookmark.repository.ReadingBookmarksRepository
 import com.quran.shared.persistence.repository.readingsession.repository.ReadingSessionsRepository
@@ -54,6 +57,7 @@ class SyncService(
     private val pipeline: SyncEnginePipeline,
     private val environment: SynchronizationEnvironment,
     private val persistenceResetRepository: PersistenceResetRepository,
+    private val persistenceImportRepository: PersistenceImportRepository,
     private val settings: Settings
 ) {
 
@@ -179,6 +183,18 @@ class SyncService(
 
     fun triggerSync() {
         syncClient.localDataUpdated()
+    }
+
+    @NativeCoroutines
+    suspend fun importData(data: PersistenceImportData): PersistenceImportResult {
+        try {
+            val result = persistenceImportRepository.importData(data)
+            triggerSync()
+            return result
+        } catch (e: Exception) {
+            Logger.e(e) { "Failed to import persistence data" }
+            throw e
+        }
     }
 
     @NativeCoroutines

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/di/AppGraph.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/di/AppGraph.kt
@@ -10,6 +10,7 @@ import com.quran.shared.persistence.di.PersistenceModule
 import com.quran.shared.persistence.repository.bookmark.repository.BookmarksRepository
 import com.quran.shared.persistence.repository.collection.repository.CollectionsRepository
 import com.quran.shared.persistence.repository.collectionbookmark.repository.CollectionBookmarksRepository
+import com.quran.shared.persistence.repository.importdata.PersistenceImportRepository
 import com.quran.shared.persistence.repository.note.repository.NotesRepository
 import com.quran.shared.persistence.repository.readingsession.repository.ReadingSessionsRepository
 import com.quran.shared.pipeline.AppEnvironment
@@ -43,6 +44,7 @@ interface AppGraph {
     val bookmarksRepository: BookmarksRepository
     val collectionsRepository: CollectionsRepository
     val collectionBookmarksRepository: CollectionBookmarksRepository
+    val persistenceImportRepository: PersistenceImportRepository
     val notesRepository: NotesRepository
     val readingSessionsRepository: ReadingSessionsRepository
 


### PR DESCRIPTION
Add import apis to make migrating from existing data storage solutions
to mobile-sync's persistence layer easier.
