### PR TITLE
Allow import of data to be non-destructive

### DIFF
--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/importdata/PersistenceImportRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/importdata/PersistenceImportRepository.kt
@@ -6,11 +6,20 @@ import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
 
 interface PersistenceImportRepository {
     /**
-     * Imports a complete local data set into an empty persistence database.
+     * Imports a local data set into the persistence database.
      *
-     * The import is all-or-nothing. If any managed persistence table already has rows,
-     * or the payload is invalid, no import rows are persisted.
+     * The import is all-or-nothing. If [deleteExisting] is true, existing rows are
+     * deleted first using sync-aware deletion semantics before the payload is merged.
+     * If [deleteExisting] is false, the payload is merged into the current data.
      */
     @NativeCoroutines
-    suspend fun importData(data: PersistenceImportData): PersistenceImportResult
+    suspend fun importData(data: PersistenceImportData): PersistenceImportResult {
+        return importData(data = data, deleteExisting = false)
+    }
+
+    @NativeCoroutines
+    suspend fun importData(
+        data: PersistenceImportData,
+        deleteExisting: Boolean
+    ): PersistenceImportResult
 }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/importdata/PersistenceImportRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/importdata/PersistenceImportRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.quran.shared.persistence.input.ImportReadingBookmark
 import com.quran.shared.persistence.input.ImportReadingSession
 import com.quran.shared.persistence.input.PersistenceImportData
 import com.quran.shared.persistence.input.PersistenceImportResult
+import com.quran.shared.persistence.model.DatabaseNote
 import com.quran.shared.persistence.util.PlatformDateTime
 import com.quran.shared.persistence.util.QuranData
 import com.quran.shared.persistence.util.fromPlatform
