### PR TITLE
Support explicit setting of timestamps

### DIFF
--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepository.kt
@@ -1,6 +1,7 @@
 package com.quran.shared.persistence.repository.bookmark.repository
 
 import com.quran.shared.persistence.model.AyahBookmark
+import com.quran.shared.persistence.util.PlatformDateTime
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
 import kotlinx.coroutines.flow.Flow
 
@@ -28,6 +29,9 @@ interface BookmarksRepository {
      */
     @NativeCoroutines
     suspend fun addBookmark(sura: Int, ayah: Int): AyahBookmark
+
+    @NativeCoroutines
+    suspend fun addBookmark(sura: Int, ayah: Int, timestamp: PlatformDateTime): AyahBookmark
 
     /**
      * Delete a bookmark for a specific sura and ayah.

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
@@ -12,9 +12,11 @@ import com.quran.shared.persistence.input.RemoteBookmark
 import com.quran.shared.persistence.model.AyahBookmark
 import com.quran.shared.persistence.repository.bookmark.extension.toAyahBookmark
 import com.quran.shared.persistence.repository.bookmark.extension.toBookmarkMutation
+import com.quran.shared.persistence.util.PlatformDateTime
 import com.quran.shared.persistence.util.QuranData
 import com.quran.shared.persistence.util.SQLITE_MAX_BIND_PARAMETERS
 import com.quran.shared.persistence.util.fromPlatform
+import com.quran.shared.persistence.util.toEpochMillisecondsOrNull
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.Dispatchers
@@ -52,13 +54,26 @@ class BookmarksRepositoryImpl(
     }
 
     override suspend fun addBookmark(sura: Int, ayah: Int): AyahBookmark {
+        return addBookmarkWithTimestampMillis(sura, ayah, timestampMillis = null)
+    }
+
+    override suspend fun addBookmark(sura: Int, ayah: Int, timestamp: PlatformDateTime): AyahBookmark {
+        return addBookmarkWithTimestampMillis(sura, ayah, timestamp.toEpochMillisecondsOrNull())
+    }
+
+    private suspend fun addBookmarkWithTimestampMillis(
+        sura: Int,
+        ayah: Int,
+        timestampMillis: Long?
+    ): AyahBookmark {
         logger.i { "Adding ayah bookmark for $sura:$ayah" }
         return withContext(Dispatchers.IO) {
             val ayahId = getAyahId(sura, ayah)
             ayahBookmarkQueries.value.addNewBookmark(
                 ayah_id = ayahId.toLong(),
                 sura = sura.toLong(),
-                ayah = ayah.toLong()
+                ayah = ayah.toLong(),
+                timestamp = timestampMillis
             )
             val record = ayahBookmarkQueries.value.getBookmarkForAyah(sura.toLong(), ayah.toLong())
                 .executeAsOneOrNull()
@@ -70,7 +85,10 @@ class BookmarksRepositoryImpl(
     override suspend fun deleteBookmark(sura: Int, ayah: Int): Boolean {
         logger.i { "Deleting ayah bookmark for $sura:$ayah" }
         withContext(Dispatchers.IO) {
-            ayahBookmarkQueries.value.deleteBookmark(sura.toLong(), ayah.toLong())
+            ayahBookmarkQueries.value.deleteBookmark(
+                sura = sura.toLong(),
+                ayah = ayah.toLong()
+            )
         }
         return true
     }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collection/repository/CollectionsRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collection/repository/CollectionsRepository.kt
@@ -1,6 +1,7 @@
 package com.quran.shared.persistence.repository.collection.repository
 
 import com.quran.shared.persistence.model.Collection
+import com.quran.shared.persistence.util.PlatformDateTime
 import kotlinx.coroutines.flow.Flow
 
 interface CollectionsRepository {
@@ -16,10 +17,14 @@ interface CollectionsRepository {
      */
     suspend fun addCollection(name: String): Collection
 
+    suspend fun addCollection(name: String, timestamp: PlatformDateTime): Collection
+
     /**
      * Update the name of a collection identified by its local ID.
      */
     suspend fun updateCollection(localId: String, name: String): Collection
+
+    suspend fun updateCollection(localId: String, name: String, timestamp: PlatformDateTime): Collection
 
     /**
      * Delete a collection identified by its local ID.

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collection/repository/CollectionsRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collection/repository/CollectionsRepositoryImpl.kt
@@ -12,8 +12,10 @@ import com.quran.shared.persistence.input.RemoteCollection
 import com.quran.shared.persistence.model.Collection
 import com.quran.shared.persistence.repository.collection.extension.toCollection
 import com.quran.shared.persistence.repository.collection.extension.toCollectionMutation
+import com.quran.shared.persistence.util.PlatformDateTime
 import com.quran.shared.persistence.util.SQLITE_MAX_BIND_PARAMETERS
 import com.quran.shared.persistence.util.fromPlatform
+import com.quran.shared.persistence.util.toEpochMillisecondsOrNull
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.Dispatchers
@@ -49,9 +51,20 @@ class CollectionsRepositoryImpl(
     }
 
     override suspend fun addCollection(name: String): Collection {
+        return addCollectionWithTimestampMillis(name, timestampMillis = null)
+    }
+
+    override suspend fun addCollection(name: String, timestamp: PlatformDateTime): Collection {
+        return addCollectionWithTimestampMillis(name, timestamp.toEpochMillisecondsOrNull())
+    }
+
+    private suspend fun addCollectionWithTimestampMillis(name: String, timestampMillis: Long?): Collection {
         logger.i { "Adding collection with name=$name" }
         return withContext(Dispatchers.IO) {
-            collectionQueries.value.addNewCollection(name)
+            collectionQueries.value.addNewCollection(
+                name = name,
+                timestamp = timestampMillis
+            )
             val record = collectionQueries.value.getCollectionByName(name)
                 .executeAsOneOrNull()
             requireNotNull(record) { "Expected collection for name=$name after insert." }
@@ -60,9 +73,25 @@ class CollectionsRepositoryImpl(
     }
 
     override suspend fun updateCollection(localId: String, name: String): Collection {
+        return updateCollectionWithTimestampMillis(localId, name, timestampMillis = null)
+    }
+
+    override suspend fun updateCollection(localId: String, name: String, timestamp: PlatformDateTime): Collection {
+        return updateCollectionWithTimestampMillis(localId, name, timestamp.toEpochMillisecondsOrNull())
+    }
+
+    private suspend fun updateCollectionWithTimestampMillis(
+        localId: String,
+        name: String,
+        timestampMillis: Long?
+    ): Collection {
         logger.i { "Updating collection localId=$localId with name=$name" }
         return withContext(Dispatchers.IO) {
-            collectionQueries.value.updateCollectionName(name = name, id = localId.toLong())
+            collectionQueries.value.updateCollectionName(
+                name = name,
+                id = localId.toLong(),
+                timestamp = timestampMillis
+            )
             val record = collectionQueries.value.getCollectionByLocalId(localId.toLong())
                 .executeAsOneOrNull()
             requireNotNull(record) { "Expected collection localId=$localId after update." }
@@ -73,7 +102,9 @@ class CollectionsRepositoryImpl(
     override suspend fun deleteCollection(localId: String): Boolean {
         logger.i { "Deleting collection localId=$localId" }
         withContext(Dispatchers.IO) {
-            collectionQueries.value.deleteCollection(id = localId.toLong())
+            collectionQueries.value.deleteCollection(
+                id = localId.toLong()
+            )
         }
         return true
     }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepository.kt
@@ -2,6 +2,7 @@ package com.quran.shared.persistence.repository.collectionbookmark.repository
 
 import com.quran.shared.persistence.model.AyahBookmark
 import com.quran.shared.persistence.model.CollectionAyahBookmark
+import com.quran.shared.persistence.util.PlatformDateTime
 
 import kotlinx.coroutines.flow.Flow
 
@@ -16,6 +17,12 @@ interface CollectionBookmarksRepository {
      */
     suspend fun addBookmarkToCollection(collectionLocalId: String, bookmark: AyahBookmark): CollectionAyahBookmark
 
+    suspend fun addBookmarkToCollection(
+        collectionLocalId: String,
+        bookmark: AyahBookmark,
+        timestamp: PlatformDateTime
+    ): CollectionAyahBookmark
+
     /**
      * Atomically creates an ayah bookmark (if missing) and links it to a collection.
      * This operation must not leave partial state if linking fails.
@@ -24,6 +31,13 @@ interface CollectionBookmarksRepository {
         collectionLocalId: String,
         sura: Int,
         ayah: Int
+    ): CollectionAyahBookmark
+
+    suspend fun addAyahBookmarkToCollection(
+        collectionLocalId: String,
+        sura: Int,
+        ayah: Int,
+        timestamp: PlatformDateTime
     ): CollectionAyahBookmark
 
     /**

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
@@ -13,9 +13,11 @@ import com.quran.shared.persistence.model.AyahBookmark
 import com.quran.shared.persistence.model.CollectionAyahBookmark
 import com.quran.shared.persistence.model.DatabaseBookmarkCollection
 import com.quran.shared.persistence.repository.bookmark.extension.toAyahBookmark
+import com.quran.shared.persistence.util.PlatformDateTime
 import com.quran.shared.persistence.util.QuranData
 import com.quran.shared.persistence.util.SQLITE_MAX_BIND_PARAMETERS
 import com.quran.shared.persistence.util.fromPlatform
+import com.quran.shared.persistence.util.toEpochMillisecondsOrNull
 import com.quran.shared.persistence.util.toPlatform
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
@@ -86,12 +88,33 @@ class CollectionBookmarksRepositoryImpl(
         collectionLocalId: String,
         bookmark: AyahBookmark
     ): CollectionAyahBookmark {
+        return addBookmarkToCollectionWithTimestampMillis(collectionLocalId, bookmark, timestampMillis = null)
+    }
+
+    override suspend fun addBookmarkToCollection(
+        collectionLocalId: String,
+        bookmark: AyahBookmark,
+        timestamp: PlatformDateTime
+    ): CollectionAyahBookmark {
+        return addBookmarkToCollectionWithTimestampMillis(
+            collectionLocalId,
+            bookmark,
+            timestamp.toEpochMillisecondsOrNull()
+        )
+    }
+
+    private suspend fun addBookmarkToCollectionWithTimestampMillis(
+        collectionLocalId: String,
+        bookmark: AyahBookmark,
+        timestampMillis: Long?
+    ): CollectionAyahBookmark {
         return withContext(Dispatchers.IO) {
             val bookmarkType = bookmark.toCollectionBookmarkType()
             bookmarkCollectionQueries.value.addBookmarkToCollection(
                 bookmark_local_id = bookmark.localId,
                 bookmark_type = bookmarkType,
-                collection_local_id = collectionLocalId.toLong()
+                collection_local_id = collectionLocalId.toLong(),
+                timestamp = timestampMillis
             )
             val record = bookmarkCollectionQueries.value
                 .getCollectionBookmarkFor(bookmark.localId, collectionLocalId.toLong())
@@ -119,6 +142,29 @@ class CollectionBookmarksRepositoryImpl(
         sura: Int,
         ayah: Int
     ): CollectionAyahBookmark {
+        return addAyahBookmarkToCollectionWithTimestampMillis(collectionLocalId, sura, ayah, timestampMillis = null)
+    }
+
+    override suspend fun addAyahBookmarkToCollection(
+        collectionLocalId: String,
+        sura: Int,
+        ayah: Int,
+        timestamp: PlatformDateTime
+    ): CollectionAyahBookmark {
+        return addAyahBookmarkToCollectionWithTimestampMillis(
+            collectionLocalId,
+            sura,
+            ayah,
+            timestamp.toEpochMillisecondsOrNull()
+        )
+    }
+
+    private suspend fun addAyahBookmarkToCollectionWithTimestampMillis(
+        collectionLocalId: String,
+        sura: Int,
+        ayah: Int,
+        timestampMillis: Long?
+    ): CollectionAyahBookmark {
         return withContext(Dispatchers.IO) {
             var created: CollectionAyahBookmark? = null
             database.transaction {
@@ -127,7 +173,8 @@ class CollectionBookmarksRepositoryImpl(
                 ayahBookmarkQueries.value.addNewBookmark(
                     ayah_id = ayahId.toLong(),
                     sura = sura.toLong(),
-                    ayah = ayah.toLong()
+                    ayah = ayah.toLong(),
+                    timestamp = timestampMillis
                 )
                 val bookmarkRecord = ayahBookmarkQueries.value
                     .getBookmarkForAyah(sura.toLong(), ayah.toLong())
@@ -145,7 +192,8 @@ class CollectionBookmarksRepositoryImpl(
                 bookmarkCollectionQueries.value.addBookmarkToCollection(
                     bookmark_local_id = bookmarkRecord.local_id.toString(),
                     bookmark_type = "AYAH",
-                    collection_local_id = collectionLocalIdLong
+                    collection_local_id = collectionLocalIdLong,
+                    timestamp = timestampMillis
                 )
 
                 val collectionRecord = bookmarkCollectionQueries.value

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/note/repository/NotesRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/note/repository/NotesRepository.kt
@@ -1,6 +1,7 @@
 package com.quran.shared.persistence.repository.note.repository
 
 import com.quran.shared.persistence.model.Note
+import com.quran.shared.persistence.util.PlatformDateTime
 
 import kotlinx.coroutines.flow.Flow
 
@@ -15,10 +16,29 @@ interface NotesRepository {
      */
     suspend fun addNote(body: String, startSura: Int, startAyah: Int, endSura: Int, endAyah: Int): Note
 
+    suspend fun addNote(
+        body: String,
+        startSura: Int,
+        startAyah: Int,
+        endSura: Int,
+        endAyah: Int,
+        timestamp: PlatformDateTime
+    ): Note
+
     /**
      * Update a note by its local ID.
      */
     suspend fun updateNote(localId: String, body: String, startSura: Int, startAyah: Int, endSura: Int, endAyah: Int): Note
+
+    suspend fun updateNote(
+        localId: String,
+        body: String,
+        startSura: Int,
+        startAyah: Int,
+        endSura: Int,
+        endAyah: Int,
+        timestamp: PlatformDateTime
+    ): Note
 
     /**
      * Delete a note by its local ID.

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/note/repository/NotesRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/note/repository/NotesRepositoryImpl.kt
@@ -12,9 +12,11 @@ import com.quran.shared.persistence.input.RemoteNote
 import com.quran.shared.persistence.model.Note
 import com.quran.shared.persistence.repository.note.extension.toNote
 import com.quran.shared.persistence.repository.note.extension.toNoteMutation
+import com.quran.shared.persistence.util.PlatformDateTime
 import com.quran.shared.persistence.util.QuranData
 import com.quran.shared.persistence.util.SQLITE_MAX_BIND_PARAMETERS
 import com.quran.shared.persistence.util.fromPlatform
+import com.quran.shared.persistence.util.toEpochMillisecondsOrNull
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.Dispatchers
@@ -50,6 +52,35 @@ class NotesRepositoryImpl(
     }
 
     override suspend fun addNote(body: String, startSura: Int, startAyah: Int, endSura: Int, endAyah: Int): Note {
+        return addNoteWithTimestampMillis(body, startSura, startAyah, endSura, endAyah, timestampMillis = null)
+    }
+
+    override suspend fun addNote(
+        body: String,
+        startSura: Int,
+        startAyah: Int,
+        endSura: Int,
+        endAyah: Int,
+        timestamp: PlatformDateTime
+    ): Note {
+        return addNoteWithTimestampMillis(
+            body,
+            startSura,
+            startAyah,
+            endSura,
+            endAyah,
+            timestamp.toEpochMillisecondsOrNull()
+        )
+    }
+
+    private suspend fun addNoteWithTimestampMillis(
+        body: String,
+        startSura: Int,
+        startAyah: Int,
+        endSura: Int,
+        endAyah: Int,
+        timestampMillis: Long?
+    ): Note {
         logger.i { "Adding note for range=$startSura:$startAyah-$endSura:$endAyah" }
         return withContext(Dispatchers.IO) {
             val startAyahId = requireAyahId(startSura, startAyah)
@@ -59,7 +90,8 @@ class NotesRepositoryImpl(
                 notesQueries.value.addNewNote(
                     note = body,
                     start_ayah_id = startAyahId.toLong(),
-                    end_ayah_id = endAyahId.toLong()
+                    end_ayah_id = endAyahId.toLong(),
+                    timestamp = timestampMillis
                 )
                 val record = notesQueries.value.getLastInsertedNote().executeAsOneOrNull()
                 requireNotNull(record) { "Expected note after insert." }
@@ -77,6 +109,46 @@ class NotesRepositoryImpl(
         endSura: Int,
         endAyah: Int
     ): Note {
+        return updateNoteWithTimestampMillis(
+            localId,
+            body,
+            startSura,
+            startAyah,
+            endSura,
+            endAyah,
+            timestampMillis = null
+        )
+    }
+
+    override suspend fun updateNote(
+        localId: String,
+        body: String,
+        startSura: Int,
+        startAyah: Int,
+        endSura: Int,
+        endAyah: Int,
+        timestamp: PlatformDateTime
+    ): Note {
+        return updateNoteWithTimestampMillis(
+            localId,
+            body,
+            startSura,
+            startAyah,
+            endSura,
+            endAyah,
+            timestamp.toEpochMillisecondsOrNull()
+        )
+    }
+
+    private suspend fun updateNoteWithTimestampMillis(
+        localId: String,
+        body: String,
+        startSura: Int,
+        startAyah: Int,
+        endSura: Int,
+        endAyah: Int,
+        timestampMillis: Long?
+    ): Note {
         logger.i { "Updating note localId=$localId" }
         return withContext(Dispatchers.IO) {
             val startAyahId = requireAyahId(startSura, startAyah)
@@ -85,7 +157,8 @@ class NotesRepositoryImpl(
                 note = body,
                 start_ayah_id = startAyahId.toLong(),
                 end_ayah_id = endAyahId.toLong(),
-                id = localId.toLong()
+                id = localId.toLong(),
+                timestamp = timestampMillis
             )
             val record = notesQueries.value.getNoteByLocalId(localId.toLong())
                 .executeAsOneOrNull()
@@ -97,7 +170,9 @@ class NotesRepositoryImpl(
     override suspend fun deleteNote(localId: String): Boolean {
         logger.i { "Deleting note localId=$localId" }
         withContext(Dispatchers.IO) {
-            notesQueries.value.deleteNote(id = localId.toLong())
+            notesQueries.value.deleteNote(
+                id = localId.toLong()
+            )
         }
         return true
     }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/readingbookmark/repository/ReadingBookmarksRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/readingbookmark/repository/ReadingBookmarksRepository.kt
@@ -3,6 +3,7 @@ package com.quran.shared.persistence.repository.readingbookmark.repository
 import com.quran.shared.persistence.model.AyahReadingBookmark
 import com.quran.shared.persistence.model.PageReadingBookmark
 import com.quran.shared.persistence.model.ReadingBookmark
+import com.quran.shared.persistence.util.PlatformDateTime
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
 import kotlinx.coroutines.flow.Flow
 
@@ -17,7 +18,13 @@ interface ReadingBookmarksRepository {
     suspend fun addAyahReadingBookmark(sura: Int, ayah: Int): AyahReadingBookmark
 
     @NativeCoroutines
+    suspend fun addAyahReadingBookmark(sura: Int, ayah: Int, timestamp: PlatformDateTime): AyahReadingBookmark
+
+    @NativeCoroutines
     suspend fun addPageReadingBookmark(page: Int): PageReadingBookmark
+
+    @NativeCoroutines
+    suspend fun addPageReadingBookmark(page: Int, timestamp: PlatformDateTime): PageReadingBookmark
 
     @NativeCoroutines
     suspend fun deleteReadingBookmark(): Boolean

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/readingbookmark/repository/ReadingBookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/readingbookmark/repository/ReadingBookmarksRepositoryImpl.kt
@@ -16,8 +16,10 @@ import com.quran.shared.persistence.repository.readingbookmark.extension.toAyahR
 import com.quran.shared.persistence.repository.readingbookmark.extension.toPageReadingBookmark
 import com.quran.shared.persistence.repository.readingbookmark.extension.toReadingBookmark
 import com.quran.shared.persistence.repository.readingbookmark.extension.toReadingBookmarkMutation
+import com.quran.shared.persistence.util.PlatformDateTime
 import com.quran.shared.persistence.util.SQLITE_MAX_BIND_PARAMETERS
 import com.quran.shared.persistence.util.fromPlatform
+import com.quran.shared.persistence.util.toEpochMillisecondsOrNull
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.Dispatchers
@@ -52,11 +54,28 @@ class ReadingBookmarksRepositoryImpl(
     }
 
     override suspend fun addAyahReadingBookmark(sura: Int, ayah: Int): AyahReadingBookmark {
+        return addAyahReadingBookmarkWithTimestampMillis(sura, ayah, timestampMillis = null)
+    }
+
+    override suspend fun addAyahReadingBookmark(
+        sura: Int,
+        ayah: Int,
+        timestamp: PlatformDateTime
+    ): AyahReadingBookmark {
+        return addAyahReadingBookmarkWithTimestampMillis(sura, ayah, timestamp.toEpochMillisecondsOrNull())
+    }
+
+    private suspend fun addAyahReadingBookmarkWithTimestampMillis(
+        sura: Int,
+        ayah: Int,
+        timestampMillis: Long?
+    ): AyahReadingBookmark {
         logger.i { "Adding ayah reading bookmark for $sura:$ayah" }
         return withContext(Dispatchers.IO) {
             readingBookmarkQueries.value.addAyahReadingBookmark(
                 sura = sura.toLong(),
-                ayah = ayah.toLong()
+                ayah = ayah.toLong(),
+                timestamp = timestampMillis
             )
             val record = readingBookmarkQueries.value.getReadingBookmarkForAyah(sura.toLong(), ayah.toLong())
                 .executeAsOneOrNull()
@@ -66,9 +85,23 @@ class ReadingBookmarksRepositoryImpl(
     }
 
     override suspend fun addPageReadingBookmark(page: Int): PageReadingBookmark {
+        return addPageReadingBookmarkWithTimestampMillis(page, timestampMillis = null)
+    }
+
+    override suspend fun addPageReadingBookmark(page: Int, timestamp: PlatformDateTime): PageReadingBookmark {
+        return addPageReadingBookmarkWithTimestampMillis(page, timestamp.toEpochMillisecondsOrNull())
+    }
+
+    private suspend fun addPageReadingBookmarkWithTimestampMillis(
+        page: Int,
+        timestampMillis: Long?
+    ): PageReadingBookmark {
         logger.i { "Adding page reading bookmark for page=$page" }
         return withContext(Dispatchers.IO) {
-            readingBookmarkQueries.value.addPageReadingBookmark(page = page.toLong())
+            readingBookmarkQueries.value.addPageReadingBookmark(
+                page = page.toLong(),
+                timestamp = timestampMillis
+            )
             val record = readingBookmarkQueries.value.getReadingBookmarkForPage(page.toLong())
                 .executeAsOneOrNull()
             requireNotNull(record) { "Expected reading bookmark for page=$page after insert." }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/readingsession/repository/ReadingSessionsRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/readingsession/repository/ReadingSessionsRepository.kt
@@ -1,6 +1,7 @@
 package com.quran.shared.persistence.repository.readingsession.repository
 
 import com.quran.shared.persistence.model.ReadingSession
+import com.quran.shared.persistence.util.PlatformDateTime
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
 import kotlinx.coroutines.flow.Flow
 
@@ -24,6 +25,9 @@ interface ReadingSessionsRepository {
     @NativeCoroutines
     suspend fun addReadingSession(sura: Int, ayah: Int): ReadingSession
 
+    @NativeCoroutines
+    suspend fun addReadingSession(sura: Int, ayah: Int, timestamp: PlatformDateTime): ReadingSession
+
     /**
      * Update an existing reading session by local ID.
      *
@@ -34,6 +38,14 @@ interface ReadingSessionsRepository {
      */
     @NativeCoroutines
     suspend fun updateReadingSession(localId: String, sura: Int, ayah: Int): ReadingSession
+
+    @NativeCoroutines
+    suspend fun updateReadingSession(
+        localId: String,
+        sura: Int,
+        ayah: Int,
+        timestamp: PlatformDateTime
+    ): ReadingSession
 
     /**
      * Returns a flow of all reading sessions for observation.

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/readingsession/repository/ReadingSessionsRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/readingsession/repository/ReadingSessionsRepositoryImpl.kt
@@ -12,8 +12,10 @@ import com.quran.shared.persistence.input.RemoteReadingSession
 import com.quran.shared.persistence.model.ReadingSession
 import com.quran.shared.persistence.repository.readingsession.extension.toReadingSession
 import com.quran.shared.persistence.repository.readingsession.extension.toReadingSessionMutation
+import com.quran.shared.persistence.util.PlatformDateTime
 import com.quran.shared.persistence.util.SQLITE_MAX_BIND_PARAMETERS
 import com.quran.shared.persistence.util.fromPlatform
+import com.quran.shared.persistence.util.toEpochMillisecondsOrNull
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.Dispatchers
@@ -61,9 +63,21 @@ class ReadingSessionsRepositoryImpl(
     }
 
     override suspend fun addReadingSession(sura: Int, ayah: Int): ReadingSession {
+        return addReadingSessionWithTimestampMillis(sura, ayah, timestampMillis = null)
+    }
+
+    override suspend fun addReadingSession(sura: Int, ayah: Int, timestamp: PlatformDateTime): ReadingSession {
+        return addReadingSessionWithTimestampMillis(sura, ayah, timestamp.toEpochMillisecondsOrNull())
+    }
+
+    private suspend fun addReadingSessionWithTimestampMillis(
+        sura: Int,
+        ayah: Int,
+        timestampMillis: Long?
+    ): ReadingSession {
         logger.i { "Adding reading session ($sura:$ayah)" }
         return withContext(Dispatchers.IO) {
-            val updatedAt = currentTimeMillis()
+            val updatedAt = timestampMillis ?: currentTimeMillis()
             var readingSession: ReadingSession? = null
 
             database.transaction {
@@ -72,7 +86,7 @@ class ReadingSessionsRepositoryImpl(
                     verse_number = ayah.toLong(),
                     modified_at = updatedAt
                 )
-                pruneOldReadingSessions(updatedAt)
+                pruneOldReadingSessions()
 
                 val record = readingSessionsQueries.value.getReadingSessionForChapterVerse(
                     sura.toLong(),
@@ -88,10 +102,28 @@ class ReadingSessionsRepositoryImpl(
     }
 
     override suspend fun updateReadingSession(localId: String, sura: Int, ayah: Int): ReadingSession {
+        return updateReadingSessionWithTimestampMillis(localId, sura, ayah, timestampMillis = null)
+    }
+
+    override suspend fun updateReadingSession(
+        localId: String,
+        sura: Int,
+        ayah: Int,
+        timestamp: PlatformDateTime
+    ): ReadingSession {
+        return updateReadingSessionWithTimestampMillis(localId, sura, ayah, timestamp.toEpochMillisecondsOrNull())
+    }
+
+    private suspend fun updateReadingSessionWithTimestampMillis(
+        localId: String,
+        sura: Int,
+        ayah: Int,
+        timestampMillis: Long?
+    ): ReadingSession {
         logger.i { "Updating reading session localId=$localId to $sura:$ayah" }
         return withContext(Dispatchers.IO) {
             val id = localId.toLong()
-            val updatedAt = currentTimeMillis()
+            val updatedAt = timestampMillis ?: currentTimeMillis()
             var updatedSession: ReadingSession? = null
 
             database.transaction {
@@ -113,7 +145,7 @@ class ReadingSessionsRepositoryImpl(
                     verse_number = ayah.toLong(),
                     modified_at = updatedAt
                 )
-                pruneOldReadingSessions(updatedAt)
+                pruneOldReadingSessions()
 
                 val record = readingSessionsQueries.value.getReadingSessionByLocalId(id)
                     .executeAsOneOrNull()
@@ -130,8 +162,7 @@ class ReadingSessionsRepositoryImpl(
         withContext(Dispatchers.IO) {
             readingSessionsQueries.value.deleteReadingSession(
                 chapter_number = sura.toLong(),
-                verse_number = ayah.toLong(),
-                modified_at = currentTimeMillis()
+                verse_number = ayah.toLong()
             )
         }
         return true
@@ -187,7 +218,7 @@ class ReadingSessionsRepositoryImpl(
                     )
                 }
 
-                pruneOldReadingSessions(currentTimeMillis())
+                pruneOldReadingSessions()
             }
         }
     }
@@ -215,13 +246,12 @@ class ReadingSessionsRepositoryImpl(
         }
     }
 
-    private fun pruneOldReadingSessions(modifiedAt: Long) {
+    private fun pruneOldReadingSessions() {
         readingSessionsQueries.value.getReadingSessionsToPrune(MAX_ACTIVE_READING_SESSIONS)
             .executeAsList()
             .forEach { session ->
                 readingSessionsQueries.value.pruneReadingSessionByLocalId(
-                    local_id = session.local_id,
-                    modified_at = modifiedAt
+                    local_id = session.local_id
                 )
             }
     }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/util/Timestamps.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/util/Timestamps.kt
@@ -1,0 +1,5 @@
+package com.quran.shared.persistence.util
+
+internal fun PlatformDateTime?.toEpochMillisecondsOrNull(): Long? {
+    return this?.fromPlatform()?.toEpochMilliseconds()
+}

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/ayah_bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/ayah_bookmarks.sq
@@ -31,12 +31,30 @@ getBookmarkByRemoteId:
   SELECT * FROM ayah_bookmark WHERE remote_id = ? LIMIT 1;
 
 addNewBookmark {
-  INSERT OR IGNORE INTO ayah_bookmark (remote_id, ayah_id, sura, ayah, is_edited, deleted)
-  VALUES (NULL, :ayah_id, :sura, :ayah, 0, 0);
+  INSERT OR IGNORE INTO ayah_bookmark (
+    remote_id,
+    ayah_id,
+    sura,
+    ayah,
+    is_edited,
+    created_at,
+    modified_at,
+    deleted
+  )
+  VALUES (
+    NULL,
+    :ayah_id,
+    :sura,
+    :ayah,
+    0,
+    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    0
+  );
   UPDATE ayah_bookmark
     SET is_edited = CASE WHEN remote_id IS NULL THEN is_edited ELSE 1 END,
       deleted = 0,
-      modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+      modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
     WHERE sura = :sura AND ayah = :ayah;
 }
 
@@ -110,8 +128,7 @@ deleteBookmark {
   DELETE FROM ayah_bookmark WHERE sura=:sura AND ayah=:ayah AND remote_id IS NULL;
   UPDATE ayah_bookmark
   SET deleted = 1,
-    is_edited = 1,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+    is_edited = 1
   WHERE sura=:sura AND ayah=:ayah AND remote_id IS NOT NULL;
 }
 

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmark_collections.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmark_collections.sq
@@ -106,12 +106,22 @@ addBookmarkToCollection {
     bookmark_local_id,
     bookmark_type,
     collection_local_id,
+    created_at,
+    modified_at,
     deleted
   )
-  VALUES (NULL, :bookmark_local_id, :bookmark_type, :collection_local_id, 0);
+  VALUES (
+    NULL,
+    :bookmark_local_id,
+    :bookmark_type,
+    :collection_local_id,
+    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    0
+  );
   UPDATE bookmark_collection
   SET deleted = 0,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
   WHERE bookmark_local_id = :bookmark_local_id AND collection_local_id = :collection_local_id;
 }
 
@@ -141,8 +151,7 @@ deleteBookmarkFromCollection {
     AND collection_local_id = :collection_local_id
     AND remote_id IS NULL;
   UPDATE bookmark_collection
-  SET deleted = 1,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+  SET deleted = 1
   WHERE bookmark_local_id = :bookmark_local_id
     AND collection_local_id = :collection_local_id
     AND remote_id IS NOT NULL;

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/collections.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/collections.sq
@@ -28,12 +28,19 @@ getCollectionByRemoteId:
   SELECT * FROM collection WHERE remote_id = ? LIMIT 1;
 
 addNewCollection {
-  INSERT OR IGNORE INTO collection (remote_id, name, deleted, is_edited)
-  VALUES (NULL, :name, 0, 0);
+  INSERT OR IGNORE INTO collection (remote_id, name, created_at, modified_at, deleted, is_edited)
+  VALUES (
+    NULL,
+    :name,
+    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    0,
+    0
+  );
   UPDATE collection
   SET deleted = 0,
     is_edited = 0,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
   WHERE name = :name;
 }
 
@@ -59,7 +66,7 @@ updateCollectionName:
   UPDATE collection
   SET name = :name,
     is_edited = CASE WHEN remote_id IS NULL THEN is_edited ELSE 1 END,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
   WHERE local_id = :id;
 
 deleteCollection {
@@ -67,8 +74,7 @@ deleteCollection {
   DELETE FROM collection WHERE local_id = :id AND remote_id IS NULL;
   UPDATE collection
   SET deleted = 1,
-    is_edited = 1,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+    is_edited = 1
   WHERE local_id = :id AND remote_id IS NOT NULL;
 }
 

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/notes.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/notes.sq
@@ -30,8 +30,24 @@ getLastInsertedNote:
   SELECT * FROM note WHERE local_id = last_insert_rowid() LIMIT 1;
 
 addNewNote:
-  INSERT INTO note (remote_id, note, start_ayah_id, end_ayah_id, deleted)
-  VALUES (NULL, :note, :start_ayah_id, :end_ayah_id, 0);
+  INSERT INTO note (
+    remote_id,
+    note,
+    start_ayah_id,
+    end_ayah_id,
+    created_at,
+    modified_at,
+    deleted
+  )
+  VALUES (
+    NULL,
+    :note,
+    :start_ayah_id,
+    :end_ayah_id,
+    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    0
+  );
 
 insertImportedNote:
   INSERT INTO note (
@@ -62,14 +78,13 @@ updateNote:
     end_ayah_id = :end_ayah_id,
     deleted = 0,
     is_edited = CASE WHEN remote_id IS NULL THEN 0 ELSE 1 END,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
   WHERE local_id = :id;
 
 deleteNote {
   DELETE FROM note WHERE local_id = :id AND remote_id IS NULL;
   UPDATE note
-  SET deleted = 1,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+  SET deleted = 1
   WHERE local_id = :id AND remote_id IS NOT NULL;
 }
 

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/reading_bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/reading_bookmarks.sq
@@ -46,15 +46,34 @@ addAyahReadingBookmark {
   WHERE deleted = 0 AND remote_id IS NULL;
   UPDATE reading_bookmark
   SET deleted = 1,
-    is_edited = 1,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+    is_edited = 1
   WHERE deleted = 0 AND remote_id IS NOT NULL;
-  INSERT OR IGNORE INTO reading_bookmark (remote_id, bookmark_type, sura, ayah, page, is_edited, deleted)
-  VALUES (NULL, 'AYAH', :sura, :ayah, NULL, 0, 0);
+  INSERT OR IGNORE INTO reading_bookmark (
+    remote_id,
+    bookmark_type,
+    sura,
+    ayah,
+    page,
+    is_edited,
+    created_at,
+    modified_at,
+    deleted
+  )
+  VALUES (
+    NULL,
+    'AYAH',
+    :sura,
+    :ayah,
+    NULL,
+    0,
+    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    0
+  );
   UPDATE reading_bookmark
     SET deleted = 0,
       is_edited = CASE WHEN remote_id IS NULL THEN is_edited ELSE 1 END,
-      modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+      modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
     WHERE bookmark_type = 'AYAH' AND sura = :sura AND ayah = :ayah;
 }
 
@@ -63,15 +82,34 @@ addPageReadingBookmark {
   WHERE deleted = 0 AND remote_id IS NULL;
   UPDATE reading_bookmark
   SET deleted = 1,
-    is_edited = 1,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+    is_edited = 1
   WHERE deleted = 0 AND remote_id IS NOT NULL;
-  INSERT OR IGNORE INTO reading_bookmark (remote_id, bookmark_type, sura, ayah, page, is_edited, deleted)
-  VALUES (NULL, 'PAGE', NULL, NULL, :page, 0, 0);
+  INSERT OR IGNORE INTO reading_bookmark (
+    remote_id,
+    bookmark_type,
+    sura,
+    ayah,
+    page,
+    is_edited,
+    created_at,
+    modified_at,
+    deleted
+  )
+  VALUES (
+    NULL,
+    'PAGE',
+    NULL,
+    NULL,
+    :page,
+    0,
+    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    0
+  );
   UPDATE reading_bookmark
     SET deleted = 0,
       is_edited = CASE WHEN remote_id IS NULL THEN is_edited ELSE 1 END,
-      modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+      modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
     WHERE bookmark_type = 'PAGE' AND page = :page;
 }
 
@@ -127,8 +165,7 @@ deleteReadingBookmark {
   DELETE FROM reading_bookmark WHERE local_id = :id AND remote_id IS NULL;
   UPDATE reading_bookmark
   SET deleted = 1,
-    is_edited = 1,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+    is_edited = 1
   WHERE local_id = :id AND remote_id IS NOT NULL;
 }
 

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/reading_sessions.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/reading_sessions.sq
@@ -85,8 +85,7 @@ deleteReadingSession {
   DELETE FROM reading_session WHERE chapter_number = :chapter_number AND verse_number = :verse_number AND remote_id IS NULL;
   UPDATE reading_session
   SET deleted = 1,
-    is_edited = 1,
-    modified_at = :modified_at
+    is_edited = 1
   WHERE chapter_number = :chapter_number AND verse_number = :verse_number AND remote_id IS NOT NULL;
 }
 
@@ -94,8 +93,7 @@ pruneReadingSessionByLocalId {
   DELETE FROM reading_session WHERE local_id = :local_id AND remote_id IS NULL;
   UPDATE reading_session
   SET deleted = 1,
-    is_edited = 1,
-    modified_at = :modified_at
+    is_edited = 1
   WHERE local_id = :local_id AND remote_id IS NOT NULL;
 }
 

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarksRepositoryTest.kt
@@ -11,6 +11,7 @@ import com.quran.shared.persistence.input.RemoteBookmark
 import com.quran.shared.persistence.repository.bookmark.repository.BookmarksRepositoryImpl
 import com.quran.shared.persistence.repository.bookmark.repository.BookmarksSynchronizationRepository
 import com.quran.shared.persistence.util.QuranData
+import com.quran.shared.persistence.util.fromPlatform
 import com.quran.shared.persistence.util.toPlatform
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
@@ -48,6 +49,18 @@ class BookmarksRepositoryTest {
     }
 
     @Test
+    fun `addBookmark respects explicit timestamp`() = runTest {
+        val timestamp = Instant.fromEpochMilliseconds(1234L).toPlatform()
+
+        val bookmark = repository.addBookmark(2, 255, timestamp)
+        val record = database.ayah_bookmarksQueries.getBookmarkForAyah(2L, 255L).executeAsOne()
+
+        assertEquals(1234L, bookmark.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1234L, record.created_at)
+        assertEquals(1234L, record.modified_at)
+    }
+
+    @Test
     fun `addBookmark does not duplicate the same ayah bookmark`() = runTest {
         repository.addBookmark(2, 255)
         repository.addBookmark(2, 255)
@@ -64,6 +77,26 @@ class BookmarksRepositoryTest {
 
         assertTrue(repository.deleteBookmark(2, 255))
         assertTrue(repository.getAllBookmarks().isEmpty())
+    }
+
+    @Test
+    fun `deleteBookmark preserves timestamp for remote rows`() = runTest {
+        database.ayah_bookmarksQueries.persistRemoteBookmark(
+            remote_id = "remote-bookmark-id",
+            ayah_id = QuranData.getAyahId(2, 255).toLong(),
+            sura = 2L,
+            ayah = 255L,
+            created_at = 1L,
+            modified_at = 1L
+        )
+
+        repository.deleteBookmark(2, 255)
+
+        val mutation = syncRepository.fetchMutatedBookmarks().single()
+        val record = database.ayah_bookmarksQueries.getBookmarkByRemoteId("remote-bookmark-id").executeAsOne()
+        assertEquals(Mutation.DELETED, mutation.mutation)
+        assertEquals(1L, mutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1L, record.modified_at)
     }
 
     @Test

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionBookmarksRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionBookmarksRepositoryTest.kt
@@ -9,6 +9,7 @@ import com.quran.shared.persistence.TestDatabaseDriver
 import com.quran.shared.persistence.input.RemoteCollectionBookmark
 import com.quran.shared.persistence.repository.bookmark.repository.BookmarksRepositoryImpl
 import com.quran.shared.persistence.repository.collectionbookmark.repository.CollectionBookmarksRepositoryImpl
+import com.quran.shared.persistence.util.fromPlatform
 import com.quran.shared.persistence.util.toPlatform
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -35,7 +36,7 @@ class CollectionBookmarksRepositoryTest {
 
     @Test
     fun `addBookmarkToCollection stores an ayah bookmark`() = runTest {
-        database.collectionsQueries.addNewCollection(name = "Recents")
+        database.collectionsQueries.addNewCollection(name = "Recents", timestamp = null)
         val collection = database.collectionsQueries.getCollectionByName("Recents").executeAsOne()
         val collectionRemoteId = "remote-collection-id"
         database.collectionsQueries.updateRemoteCollectionByLocalId(
@@ -61,7 +62,7 @@ class CollectionBookmarksRepositoryTest {
 
     @Test
     fun `addAyahBookmarkToCollection atomically stores bookmark and link`() = runTest {
-        database.collectionsQueries.addNewCollection(name = "AtomicRecents")
+        database.collectionsQueries.addNewCollection(name = "AtomicRecents", timestamp = null)
         val collection = database.collectionsQueries.getCollectionByName("AtomicRecents").executeAsOne()
         val collectionRemoteId = "remote-atomic-collection-id"
         database.collectionsQueries.updateRemoteCollectionByLocalId(
@@ -91,6 +92,29 @@ class CollectionBookmarksRepositoryTest {
     }
 
     @Test
+    fun `addAyahBookmarkToCollection respects explicit timestamp for bookmark and link`() = runTest {
+        database.collectionsQueries.addNewCollection(name = "TimestampedLink", timestamp = null)
+        val collection = database.collectionsQueries.getCollectionByName("TimestampedLink").executeAsOne()
+
+        val collectionBookmark = repository.addAyahBookmarkToCollection(
+            collectionLocalId = collection.local_id.toString(),
+            sura = 2,
+            ayah = 255,
+            timestamp = Instant.fromEpochMilliseconds(1234L).toPlatform()
+        )
+        val bookmark = database.ayah_bookmarksQueries.getBookmarkForAyah(2L, 255L).executeAsOne()
+        val link = database.bookmark_collectionsQueries
+            .getCollectionBookmarkFor(bookmark.local_id.toString(), collection.local_id)
+            .executeAsOne()
+
+        assertEquals(1234L, collectionBookmark.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1234L, bookmark.created_at)
+        assertEquals(1234L, bookmark.modified_at)
+        assertEquals(1234L, link.created_at)
+        assertEquals(1234L, link.modified_at)
+    }
+
+    @Test
     fun `addAyahBookmarkToCollection rolls back bookmark when collection is missing`() = runTest {
         assertFailsWith<IllegalArgumentException> {
             repository.addAyahBookmarkToCollection(
@@ -108,7 +132,7 @@ class CollectionBookmarksRepositoryTest {
 
     @Test
     fun `getBookmarksForCollection returns all bookmarks for a collection`() = runTest {
-        database.collectionsQueries.addNewCollection(name = "TestList")
+        database.collectionsQueries.addNewCollection(name = "TestList", timestamp = null)
         val collection = database.collectionsQueries.getCollectionByName("TestList").executeAsOne()
         val bookmark1 = bookmarksRepository.addBookmark(2, 1)
         val bookmark2 = bookmarksRepository.addBookmark(2, 2)
@@ -123,7 +147,7 @@ class CollectionBookmarksRepositoryTest {
 
     @Test
     fun `removeBookmarkFromCollection removes the link`() = runTest {
-        database.collectionsQueries.addNewCollection(name = "TestRemove")
+        database.collectionsQueries.addNewCollection(name = "TestRemove", timestamp = null)
         val collection = database.collectionsQueries.getCollectionByName("TestRemove").executeAsOne()
         val bookmark = bookmarksRepository.addBookmark(2, 1)
         repository.addBookmarkToCollection(collection.local_id.toString(), bookmark)
@@ -134,8 +158,41 @@ class CollectionBookmarksRepositoryTest {
     }
 
     @Test
+    fun `removeBookmarkFromCollection preserves timestamp for remote rows`() = runTest {
+        database.collectionsQueries.addNewCollection(name = "TimestampedRemove", timestamp = null)
+        val collection = database.collectionsQueries.getCollectionByName("TimestampedRemove").executeAsOne()
+        database.collectionsQueries.updateRemoteCollectionByLocalId(
+            remote_id = "remote-collection-id",
+            name = collection.name,
+            modified_at = 1L,
+            local_id = collection.local_id
+        )
+        val bookmark = bookmarksRepository.addBookmark(2, 1)
+        repository.addBookmarkToCollection(collection.local_id.toString(), bookmark)
+        database.bookmark_collectionsQueries.persistRemoteBookmarkCollection(
+            remote_id = "remote-collection-bookmark-id",
+            bookmark_local_id = bookmark.localId,
+            bookmark_type = "AYAH",
+            collection_local_id = collection.local_id,
+            created_at = 1000L,
+            modified_at = 1000L
+        )
+
+        val removed = repository.removeBookmarkFromCollection(collection.local_id.toString(), bookmark)
+        val mutation = repository.fetchMutatedCollectionBookmarks().single()
+        val record = database.bookmark_collectionsQueries
+            .getCollectionBookmarkFor(bookmark.localId, collection.local_id)
+            .executeAsOne()
+
+        assertTrue(removed)
+        assertEquals(Mutation.DELETED, mutation.mutation)
+        assertEquals(1000L, mutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1000L, record.modified_at)
+    }
+
+    @Test
     fun `removeAyahBookmarkFromCollection removes the link using model`() = runTest {
-        database.collectionsQueries.addNewCollection(name = "TestRemoveModel")
+        database.collectionsQueries.addNewCollection(name = "TestRemoveModel", timestamp = null)
         val collection = database.collectionsQueries.getCollectionByName("TestRemoveModel").executeAsOne()
         val cb = repository.addAyahBookmarkToCollection(collection.local_id.toString(), 2, 1)
 
@@ -146,7 +203,7 @@ class CollectionBookmarksRepositoryTest {
 
     @Test
     fun `getBookmarksForCollectionFlow emits bookmarks list`() = runTest {
-        database.collectionsQueries.addNewCollection(name = "TestFlow")
+        database.collectionsQueries.addNewCollection(name = "TestFlow", timestamp = null)
         val collection = database.collectionsQueries.getCollectionByName("TestFlow").executeAsOne()
         repository.addAyahBookmarkToCollection(collection.local_id.toString(), 2, 1)
 
@@ -158,7 +215,7 @@ class CollectionBookmarksRepositoryTest {
 
     @Test
     fun `applyRemoteChanges persists remote ayah collection bookmark`() = runTest {
-        database.collectionsQueries.addNewCollection(name = "Recents")
+        database.collectionsQueries.addNewCollection(name = "Recents", timestamp = null)
         val collection = database.collectionsQueries.getCollectionByName("Recents").executeAsOne()
         database.collectionsQueries.updateRemoteCollectionByLocalId(
             remote_id = "remote-collection-id",
@@ -198,7 +255,7 @@ class CollectionBookmarksRepositoryTest {
 
     @Test
     fun `applyRemoteChanges backfills remote bookmark id for existing local ayah bookmark`() = runTest {
-        database.collectionsQueries.addNewCollection(name = "BackfillRemoteBookmarkId")
+        database.collectionsQueries.addNewCollection(name = "BackfillRemoteBookmarkId", timestamp = null)
         val collection = database.collectionsQueries.getCollectionByName("BackfillRemoteBookmarkId").executeAsOne()
         database.collectionsQueries.updateRemoteCollectionByLocalId(
             remote_id = "remote-collection-id-backfill",
@@ -240,7 +297,7 @@ class CollectionBookmarksRepositoryTest {
 
     @Test
     fun `applyRemoteChanges creates missing local ayah bookmark for collection link`() = runTest {
-        database.collectionsQueries.addNewCollection(name = "NeedBookmark")
+        database.collectionsQueries.addNewCollection(name = "NeedBookmark", timestamp = null)
         val collection = database.collectionsQueries.getCollectionByName("NeedBookmark").executeAsOne()
         database.collectionsQueries.updateRemoteCollectionByLocalId(
             remote_id = "remote-collection-id-2",
@@ -275,7 +332,7 @@ class CollectionBookmarksRepositoryTest {
 
     @Test
     fun `fetchMutatedCollectionBookmarks includes created links without remote bookmark ids`() = runTest {
-        database.collectionsQueries.addNewCollection(name = "NeedsBookmarkRemoteId")
+        database.collectionsQueries.addNewCollection(name = "NeedsBookmarkRemoteId", timestamp = null)
         val collection = database.collectionsQueries.getCollectionByName("NeedsBookmarkRemoteId").executeAsOne()
         database.collectionsQueries.updateRemoteCollectionByLocalId(
             remote_id = "remote-collection-id-4",
@@ -298,7 +355,7 @@ class CollectionBookmarksRepositoryTest {
 
     @Test
     fun `fetchMutatedCollectionBookmarks includes deletion when link has remote id but bookmark remote id is null`() = runTest {
-        database.collectionsQueries.addNewCollection(name = "DeleteWithoutBookmarkRemoteId")
+        database.collectionsQueries.addNewCollection(name = "DeleteWithoutBookmarkRemoteId", timestamp = null)
         val collection = database.collectionsQueries.getCollectionByName("DeleteWithoutBookmarkRemoteId").executeAsOne()
         database.collectionsQueries.updateRemoteCollectionByLocalId(
             remote_id = "remote-collection-id-delete",
@@ -331,7 +388,7 @@ class CollectionBookmarksRepositoryTest {
 
     @Test
     fun `applyRemoteChanges ignores remote page collection bookmarks`() = runTest {
-        database.collectionsQueries.addNewCollection(name = "IgnorePages")
+        database.collectionsQueries.addNewCollection(name = "IgnorePages", timestamp = null)
         val collection = database.collectionsQueries.getCollectionByName("IgnorePages").executeAsOne()
         database.collectionsQueries.updateRemoteCollectionByLocalId(
             remote_id = "remote-collection-id-3",

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionsRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionsRepositoryTest.kt
@@ -1,0 +1,69 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.quran.shared.persistence.repository
+
+import com.quran.shared.mutations.Mutation
+import com.quran.shared.persistence.QuranDatabase
+import com.quran.shared.persistence.TestDatabaseDriver
+import com.quran.shared.persistence.repository.collection.repository.CollectionsRepositoryImpl
+import com.quran.shared.persistence.util.fromPlatform
+import com.quran.shared.persistence.util.toPlatform
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Instant
+
+class CollectionsRepositoryTest {
+    private lateinit var database: QuranDatabase
+    private lateinit var repository: CollectionsRepositoryImpl
+
+    @BeforeTest
+    fun setup() {
+        database = QuranDatabase(TestDatabaseDriver().createDriver())
+        repository = CollectionsRepositoryImpl(database)
+    }
+
+    @Test
+    fun `addCollection respects explicit timestamp`() = runTest {
+        val collection = repository.addCollection("Favorites", timestamp(1234L))
+        val record = database.collectionsQueries.getCollectionByLocalId(collection.localId.toLong()).executeAsOne()
+
+        assertEquals(1234L, collection.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1234L, record.created_at)
+        assertEquals(1234L, record.modified_at)
+    }
+
+    @Test
+    fun `updateCollection respects explicit timestamp and preserves created_at`() = runTest {
+        val collection = repository.addCollection("Favorites", timestamp(1000L))
+
+        val updated = repository.updateCollection(collection.localId, "Updated", timestamp(2345L))
+        val record = database.collectionsQueries.getCollectionByLocalId(collection.localId.toLong()).executeAsOne()
+
+        assertEquals(2345L, updated.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1000L, record.created_at)
+        assertEquals(2345L, record.modified_at)
+    }
+
+    @Test
+    fun `deleteCollection preserves timestamp for remote rows`() = runTest {
+        database.collectionsQueries.persistRemoteCollection(
+            remote_id = "remote-collection-id",
+            name = "Favorites",
+            created_at = 1000L,
+            modified_at = 1000L
+        )
+        val collection = database.collectionsQueries.getCollectionByRemoteId("remote-collection-id").executeAsOne()
+
+        repository.deleteCollection(collection.local_id.toString())
+
+        val mutation = repository.fetchMutatedCollections().single()
+        val record = database.collectionsQueries.getCollectionByRemoteId("remote-collection-id").executeAsOne()
+        assertEquals(Mutation.DELETED, mutation.mutation)
+        assertEquals(1000L, mutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1000L, record.modified_at)
+    }
+
+    private fun timestamp(milliseconds: Long) = Instant.fromEpochMilliseconds(milliseconds).toPlatform()
+}

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/NotesRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/NotesRepositoryTest.kt
@@ -1,12 +1,17 @@
 package com.quran.shared.persistence.repository
 
+import com.quran.shared.mutations.Mutation
 import com.quran.shared.persistence.QuranDatabase
 import com.quran.shared.persistence.TestDatabaseDriver
 import com.quran.shared.persistence.repository.note.repository.NotesRepositoryImpl
+import com.quran.shared.persistence.util.QuranData
+import com.quran.shared.persistence.util.fromPlatform
+import com.quran.shared.persistence.util.toPlatform
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Instant
 
 class NotesRepositoryTest {
     private lateinit var database: QuranDatabase
@@ -34,4 +39,64 @@ class NotesRepositoryTest {
         assertEquals(2, note.endSura)
         assertEquals(13, note.endAyah)
     }
+
+    @Test
+    fun `addNote respects explicit timestamp`() = runTest {
+        val note = repository.addNote(
+            body = "test note",
+            startSura = 2,
+            startAyah = 13,
+            endSura = 2,
+            endAyah = 13,
+            timestamp = timestamp(1_700_000_001_234L)
+        )
+        val record = database.notesQueries.getNoteByLocalId(note.localId.toLong()).executeAsOne()
+
+        assertEquals(1_700_000_001_234L, note.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1_700_000_001_234L, record.created_at)
+        assertEquals(1_700_000_001_234L, record.modified_at)
+    }
+
+    @Test
+    fun `updateNote respects explicit timestamp and preserves created_at`() = runTest {
+        val note = repository.addNote("test note", 2, 13, 2, 13, timestamp(1_700_000_001_000L))
+
+        val updated = repository.updateNote(
+            note.localId,
+            "updated note",
+            2,
+            14,
+            2,
+            14,
+            timestamp(1_700_000_002_345L)
+        )
+        val record = database.notesQueries.getNoteByLocalId(note.localId.toLong()).executeAsOne()
+
+        assertEquals(1_700_000_002_345L, updated.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1_700_000_001_000L, record.created_at)
+        assertEquals(1_700_000_002_345L, record.modified_at)
+    }
+
+    @Test
+    fun `deleteNote preserves timestamp for remote rows`() = runTest {
+        database.notesQueries.persistRemoteNote(
+            remote_id = "remote-note-id",
+            note = "test note",
+            start_ayah_id = QuranData.getAyahId(2, 13).toLong(),
+            end_ayah_id = QuranData.getAyahId(2, 14).toLong(),
+            created_at = 1_700_000_001_000L,
+            modified_at = 1_700_000_001_000L
+        )
+        val note = database.notesQueries.getNoteByLocalId(1L).executeAsOne()
+
+        repository.deleteNote(note.local_id.toString())
+
+        val mutation = repository.fetchMutatedNotes(0).single()
+        val record = database.notesQueries.getNoteByLocalId(note.local_id).executeAsOne()
+        assertEquals(Mutation.DELETED, mutation.mutation)
+        assertEquals(1_700_000_001_000L, mutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1_700_000_001_000L, record.modified_at)
+    }
+
+    private fun timestamp(milliseconds: Long) = Instant.fromEpochMilliseconds(milliseconds).toPlatform()
 }

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/ReadingBookmarksRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/ReadingBookmarksRepositoryTest.kt
@@ -13,6 +13,7 @@ import com.quran.shared.persistence.model.PageReadingBookmark
 import com.quran.shared.persistence.model.ReadingBookmark
 import com.quran.shared.persistence.repository.readingbookmark.repository.ReadingBookmarksRepositoryImpl
 import com.quran.shared.persistence.repository.readingbookmark.repository.ReadingBookmarksSynchronizationRepository
+import com.quran.shared.persistence.util.fromPlatform
 import com.quran.shared.persistence.util.toPlatform
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
@@ -50,6 +51,18 @@ class ReadingBookmarksRepositoryTest {
     }
 
     @Test
+    fun `addAyahReadingBookmark respects explicit timestamp`() = runTest {
+        val timestamp = Instant.fromEpochMilliseconds(1234L).toPlatform()
+
+        val bookmark = repository.addAyahReadingBookmark(2, 255, timestamp)
+        val record = database.reading_bookmarksQueries.getReadingBookmarkForAyah(2L, 255L).executeAsOne()
+
+        assertEquals(1234L, bookmark.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1234L, record.created_at)
+        assertEquals(1234L, record.modified_at)
+    }
+
+    @Test
     fun `addAyahReadingBookmark replaces the previous reading bookmark`() = runTest {
         repository.addAyahReadingBookmark(2, 255)
         repository.addAyahReadingBookmark(3, 2)
@@ -71,6 +84,40 @@ class ReadingBookmarksRepositoryTest {
     }
 
     @Test
+    fun `addPageReadingBookmark respects explicit timestamp when replacing remote row`() = runTest {
+        syncRepository.applyRemoteChanges(
+            updatesToPersist = listOf(
+                RemoteModelMutation(
+                    model = RemoteBookmark.Ayah(
+                        sura = 2,
+                        ayah = 255,
+                        isReading = true,
+                        lastUpdated = Instant.fromEpochMilliseconds(1000L).toPlatform()
+                    ),
+                    remoteID = "remote-reading-id",
+                    mutation = Mutation.CREATED
+                )
+            ),
+            localMutationsToClear = emptyList()
+        )
+
+        val bookmark = repository.addPageReadingBookmark(
+            page = 42,
+            timestamp = Instant.fromEpochMilliseconds(2345L).toPlatform()
+        )
+        val remoteRecord = database.reading_bookmarksQueries
+            .getReadingBookmarkByRemoteId("remote-reading-id")
+            .executeAsOne()
+        val pageRecord = database.reading_bookmarksQueries.getReadingBookmarkForPage(42L).executeAsOne()
+
+        assertEquals(2345L, bookmark.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1L, remoteRecord.deleted)
+        assertEquals(1000L, remoteRecord.modified_at)
+        assertEquals(2345L, pageRecord.created_at)
+        assertEquals(2345L, pageRecord.modified_at)
+    }
+
+    @Test
     fun `addAyahReadingBookmark replaces a page reading bookmark`() = runTest {
         repository.addPageReadingBookmark(42)
         repository.addAyahReadingBookmark(3, 2)
@@ -87,6 +134,33 @@ class ReadingBookmarksRepositoryTest {
 
         assertTrue(repository.deleteReadingBookmark())
         assertNull(repository.getReadingBookmark())
+    }
+
+    @Test
+    fun `deleteReadingBookmark preserves timestamp for remote rows`() = runTest {
+        syncRepository.applyRemoteChanges(
+            updatesToPersist = listOf(
+                RemoteModelMutation(
+                    model = RemoteBookmark.Ayah(
+                        sura = 2,
+                        ayah = 255,
+                        isReading = true,
+                        lastUpdated = Instant.fromEpochMilliseconds(1000L).toPlatform()
+                    ),
+                    remoteID = "remote-reading-id",
+                    mutation = Mutation.CREATED
+                )
+            ),
+            localMutationsToClear = emptyList()
+        )
+
+        assertTrue(repository.deleteReadingBookmark())
+
+        val mutation = syncRepository.fetchMutatedReadingBookmarks().single()
+        val record = database.reading_bookmarksQueries.getReadingBookmarkByRemoteId("remote-reading-id").executeAsOne()
+        assertEquals(Mutation.DELETED, mutation.mutation)
+        assertEquals(1000L, mutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1000L, record.modified_at)
     }
 
     @Test

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/ReadingSessionsRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/ReadingSessionsRepositoryTest.kt
@@ -52,6 +52,19 @@ class ReadingSessionsRepositoryTest {
     }
 
     @Test
+    fun `addReadingSession respects explicit timestamp`() = runTest {
+        repository = ReadingSessionsRepositoryImpl(database) { 9999L }
+
+        val readingSession = repository.addReadingSession(2, 255, timestamp(1234L))
+        val record = database.reading_sessionsQueries.getReadingSessionForChapterVerse(2L, 255L)
+            .executeAsOne()
+
+        assertEquals(1234L, readingSession.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1234L, record.created_at)
+        assertEquals(1234L, record.modified_at)
+    }
+
+    @Test
     fun `addReadingSession updates existing session with latest millisecond timestamp`() = runTest {
         var now = 1000L
         repository = ReadingSessionsRepositoryImpl(database) { now }
@@ -64,7 +77,7 @@ class ReadingSessionsRepositoryTest {
     }
 
     @Test
-    fun `deleteReadingSession persists millisecond timestamp for remote rows`() = runTest {
+    fun `deleteReadingSession does not update remote row timestamp`() = runTest {
         repository = ReadingSessionsRepositoryImpl(database) { 1234567890123L }
         database.reading_sessionsQueries.persistRemoteReadingSession(
             remote_id = "remote-reading-session-id",
@@ -77,8 +90,32 @@ class ReadingSessionsRepositoryTest {
         repository.deleteReadingSession(2, 255)
 
         val localMutation = repository.fetchMutatedReadingSessions().single()
+        val record = database.reading_sessionsQueries.getReadingSessionByRemoteId("remote-reading-session-id")
+            .executeAsOne()
         assertEquals(Mutation.DELETED, localMutation.mutation)
-        assertEquals(1234567890123L, localMutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1L, localMutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1L, record.modified_at)
+    }
+
+    @Test
+    fun `deleteReadingSession preserves timestamp for remote rows`() = runTest {
+        repository = ReadingSessionsRepositoryImpl(database) { 9999L }
+        database.reading_sessionsQueries.persistRemoteReadingSession(
+            remote_id = "remote-reading-session-id",
+            chapter_number = 2L,
+            verse_number = 255L,
+            created_at = 1L,
+            modified_at = 1L
+        )
+
+        repository.deleteReadingSession(2, 255)
+
+        val localMutation = repository.fetchMutatedReadingSessions().single()
+        val record = database.reading_sessionsQueries.getReadingSessionByRemoteId("remote-reading-session-id")
+            .executeAsOne()
+        assertEquals(Mutation.DELETED, localMutation.mutation)
+        assertEquals(1L, localMutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1L, record.modified_at)
     }
 
     @Test
@@ -119,6 +156,20 @@ class ReadingSessionsRepositoryTest {
 
         assertEquals(1234567890123L, updated.lastUpdated.fromPlatform().toEpochMilliseconds())
         assertEquals(1234567890123L, record.modified_at)
+    }
+
+    @Test
+    fun `updateReadingSession respects explicit timestamp`() = runTest {
+        repository = ReadingSessionsRepositoryImpl(database) { 9999L }
+        val readingSession = repository.addReadingSession(2, 255, timestamp(1000L))
+
+        val updated = repository.updateReadingSession(readingSession.localId, 3, 10, timestamp(3456L))
+        val record = database.reading_sessionsQueries.getReadingSessionByLocalId(readingSession.localId.toLong())
+            .executeAsOne()
+
+        assertEquals(3456L, updated.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1000L, record.created_at)
+        assertEquals(3456L, record.modified_at)
     }
 
     @Test
@@ -229,7 +280,7 @@ class ReadingSessionsRepositoryTest {
         assertEquals((21 downTo 2).toList(), remaining.map { it.ayah })
         assertEquals(1L, pruned.deleted)
         assertEquals(1L, pruned.is_edited)
-        assertEquals(21000L, pruned.modified_at)
+        assertEquals(1000L, pruned.modified_at)
     }
 
     @Test
@@ -391,6 +442,8 @@ class ReadingSessionsRepositoryTest {
         assertEquals((21 downTo 2).toList(), repository.getReadingSessions().map { it.ayah })
         assertEquals(1L, pruned.deleted)
         assertEquals(1L, pruned.is_edited)
-        assertEquals(22000L, pruned.modified_at)
+        assertEquals(1000L, pruned.modified_at)
     }
+
+    private fun timestamp(milliseconds: Long) = Instant.fromEpochMilliseconds(milliseconds).toPlatform()
 }

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncService.kt
@@ -14,6 +14,7 @@ import com.quran.shared.persistence.model.ReadingBookmark
 import com.quran.shared.persistence.model.ReadingSession
 import com.quran.shared.persistence.input.PersistenceImportData
 import com.quran.shared.persistence.input.PersistenceImportResult
+import com.quran.shared.persistence.util.PlatformDateTime
 import com.quran.shared.persistence.repository.bookmark.repository.BookmarksRepository
 import com.quran.shared.persistence.repository.PersistenceResetRepository
 import com.quran.shared.persistence.repository.collection.repository.CollectionsRepository
@@ -167,7 +168,7 @@ class SyncService(
     }
 
     @NativeCoroutines
-    suspend fun logout(clearLocalData: Boolean = false): Unit {
+    suspend fun logout(clearLocalData: Boolean = false) {
         try {
             authService.logout()
             syncClient.cancelSyncing()
@@ -210,14 +211,43 @@ class SyncService(
     }
 
     @NativeCoroutines
+    suspend fun addBookmark(sura: Int, ayah: Int, timestamp: PlatformDateTime): AyahBookmark {
+        try {
+            val bookmark = bookmarksRepository.addBookmark(sura, ayah, timestamp)
+            triggerSync()
+            return bookmark
+        } catch (e: Exception) {
+            Logger.e(e) { "Failed to add ayah bookmark" }
+            throw e
+        }
+    }
+
+    @NativeCoroutines
     suspend fun addReadingBookmark(sura: Int, ayah: Int): AyahReadingBookmark {
         return addAyahReadingBookmark(sura, ayah)
+    }
+
+    @NativeCoroutines
+    suspend fun addReadingBookmark(sura: Int, ayah: Int, timestamp: PlatformDateTime): AyahReadingBookmark {
+        return addAyahReadingBookmark(sura, ayah, timestamp)
     }
 
     @NativeCoroutines
     suspend fun addAyahReadingBookmark(sura: Int, ayah: Int): AyahReadingBookmark {
         try {
             val bookmark = readingBookmarksRepository.addAyahReadingBookmark(sura, ayah)
+            triggerSync()
+            return bookmark
+        } catch (e: Exception) {
+            Logger.e(e) { "Failed to add reading ayah bookmark" }
+            throw e
+        }
+    }
+
+    @NativeCoroutines
+    suspend fun addAyahReadingBookmark(sura: Int, ayah: Int, timestamp: PlatformDateTime): AyahReadingBookmark {
+        try {
+            val bookmark = readingBookmarksRepository.addAyahReadingBookmark(sura, ayah, timestamp)
             triggerSync()
             return bookmark
         } catch (e: Exception) {
@@ -239,9 +269,33 @@ class SyncService(
     }
 
     @NativeCoroutines
+    suspend fun addPageReadingBookmark(page: Int, timestamp: PlatformDateTime): PageReadingBookmark {
+        try {
+            val bookmark = readingBookmarksRepository.addPageReadingBookmark(page, timestamp)
+            triggerSync()
+            return bookmark
+        } catch (e: Exception) {
+            Logger.e(e) { "Failed to add reading page bookmark" }
+            throw e
+        }
+    }
+
+    @NativeCoroutines
     suspend fun addReadingSession(sura: Int, ayah: Int): ReadingSession {
         try {
             val readingSession = readingSessionsRepository.addReadingSession(sura, ayah)
+            triggerSync()
+            return readingSession
+        } catch (e: Exception) {
+            Logger.e(e) { "Failed to add reading session" }
+            throw e
+        }
+    }
+
+    @NativeCoroutines
+    suspend fun addReadingSession(sura: Int, ayah: Int, timestamp: PlatformDateTime): ReadingSession {
+        try {
+            val readingSession = readingSessionsRepository.addReadingSession(sura, ayah, timestamp)
             triggerSync()
             return readingSession
         } catch (e: Exception) {
@@ -265,7 +319,7 @@ class SyncService(
     }
 
     @NativeCoroutines
-    suspend fun deleteBookmark(bookmark: AyahBookmark): Unit {
+    suspend fun deleteBookmark(bookmark: AyahBookmark) {
         try {
             bookmarksRepository.deleteBookmark(bookmark.sura, bookmark.ayah)
             triggerSync()
@@ -276,7 +330,7 @@ class SyncService(
     }
 
     @NativeCoroutines
-    suspend fun addCollection(name: String): Unit {
+    suspend fun addCollection(name: String) {
         try {
             collectionsRepository.addCollection(name)
             triggerSync()
@@ -287,7 +341,18 @@ class SyncService(
     }
 
     @NativeCoroutines
-    suspend fun deleteCollection(localId: String): Unit {
+    suspend fun addCollection(name: String, timestamp: PlatformDateTime) {
+        try {
+            collectionsRepository.addCollection(name, timestamp)
+            triggerSync()
+        } catch (e: Exception) {
+            Logger.e(e) { "Failed to add collection" }
+            throw e
+        }
+    }
+
+    @NativeCoroutines
+    suspend fun deleteCollection(localId: String) {
         try {
             collectionsRepository.deleteCollection(localId)
             triggerSync()
@@ -298,9 +363,24 @@ class SyncService(
     }
 
     @NativeCoroutines
-    suspend fun addBookmarkToCollection(collectionLocalId: String, bookmark: AyahBookmark): Unit {
+    suspend fun addBookmarkToCollection(collectionLocalId: String, bookmark: AyahBookmark) {
         try {
             collectionBookmarksRepository.addBookmarkToCollection(collectionLocalId, bookmark)
+            triggerSync()
+        } catch (e: Exception) {
+            Logger.e(e) { "Failed to add bookmark to collection" }
+            throw e
+        }
+    }
+
+    @NativeCoroutines
+    suspend fun addBookmarkToCollection(
+        collectionLocalId: String,
+        bookmark: AyahBookmark,
+        timestamp: PlatformDateTime
+    ) {
+        try {
+            collectionBookmarksRepository.addBookmarkToCollection(collectionLocalId, bookmark, timestamp)
             triggerSync()
         } catch (e: Exception) {
             Logger.e(e) { "Failed to add bookmark to collection" }
@@ -326,7 +406,25 @@ class SyncService(
     }
 
     @NativeCoroutines
-    suspend fun removeBookmarkFromCollection(collectionLocalId: String, bookmark: AyahBookmark): Unit {
+    suspend fun addAyahBookmarkToCollection(
+        collectionLocalId: String,
+        sura: Int,
+        ayah: Int,
+        timestamp: PlatformDateTime
+    ): CollectionAyahBookmark {
+        try {
+            val collectionBookmark = collectionBookmarksRepository
+                .addAyahBookmarkToCollection(collectionLocalId, sura, ayah, timestamp)
+            triggerSync()
+            return collectionBookmark
+        } catch (e: Exception) {
+            Logger.e(e) { "Failed to add ayah bookmark to collection" }
+            throw e
+        }
+    }
+
+    @NativeCoroutines
+    suspend fun removeBookmarkFromCollection(collectionLocalId: String, bookmark: AyahBookmark) {
         try {
             collectionBookmarksRepository.removeBookmarkFromCollection(collectionLocalId, bookmark)
             triggerSync()
@@ -337,7 +435,7 @@ class SyncService(
     }
 
     @NativeCoroutines
-    suspend fun removeAyahBookmarkFromCollection(bookmark: CollectionAyahBookmark): Unit {
+    suspend fun removeAyahBookmarkFromCollection(bookmark: CollectionAyahBookmark) {
         try {
             collectionBookmarksRepository.removeAyahBookmarkFromCollection(bookmark)
             triggerSync()
@@ -348,7 +446,7 @@ class SyncService(
     }
 
     @NativeCoroutines
-    suspend fun addNote(body: String, startSura: Int, startAyah: Int, endSura: Int, endAyah: Int): Unit {
+    suspend fun addNote(body: String, startSura: Int, startAyah: Int, endSura: Int, endAyah: Int) {
         try {
             notesRepository.addNote(body, startSura, startAyah, endSura, endAyah)
             triggerSync()
@@ -359,7 +457,25 @@ class SyncService(
     }
 
     @NativeCoroutines
-    suspend fun deleteNote(localId: String): Unit {
+    suspend fun addNote(
+        body: String,
+        startSura: Int,
+        startAyah: Int,
+        endSura: Int,
+        endAyah: Int,
+        timestamp: PlatformDateTime
+    ) {
+        try {
+            notesRepository.addNote(body, startSura, startAyah, endSura, endAyah, timestamp)
+            triggerSync()
+        } catch (e: Exception) {
+            Logger.e(e) { "Failed to add note" }
+            throw e
+        }
+    }
+
+    @NativeCoroutines
+    suspend fun deleteNote(localId: String) {
         try {
             notesRepository.deleteNote(localId)
             triggerSync()

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/BookmarksSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/BookmarksSyncAdapter.kt
@@ -112,7 +112,7 @@ internal class BookmarksSyncAdapter(
             resourceId = localMutation.remoteID,
             mutation = localMutation.mutation,
             data = if (localMutation.mutation == Mutation.DELETED) null else localMutation.model.toResourceData(),
-            timestamp = null
+            timestamp = localMutation.model.lastModified.toEpochMilliseconds()
         )
     }
 

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapter.kt
@@ -123,7 +123,7 @@ internal class CollectionBookmarksSyncAdapter(
             resourceId = localMutation.remoteID,
             mutation = localMutation.mutation,
             data = localMutation.model.toResourceData(),
-            timestamp = null
+            timestamp = localMutation.model.lastModified.toEpochMilliseconds()
         )
     }
 

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionsSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionsSyncAdapter.kt
@@ -111,7 +111,7 @@ internal class CollectionsSyncAdapter(
             resourceId = localMutation.remoteID,
             mutation = localMutation.mutation,
             data = if (localMutation.mutation == Mutation.DELETED) null else localMutation.model.toResourceData(),
-            timestamp = null
+            timestamp = localMutation.model.lastModified.toEpochMilliseconds()
         )
     }
 

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/NotesSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/NotesSyncAdapter.kt
@@ -116,7 +116,7 @@ internal class NotesSyncAdapter(
             resourceId = localMutation.remoteID,
             mutation = localMutation.mutation,
             data = if (localMutation.mutation == Mutation.DELETED) null else localMutation.model.toResourceData(),
-            timestamp = null
+            timestamp = localMutation.model.lastModified.toEpochMilliseconds()
         )
     }
 

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/ReadingSessionsSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/ReadingSessionsSyncAdapter.kt
@@ -75,7 +75,7 @@ internal class ReadingSessionsSyncAdapter(
             resourceId = localMutation.remoteID,
             mutation = localMutation.mutation,
             data = if (localMutation.mutation == Mutation.DELETED) null else localMutation.model.toResourceData(),
-            timestamp = null
+            timestamp = localMutation.model.lastModified.toEpochMilliseconds()
         )
     }
 

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/BookmarksSyncAdapterTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/BookmarksSyncAdapterTest.kt
@@ -67,6 +67,7 @@ class BookmarksSyncAdapterTest {
 
         val data = assertNotNull(mutation.data)
         assertEquals("BOOKMARK", mutation.resource)
+        assertEquals(1000L, mutation.timestamp)
         assertEquals("page", data["type"]?.jsonPrimitive?.content)
         assertEquals(42, data["key"]?.jsonPrimitive?.int)
         assertEquals(true, data["isReading"]?.jsonPrimitive?.boolean)

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapterTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapterTest.kt
@@ -84,6 +84,7 @@ class CollectionBookmarksSyncAdapterTest {
         assertEquals(1, pushedMutations.size)
         assertEquals("COLLECTION_BOOKMARK", pushedMutations.single().resource)
         assertNull(pushedMutations.single().resourceId)
+        assertEquals(1000L, pushedMutations.single().timestamp)
         assertEquals("remote-collection-1", pushedMutations.single().data?.get("collectionId")?.jsonPrimitive?.content)
         assertNull(pushedMutations.single().data?.get("bookmarkId"))
 

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/ReadingSessionsSyncAdapterTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/ReadingSessionsSyncAdapterTest.kt
@@ -66,6 +66,8 @@ class ReadingSessionsSyncAdapterTest {
         )
 
         val plan = adapter.buildPlan(0L, emptyList())
+        assertEquals(1000L, plan.mutationsToPush().single().timestamp)
+
         val pushedMutations = listOf(
             SyncMutation(
                 resource = "READING_SESSION",

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/SyncMutationTimestampTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/SyncMutationTimestampTest.kt
@@ -1,0 +1,143 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.quran.shared.syncengine
+
+import com.quran.shared.mutations.LocalModelMutation
+import com.quran.shared.mutations.Mutation
+import com.quran.shared.mutations.RemoteModelMutation
+import com.quran.shared.syncengine.model.NoteAyah
+import com.quran.shared.syncengine.model.NoteRange
+import com.quran.shared.syncengine.model.SyncCollection
+import com.quran.shared.syncengine.model.SyncNote
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+import kotlin.time.Instant
+
+class SyncMutationTimestampTest {
+
+    @Test
+    fun `collection mutations carry local model timestamp`() = runTest {
+        val localMutation = LocalModelMutation(
+            model = SyncCollection(
+                id = "local-collection",
+                name = "Favorites",
+                lastModified = Instant.fromEpochMilliseconds(12_345)
+            ),
+            remoteID = null,
+            localID = "local-collection",
+            mutation = Mutation.CREATED
+        )
+
+        val adapter = CollectionsSyncAdapter(
+            CollectionsSynchronizationConfigurations(
+                localDataFetcher = collectionFetcher(listOf(localMutation)),
+                resultNotifier = noopCollectionNotifier(),
+                localModificationDateFetcher = zeroModificationDateFetcher()
+            )
+        )
+
+        val mutation = adapter.buildPlan(0L, emptyList()).mutationsToPush().single()
+
+        assertEquals(12_345L, mutation.timestamp)
+    }
+
+    @Test
+    fun `note mutations carry local model timestamp`() = runTest {
+        val localMutation = LocalModelMutation(
+            model = SyncNote(
+                id = "local-note",
+                body = "Note",
+                ranges = listOf(
+                    NoteRange(
+                        start = NoteAyah(sura = 2, ayah = 255),
+                        end = NoteAyah(sura = 2, ayah = 255)
+                    )
+                ),
+                lastModified = Instant.fromEpochMilliseconds(54_321)
+            ),
+            remoteID = null,
+            localID = "local-note",
+            mutation = Mutation.CREATED
+        )
+
+        val adapter = NotesSyncAdapter(
+            NotesSynchronizationConfigurations(
+                localDataFetcher = noteFetcher(listOf(localMutation)),
+                resultNotifier = noopNoteNotifier(),
+                localModificationDateFetcher = zeroModificationDateFetcher()
+            )
+        )
+
+        val mutation = adapter.buildPlan(0L, emptyList()).mutationsToPush().single()
+
+        assertEquals(54_321L, mutation.timestamp)
+    }
+
+    private fun collectionFetcher(
+        localMutations: List<LocalModelMutation<SyncCollection>>
+    ): LocalDataFetcher<SyncCollection> {
+        return object : LocalDataFetcher<SyncCollection> {
+            override suspend fun fetchLocalMutations(lastModified: Long): List<LocalModelMutation<SyncCollection>> {
+                return localMutations
+            }
+
+            override suspend fun checkLocalExistence(remoteIDs: List<String>): Map<String, Boolean> {
+                return remoteIDs.associateWith { true }
+            }
+
+            override suspend fun fetchLocalModel(remoteId: String): SyncCollection? = null
+        }
+    }
+
+    private fun noteFetcher(
+        localMutations: List<LocalModelMutation<SyncNote>>
+    ): LocalDataFetcher<SyncNote> {
+        return object : LocalDataFetcher<SyncNote> {
+            override suspend fun fetchLocalMutations(lastModified: Long): List<LocalModelMutation<SyncNote>> {
+                return localMutations
+            }
+
+            override suspend fun checkLocalExistence(remoteIDs: List<String>): Map<String, Boolean> {
+                return remoteIDs.associateWith { true }
+            }
+
+            override suspend fun fetchLocalModel(remoteId: String): SyncNote? = null
+        }
+    }
+
+    private fun noopCollectionNotifier(): ResultNotifier<SyncCollection> {
+        return object : ResultNotifier<SyncCollection> {
+            override suspend fun didSucceed(
+                newToken: Long,
+                newRemoteMutations: List<RemoteModelMutation<SyncCollection>>,
+                processedLocalMutations: List<LocalModelMutation<SyncCollection>>
+            ) = Unit
+
+            override suspend fun didFail(message: String) {
+                fail("didFail called: $message")
+            }
+        }
+    }
+
+    private fun noopNoteNotifier(): ResultNotifier<SyncNote> {
+        return object : ResultNotifier<SyncNote> {
+            override suspend fun didSucceed(
+                newToken: Long,
+                newRemoteMutations: List<RemoteModelMutation<SyncNote>>,
+                processedLocalMutations: List<LocalModelMutation<SyncNote>>
+            ) = Unit
+
+            override suspend fun didFail(message: String) {
+                fail("didFail called: $message")
+            }
+        }
+    }
+
+    private fun zeroModificationDateFetcher(): LocalModificationDateFetcher {
+        return object : LocalModificationDateFetcher {
+            override suspend fun localLastModificationDate(): Long? = 0L
+        }
+    }
+}


### PR DESCRIPTION
This allows the persistence layer to be able to save and store
timestamps. These timestamps are not yet synced to the backend, but will
be when backend supports this in sha' Allah.

In the meanwhile, clients that only use local persistence can have
working timestamps. When the fix for sync is applied, it should not
require code changes from the clients.