@@ -25,50 +26,59 @@ class PersistenceImportRepositoryImpl(
     private val database: QuranDatabase
 ) : PersistenceImportRepository {
 
-    override suspend fun importData(data: PersistenceImportData): PersistenceImportResult {
+    override suspend fun importData(
+        data: PersistenceImportData,
+        deleteExisting: Boolean
+    ): PersistenceImportResult {
         return withContext(Dispatchers.IO) {
             validate(data)
             var result: PersistenceImportResult? = null
             database.transaction {
-                requireDatabaseEmpty()
-
-                val bookmarkLocalIds = importBookmarks(data.bookmarks)
-                val collectionLocalIds = importCollections(data.collections)
-                importReadingSessions(data.readingSessions)
-                importReadingBookmark(data.readingBookmark)
-                importNotes(data.notes)
-                importCollectionBookmarks(
-                    links = data.collectionBookmarks,
-                    bookmarkLocalIds = bookmarkLocalIds,
-                    collectionLocalIds = collectionLocalIds
-                )
-
-                result = PersistenceImportResult(
-                    bookmarksImported = data.bookmarks.size,
-                    collectionsImported = data.collections.size,
-                    collectionBookmarksImported = data.collectionBookmarks.size,
-                    readingSessionsImported = data.readingSessions.size,
-                    readingBookmarkImported = data.readingBookmark != null,
-                    notesImported = data.notes.size
-                )
+                if (deleteExisting) {
+                    deleteExistingData()
+                }
+                result = mergeData(data)
             }
             requireNotNull(result)
         }
     }
 
-    private fun requireDatabaseEmpty() {
-        val nonEmptyTables = buildList {
-            if (database.ayah_bookmarksQueries.countAll().executeAsOne() > 0) add("ayah_bookmark")
-            if (database.reading_bookmarksQueries.countAll().executeAsOne() > 0) add("reading_bookmark")
-            if (database.collectionsQueries.countAll().executeAsOne() > 0) add("collection")
-            if (database.bookmark_collectionsQueries.countAll().executeAsOne() > 0) add("bookmark_collection")
-            if (database.notesQueries.countAll().executeAsOne() > 0) add("note")
-            if (database.reading_sessionsQueries.countAll().executeAsOne() > 0) add("reading_session")
-        }
-        check(nonEmptyTables.isEmpty()) {
-            "Cannot import into a non-empty persistence database. Non-empty tables: " +
-                nonEmptyTables.joinToString()
-        }
+    private fun mergeData(data: PersistenceImportData): PersistenceImportResult {
+        val bookmarkLocalIds = importBookmarks(data.bookmarks)
+        val collectionLocalIds = importCollections(data.collections)
+        importReadingSessions(data.readingSessions)
+        importReadingBookmark(data.readingBookmark)
+        importNotes(data.notes)
+        importCollectionBookmarks(
+            links = data.collectionBookmarks,
+            bookmarkLocalIds = bookmarkLocalIds,
+            collectionLocalIds = collectionLocalIds
+        )
+
+        return PersistenceImportResult(
+            bookmarksImported = data.bookmarks.size,
+            collectionsImported = data.collections.size,
+            collectionBookmarksImported = data.collectionBookmarks.size,
+            readingSessionsImported = data.readingSessions.size,
+            readingBookmarkImported = data.readingBookmark != null,
+            notesImported = data.notes.size
+        )
+    }
+
+    private fun deleteExistingData() {
+        val timestamp = currentImportTimestampMillis()
+        database.bookmark_collectionsQueries.deleteUnsyncedBookmarkCollections()
+        database.bookmark_collectionsQueries.markRemoteBookmarkCollectionsDeleted(modified_at = timestamp)
+        database.ayah_bookmarksQueries.deleteUnsyncedBookmarks()
+        database.ayah_bookmarksQueries.markRemoteBookmarksDeleted(modified_at = timestamp)
+        database.reading_bookmarksQueries.deleteUnsyncedReadingBookmarks()
+        database.reading_bookmarksQueries.markRemoteReadingBookmarksDeleted(modified_at = timestamp)
+        database.collectionsQueries.deleteUnsyncedCollections()
+        database.collectionsQueries.markRemoteCollectionsDeleted(modified_at = timestamp)
+        database.notesQueries.deleteUnsyncedNotes()
+        database.notesQueries.markRemoteNotesDeleted(modified_at = timestamp)
+        database.reading_sessionsQueries.deleteUnsyncedReadingSessions()
+        database.reading_sessionsQueries.markRemoteReadingSessionsDeleted(modified_at = timestamp)
     }
 
     private fun validate(data: PersistenceImportData) {
@@ -201,12 +211,21 @@ class PersistenceImportRepositoryImpl(
     }
 
     private fun importNotes(notes: List<ImportNote>) {
+        val noteKeys = database.notesQueries.getNotes()
+            .executeAsList()
+            .mapTo(mutableSetOf()) { it.importKey() }
+
         notes.forEach { note ->
             val timestamp = note.lastUpdated.toImportTimestampMillis()
+            val startAyahId = requireAyahId(note.startSura, note.startAyah, "note start").toLong()
+            val endAyahId = requireAyahId(note.endSura, note.endAyah, "note end").toLong()
+            if (!noteKeys.add(note.importKey(startAyahId, endAyahId))) {
+                return@forEach
+            }
             database.notesQueries.insertImportedNote(
                 note = note.body,
-                start_ayah_id = requireAyahId(note.startSura, note.startAyah, "note start").toLong(),
-                end_ayah_id = requireAyahId(note.endSura, note.endAyah, "note end").toLong(),
+                start_ayah_id = startAyahId,
+                end_ayah_id = endAyahId,
                 created_at = timestamp,
                 modified_at = timestamp
             )
@@ -250,6 +269,30 @@ class PersistenceImportRepositoryImpl(
         return fromPlatform().toEpochMilliseconds()
     }
 
+    private fun currentImportTimestampMillis(): Long {
+        return kotlin.time.Clock.System.now().toEpochMilliseconds()
+    }
+
+    private fun ImportNote.importKey(startAyahId: Long, endAyahId: Long): NoteImportKey {
+        return NoteImportKey(
+            normalizedBody = body.toNormalizedNoteText(),
+            startAyahId = startAyahId,
+            endAyahId = endAyahId
+        )
+    }
+
+    private fun DatabaseNote.importKey(): NoteImportKey {
+        return NoteImportKey(
+            normalizedBody = note.toNormalizedNoteText(),
+            startAyahId = start_ayah_id,
+            endAyahId = end_ayah_id
+        )
+    }
+
+    private fun String.toNormalizedNoteText(): String {
+        return trim().replace(NOTE_WHITESPACE_REGEX, " ")
+    }
+
     private fun <T> requireUnique(label: String, values: List<T>) {
         val duplicates = values.groupingBy { it }.eachCount().filterValues { it > 1 }.keys
         require(duplicates.isEmpty()) { "Duplicate $label values: ${duplicates.joinToString()}." }
@@ -264,3 +307,10 @@ class PersistenceImportRepositoryImpl(
 }
 
 private const val MUSHAF_PAGE_COUNT = 604
+private val NOTE_WHITESPACE_REGEX = Regex("\\s+")
+
+private data class NoteImportKey(
+    val normalizedBody: String,
+    val startAyahId: Long,
+    val endAyahId: Long
+)

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/ayah_bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/ayah_bookmarks.sq
@@ -45,8 +45,8 @@ insertBookmarkIfMissing {
   VALUES (NULL, :ayah_id, :sura, :ayah, 0, 0);
 }
 
-insertImportedBookmark:
-  INSERT INTO ayah_bookmark (
+insertImportedBookmark {
+  INSERT OR IGNORE INTO ayah_bookmark (
     remote_id,
     ayah_id,
     sura,
@@ -66,6 +66,21 @@ insertImportedBookmark:
     :modified_at,
     0
   );
+  UPDATE ayah_bookmark
+  SET ayah_id = :ayah_id,
+    deleted = 0,
+    is_edited = CASE
+      WHEN remote_id IS NULL THEN 0
+      WHEN deleted = 1 THEN 0
+      ELSE is_edited
+    END,
+    modified_at = CASE
+      WHEN remote_id IS NULL THEN :modified_at
+      WHEN deleted = 1 THEN :modified_at
+      ELSE modified_at
+    END
+  WHERE sura = :sura AND ayah = :ayah;
+}
 
 getUnsyncedBookmarks:
   SELECT * FROM ayah_bookmark WHERE remote_id IS NULL OR is_edited = 1 OR deleted = 1 ORDER BY created_at DESC;
@@ -117,3 +132,13 @@ deleteBookmark {
 
 deleteAll:
   DELETE FROM ayah_bookmark;
+
+deleteUnsyncedBookmarks:
+  DELETE FROM ayah_bookmark WHERE remote_id IS NULL;
+
+markRemoteBookmarksDeleted:
+  UPDATE ayah_bookmark
+  SET deleted = 1,
+    is_edited = 1,
+    modified_at = :modified_at
+  WHERE remote_id IS NOT NULL;

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmark_collections.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmark_collections.sq
@@ -115,8 +115,8 @@ addBookmarkToCollection {
   WHERE bookmark_local_id = :bookmark_local_id AND collection_local_id = :collection_local_id;
 }
 
-insertImportedBookmarkCollection:
-  INSERT INTO bookmark_collection (
+insertImportedBookmarkCollection {
+  INSERT OR IGNORE INTO bookmark_collection (
     remote_id,
     bookmark_local_id,
     bookmark_type,
@@ -134,6 +134,17 @@ insertImportedBookmarkCollection:
     :modified_at,
     0
   );
+  UPDATE bookmark_collection
+  SET bookmark_type = :bookmark_type,
+    deleted = 0,
+    modified_at = CASE
+      WHEN remote_id IS NULL THEN :modified_at
+      WHEN deleted = 1 THEN :modified_at
+      ELSE modified_at
+    END
+  WHERE bookmark_local_id = :bookmark_local_id
+    AND collection_local_id = :collection_local_id;
+}
 
 deleteBookmarkFromCollection {
   DELETE FROM bookmark_collection
@@ -201,3 +212,12 @@ checkRemoteIDsExistence:
 
 deleteAll:
   DELETE FROM bookmark_collection;
+
+deleteUnsyncedBookmarkCollections:
+  DELETE FROM bookmark_collection WHERE remote_id IS NULL;
+
+markRemoteBookmarkCollectionsDeleted:
+  UPDATE bookmark_collection
+  SET deleted = 1,
+    modified_at = :modified_at
+  WHERE remote_id IS NOT NULL;

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/collections.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/collections.sq
@@ -37,8 +37,8 @@ addNewCollection {
   WHERE name = :name;
 }
 
-insertImportedCollection:
-  INSERT INTO collection (
+insertImportedCollection {
+  INSERT OR IGNORE INTO collection (
     remote_id,
     name,
     created_at,
@@ -54,6 +54,20 @@ insertImportedCollection:
     0,
     0
   );
+  UPDATE collection
+  SET deleted = 0,
+    is_edited = CASE
+      WHEN remote_id IS NULL THEN 0
+      WHEN deleted = 1 THEN 0
+      ELSE is_edited
+    END,
+    modified_at = CASE
+      WHEN remote_id IS NULL THEN :modified_at
+      WHEN deleted = 1 THEN :modified_at
+      ELSE modified_at
+    END
+  WHERE name = :name;
+}
 
 updateCollectionName:
   UPDATE collection
@@ -115,3 +129,13 @@ checkRemoteIDsExistence:
 
 deleteAll:
   DELETE FROM collection;
+
+deleteUnsyncedCollections:
+  DELETE FROM collection WHERE remote_id IS NULL;
+
+markRemoteCollectionsDeleted:
+  UPDATE collection
+  SET deleted = 1,
+    is_edited = 1,
+    modified_at = :modified_at
+  WHERE remote_id IS NOT NULL;

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/notes.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/notes.sq
@@ -111,3 +111,12 @@ checkRemoteIDsExistence:
 
 deleteAll:
   DELETE FROM note;
+
+deleteUnsyncedNotes:
+  DELETE FROM note WHERE remote_id IS NULL;
+
+markRemoteNotesDeleted:
+  UPDATE note
+  SET deleted = 1,
+    modified_at = :modified_at
+  WHERE remote_id IS NOT NULL;

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/reading_bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/reading_bookmarks.sq
@@ -75,8 +75,15 @@ addPageReadingBookmark {
     WHERE bookmark_type = 'PAGE' AND page = :page;
 }
 
-insertImportedAyahReadingBookmark:
-  INSERT INTO reading_bookmark (
+insertImportedAyahReadingBookmark {
+  DELETE FROM reading_bookmark
+  WHERE deleted = 0 AND remote_id IS NULL;
+  UPDATE reading_bookmark
+  SET deleted = 1,
+    is_edited = 1,
+    modified_at = :modified_at
+  WHERE deleted = 0 AND remote_id IS NOT NULL;
+  INSERT OR IGNORE INTO reading_bookmark (
     remote_id,
     bookmark_type,
     sura,
@@ -98,9 +105,30 @@ insertImportedAyahReadingBookmark:
     :modified_at,
     0
   );
+  UPDATE reading_bookmark
+  SET deleted = 0,
+    is_edited = CASE
+      WHEN remote_id IS NULL THEN 0
+      WHEN deleted = 1 THEN 0
+      ELSE is_edited
+    END,
+    modified_at = CASE
+      WHEN remote_id IS NULL THEN :modified_at
+      WHEN deleted = 1 THEN :modified_at
+      ELSE modified_at
+    END
+  WHERE bookmark_type = 'AYAH' AND sura = :sura AND ayah = :ayah;
+}
 
-insertImportedPageReadingBookmark:
-  INSERT INTO reading_bookmark (
+insertImportedPageReadingBookmark {
+  DELETE FROM reading_bookmark
+  WHERE deleted = 0 AND remote_id IS NULL;
+  UPDATE reading_bookmark
+  SET deleted = 1,
+    is_edited = 1,
+    modified_at = :modified_at
+  WHERE deleted = 0 AND remote_id IS NOT NULL;
+  INSERT OR IGNORE INTO reading_bookmark (
     remote_id,
     bookmark_type,
     sura,
@@ -122,6 +150,20 @@ insertImportedPageReadingBookmark:
     :modified_at,
     0
   );
+  UPDATE reading_bookmark
+  SET deleted = 0,
+    is_edited = CASE
+      WHEN remote_id IS NULL THEN 0
+      WHEN deleted = 1 THEN 0
+      ELSE is_edited
+    END,
+    modified_at = CASE
+      WHEN remote_id IS NULL THEN :modified_at
+      WHEN deleted = 1 THEN :modified_at
+      ELSE modified_at
+    END
+  WHERE bookmark_type = 'PAGE' AND page = :page;
+}
 
 deleteReadingBookmark {
   DELETE FROM reading_bookmark WHERE local_id = :id AND remote_id IS NULL;
@@ -209,3 +251,13 @@ checkRemoteIDsExistence:
 
 deleteAll:
   DELETE FROM reading_bookmark;
+
+deleteUnsyncedReadingBookmarks:
+  DELETE FROM reading_bookmark WHERE remote_id IS NULL;
+
+markRemoteReadingBookmarksDeleted:
+  UPDATE reading_bookmark
+  SET deleted = 1,
+    is_edited = 1,
+    modified_at = :modified_at
+  WHERE remote_id IS NOT NULL;

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/reading_sessions.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/reading_sessions.sq
@@ -52,8 +52,8 @@ addReadingSession {
   WHERE chapter_number = :chapter_number AND verse_number = :verse_number;
 }
 
-insertImportedReadingSession:
-  INSERT INTO reading_session (
+insertImportedReadingSession {
+  INSERT OR IGNORE INTO reading_session (
     remote_id,
     chapter_number,
     verse_number,
@@ -71,6 +71,20 @@ insertImportedReadingSession:
     :modified_at,
     0
   );
+  UPDATE reading_session
+  SET deleted = 0,
+    is_edited = CASE
+      WHEN remote_id IS NULL THEN 0
+      WHEN deleted = 1 THEN 0
+      ELSE is_edited
+    END,
+    modified_at = CASE
+      WHEN remote_id IS NULL THEN :modified_at
+      WHEN deleted = 1 THEN :modified_at
+      ELSE modified_at
+    END
+  WHERE chapter_number = :chapter_number AND verse_number = :verse_number;
+}
 
 updateReadingSession:
   UPDATE reading_session
@@ -134,3 +148,13 @@ checkRemoteIDsExistence:
 
 deleteAll:
   DELETE FROM reading_session;
+
+deleteUnsyncedReadingSessions:
+  DELETE FROM reading_session WHERE remote_id IS NULL;
+
+markRemoteReadingSessionsDeleted:
+  UPDATE reading_session
+  SET deleted = 1,
+    is_edited = 1,
+    modified_at = :modified_at
+  WHERE remote_id IS NOT NULL;

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/PersistenceImportRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/PersistenceImportRepositoryTest.kt
@@ -20,6 +20,7 @@ import com.quran.shared.persistence.repository.importdata.PersistenceImportRepos
 import com.quran.shared.persistence.repository.note.repository.NotesRepositoryImpl
 import com.quran.shared.persistence.repository.readingbookmark.repository.ReadingBookmarksRepositoryImpl
 import com.quran.shared.persistence.repository.readingsession.repository.ReadingSessionsRepositoryImpl
+import com.quran.shared.persistence.util.QuranData
 import com.quran.shared.persistence.util.toPlatform
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
@@ -169,19 +170,114 @@ class PersistenceImportRepositoryTest {
     }
 
     @Test
-    fun `importData fails when the database is not empty`() = runTest {
+    fun `importData merges into a non-empty database`() = runTest {
         BookmarksRepositoryImpl(database).addBookmark(2, 255)
+        CollectionsRepositoryImpl(database).addCollection("Favorites")
 
-        assertFailsWith<IllegalStateException> {
-            repository.importData(
-                PersistenceImportData(
-                    collections = listOf(ImportCollection("collection-1", "Favorites", timestamp(1_000)))
+        val data = PersistenceImportData(
+            bookmarks = listOf(
+                ImportAyahBookmark("bookmark-1", 2, 255, timestamp(1_000)),
+                ImportAyahBookmark("bookmark-2", 3, 2, timestamp(2_000))
+            ),
+            collections = listOf(
+                ImportCollection("collection-1", "Favorites", timestamp(3_000))
+            ),
+            collectionBookmarks = listOf(
+                ImportCollectionAyahBookmark("collection-1", "bookmark-1", timestamp(4_000))
+            )
+        )
+
+        repository.importData(data)
+        repository.importData(data)
+
+        val bookmarks = BookmarksRepositoryImpl(database).getAllBookmarks()
+        assertEquals(2, bookmarks.size)
+        assertTrue(bookmarks.any { it.sura == 2 && it.ayah == 255 })
+        assertTrue(bookmarks.any { it.sura == 3 && it.ayah == 2 })
+
+        val collections = CollectionsRepositoryImpl(database).getAllCollections()
+        assertEquals(1, collections.size)
+        assertEquals("Favorites", collections.single().name)
+
+        val collectionBookmarks = CollectionBookmarksRepositoryImpl(database)
+            .getBookmarksForCollection(collections.single().localId)
+        assertEquals(1, collectionBookmarks.size)
+        assertEquals(2, collectionBookmarks.single().sura)
+        assertEquals(255, collectionBookmarks.single().ayah)
+    }
+
+    @Test
+    fun `importData deduplicates notes by normalized text and ayah range`() = runTest {
+        repository.importData(
+            PersistenceImportData(
+                notes = listOf(
+                    ImportNote("Important note", 2, 1, 2, 2, timestamp(1_000))
                 )
             )
-        }
+        )
 
-        assertEquals(1L, database.ayah_bookmarksQueries.countAll().executeAsOne())
-        assertEquals(0L, database.collectionsQueries.countAll().executeAsOne())
+        repository.importData(
+            PersistenceImportData(
+                notes = listOf(
+                    ImportNote("  Important\n\t note  ", 2, 1, 2, 2, timestamp(2_000)),
+                    ImportNote("Important note", 2, 1, 2, 3, timestamp(3_000))
+                )
+            )
+        )
+
+        val notes = NotesRepositoryImpl(database).getAllNotes()
+        assertEquals(2, notes.size)
+        assertEquals(1, notes.count { it.startSura == 2 && it.startAyah == 1 && it.endAyah == 2 })
+        assertTrue(notes.any { it.startSura == 2 && it.startAyah == 1 && it.endAyah == 3 })
+    }
+
+    @Test
+    fun `importData can delete existing data before merging`() = runTest {
+        database.ayah_bookmarksQueries.persistRemoteBookmark(
+            remote_id = "remote-bookmark",
+            ayah_id = QuranData.getAyahId(2, 255).toLong(),
+            sura = 2,
+            ayah = 255,
+            created_at = 1_000,
+            modified_at = 1_000
+        )
+        BookmarksRepositoryImpl(database).addBookmark(3, 2)
+
+        val result = repository.importData(
+            data = PersistenceImportData(
+                bookmarks = listOf(
+                    ImportAyahBookmark("bookmark-1", 4, 1, timestamp(2_000))
+                )
+            ),
+            deleteExisting = true
+        )
+
+        assertEquals(1, result.bookmarksImported)
+
+        val bookmarks = BookmarksRepositoryImpl(database).getAllBookmarks()
+        assertEquals(1, bookmarks.size)
+        assertEquals(4, bookmarks.single().sura)
+        assertEquals(1, bookmarks.single().ayah)
+        assertEquals(2L, database.ayah_bookmarksQueries.countAll().executeAsOne())
+
+        val mutations = BookmarksRepositoryImpl(database).fetchMutatedBookmarks()
+        assertTrue(
+            mutations.any {
+                it.remoteID == "remote-bookmark" &&
+                    it.mutation == Mutation.DELETED &&
+                    it.model.sura == 2 &&
+                    it.model.ayah == 255
+            }
+        )
+        assertTrue(
+            mutations.any {
+                it.remoteID == null &&
+                    it.mutation == Mutation.CREATED &&
+                    it.model.sura == 4 &&
+                    it.model.ayah == 1
+            }
+        )
+        assertTrue(mutations.none { it.model.sura == 3 && it.model.ayah == 2 })
     }
 
     @Test

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncService.kt
@@ -187,8 +187,22 @@ class SyncService(
 
     @NativeCoroutines
     suspend fun importData(data: PersistenceImportData): PersistenceImportResult {
+        return importData(
+            data = data,
+            deleteExisting = false
+        )
+    }
+
+    @NativeCoroutines
+    suspend fun importData(
+        data: PersistenceImportData,
+        deleteExisting: Boolean
+    ): PersistenceImportResult {
         try {
-            val result = persistenceImportRepository.importData(data)
+            val result = persistenceImportRepository.importData(
+                data = data,
+                deleteExisting = deleteExisting
+            )
             triggerSync()
             return result
         } catch (e: Exception) {


### PR DESCRIPTION
Previously, import would intentionally fail if any data were in the
database. This patch updates it so there's an option to clear all the
data, and, if that's not set, mobile sync will just try its best to
merge data instead.
