### PR TITLE
Do not leak auth tokens with builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,14 @@ flowchart LR
 - Cocoa toolchain for iOS simulator/device builds
 
 Optional but recommended:
-- `local.properties` with OAuth credentials:
+- `local.properties` with OAuth credentials for the Android demo app:
 
 ```properties
 OAUTH_CLIENT_ID=your_client_id
 OAUTH_CLIENT_SECRET=your_client_secret
 ```
+
+Published library artifacts do not embed these credentials. Consuming apps must pass their own client ID and optional client secret when initializing the shared graph.
 
 ## Quick Start
 
@@ -94,7 +96,9 @@ AuthFlowFactoryProvider.initialize(authFactory)
 
 val graph = SharedDependencyGraph.init(
     driverFactory = DriverFactory(context = applicationContext),
-    appEnvironment = AppEnvironment.PRELIVE
+    appEnvironment = AppEnvironment.PRELIVE,
+    clientId = appClientId,
+    clientSecret = appClientSecret
 )
 
 val authService = graph.authService
@@ -117,7 +121,9 @@ final class AppContainer {
         let driverFactory = DriverFactory()
         graph = SharedDependencyGraph.shared.doInit(
             driverFactory: driverFactory,
-            appEnvironment: AppEnvironment.prelive
+            appEnvironment: AppEnvironment.prelive,
+            clientId: appClientId,
+            clientSecret: appClientSecret
         )
     }
 }
@@ -127,6 +133,7 @@ Advanced override for custom endpoints remains available:
 
 ```kotlin
 import com.quran.shared.auth.model.AuthEnvironment
+import com.quran.shared.auth.model.AuthConfig
 import com.quran.shared.syncengine.SynchronizationEnvironment
 
 val graph = SharedDependencyGraph.init(
@@ -134,7 +141,11 @@ val graph = SharedDependencyGraph.init(
     environment = SynchronizationEnvironment(
         endPointURL = "https://custom-sync.example.com/auth"
     ),
-    authEnvironment = AuthEnvironment.PRELIVE
+    authConfig = AuthConfig(
+        environment = AuthEnvironment.PRELIVE,
+        clientId = appClientId,
+        clientSecret = appClientSecret
+    )
 )
 ```
 

--- a/auth/README.md
+++ b/auth/README.md
@@ -67,10 +67,15 @@ Coordinates token lifecycles, automated refreshes, and process-death survival by
 3.  Note your **Client ID** and **Client Secret**.
 
 ### 2. 🛠 Configuration
-Update `local.properties`:
-```properties
-OAUTH_CLIENT_ID=your_client_id_here
-OAUTH_CLIENT_SECRET=your_client_secret_here
+Provide the app's OAuth client ID and optional client secret when initializing the shared graph. Credentials are runtime app configuration and are not embedded in the published auth artifact.
+
+```kotlin
+val graph = SharedDependencyGraph.init(
+    driverFactory = driverFactory,
+    appEnvironment = AppEnvironment.PRELIVE,
+    clientId = appClientId,
+    clientSecret = appClientSecret
+)
 ```
 
 ### 3. 📦 Installation

--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -1,13 +1,4 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import java.util.Properties
-
-// 1. Load the local.properties file
-val localProperties = Properties().apply {
-    val localPropertiesFile = rootProject.file("local.properties")
-    if (localPropertiesFile.exists()) {
-        localPropertiesFile.inputStream().use { load(it) }
-    }
-}
 
 // 2. Resolve build type from BuildKonfig flavor only.
 // Define the default flavor in gradle.properties and override with -Pbuildkonfig.flavor=release in CI/release.
@@ -26,12 +17,6 @@ buildkonfig {
     packageName = "com.quran.shared.auth"
 
     defaultConfigs {
-        // Read from local.properties, provide a fallback for CI/CD environments
-        val clientId = localProperties.getProperty("OAUTH_CLIENT_ID") ?: ""
-        val clientSecret = localProperties.getProperty("OAUTH_CLIENT_SECRET") ?: ""
-
-        buildConfigField(com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING, "CLIENT_ID", clientId)
-        buildConfigField(com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING, "CLIENT_SECRET", clientSecret)
         buildConfigField(com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING, "BUILD_TYPE", resolvedBuildType)
         buildConfigField(com.codingfeline.buildkonfig.compiler.FieldSpec.Type.BOOLEAN, "IS_DEBUG", isDebugBuild.toString())
     }

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/di/AuthModule.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/di/AuthModule.kt
@@ -1,8 +1,6 @@
 package com.quran.shared.auth.di
 
-import com.quran.shared.auth.model.AuthEnvironment
 import com.quran.shared.auth.model.AuthConfig
-import com.quran.shared.auth.model.defaultAuthConfig
 import com.quran.shared.auth.repository.AuthRepository
 import com.quran.shared.auth.repository.OidcAuthRepository
 import com.quran.shared.di.AppScope
@@ -46,12 +44,6 @@ abstract class AuthModule {
                 explicitNulls = false
                 ignoreUnknownKeys = true
             }
-        }
-
-        @Provides
-        @SingleIn(AppScope::class)
-        fun provideAuthConfig(authEnvironment: AuthEnvironment): AuthConfig {
-            return defaultAuthConfig(authEnvironment)
         }
 
         @Provides

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/model/AuthConfig.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/model/AuthConfig.kt
@@ -24,6 +24,15 @@ data class AuthConfig(
     val postLogoutRedirectUri: String = "com.quran.oauth://callback",
     val scopes: List<String> = listOf("openid", "offline_access", "content", "user", "bookmark", "sync", "collection", "reading_session", "preference", "note")
 ) {
+    init {
+        require(clientId.isNotBlank()) {
+            "Auth clientId must be provided by the consuming app."
+        }
+        require(clientSecret == null || clientSecret.isNotBlank()) {
+            "Auth clientSecret must be null or non-blank."
+        }
+    }
+
     val baseUrl: String = environment.baseUrl
     val authorizationEndpoint = "$baseUrl/oauth2/auth"
     val tokenEndpoint = "$baseUrl/oauth2/token"
@@ -34,12 +43,4 @@ data class AuthConfig(
 
 fun defaultAuthEnvironment(): AuthEnvironment {
     return if (BuildKonfig.IS_DEBUG) AuthEnvironment.PRELIVE else AuthEnvironment.PRODUCTION
-}
-
-fun defaultAuthConfig(environment: AuthEnvironment = defaultAuthEnvironment()): AuthConfig {
-    return AuthConfig(
-        environment = environment,
-        clientId = BuildKonfig.CLIENT_ID,
-        clientSecret = BuildKonfig.CLIENT_SECRET
-    )
 }

--- a/auth/src/commonTest/kotlin/com/quran/shared/auth/model/AuthConfigTest.kt
+++ b/auth/src/commonTest/kotlin/com/quran/shared/auth/model/AuthConfigTest.kt
@@ -2,6 +2,7 @@ package com.quran.shared.auth.model
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class AuthConfigTest {
 
@@ -25,5 +26,15 @@ class AuthConfigTest {
 
         assertEquals("https://oauth2.quran.foundation", config.baseUrl)
         assertEquals("https://oauth2.quran.foundation/oauth2/token", config.tokenEndpoint)
+    }
+
+    @Test
+    fun `blank client id fails fast`() {
+        assertFailsWith<IllegalArgumentException> {
+            AuthConfig(
+                environment = AuthEnvironment.PRELIVE,
+                clientId = ""
+            )
+        }
     }
 }

--- a/demo/android/build.gradle.kts
+++ b/demo/android/build.gradle.kts
@@ -1,3 +1,16 @@
+import java.util.Properties
+
+val localProperties = Properties().apply {
+    val localPropertiesFile = rootProject.file("local.properties")
+    if (localPropertiesFile.exists()) {
+        localPropertiesFile.inputStream().use { load(it) }
+    }
+}
+
+fun String.toBuildConfigString(): String {
+    return "\"" + replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+}
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.metro)
@@ -12,6 +25,16 @@ android {
         minSdk = 23
         targetSdk = 36
         manifestPlaceholders["oidcRedirectScheme"] = "com.quran.oauth"
+        buildConfigField(
+            "String",
+            "OAUTH_CLIENT_ID",
+            (localProperties.getProperty("OAUTH_CLIENT_ID") ?: "").toBuildConfigString()
+        )
+        buildConfigField(
+            "String",
+            "OAUTH_CLIENT_SECRET",
+            (localProperties.getProperty("OAUTH_CLIENT_SECRET") ?: "").toBuildConfigString()
+        )
     }
 
     compileOptions {
@@ -19,7 +42,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    buildFeatures.compose = true
+    buildFeatures {
+        compose = true
+        buildConfig = true
+    }
 }
 
 dependencies {

--- a/demo/android/src/main/kotlin/com/quran/shared/demo/android/MainActivity.kt
+++ b/demo/android/src/main/kotlin/com/quran/shared/demo/android/MainActivity.kt
@@ -31,7 +31,9 @@ class MainActivity : ComponentActivity() {
         val driverFactory = DriverFactory(context = this.applicationContext)
         val graph = SharedDependencyGraph.init(
             driverFactory = driverFactory,
-            appEnvironment = AppEnvironment.PRELIVE
+            appEnvironment = AppEnvironment.PRELIVE,
+            clientId = BuildConfig.OAUTH_CLIENT_ID,
+            clientSecret = BuildConfig.OAUTH_CLIENT_SECRET.takeIf { it.isNotBlank() }
         )
         
         SyncViewModel(graph.authService, graph.syncService)

--- a/demo/apple/QuranSyncDemo/QuranSyncDemo/AppContainer.swift
+++ b/demo/apple/QuranSyncDemo/QuranSyncDemo/AppContainer.swift
@@ -1,5 +1,10 @@
 import Shared
 
+private enum AuthCredentials {
+    static let clientId = "replace-with-client-id"
+    static let clientSecret: String? = nil
+}
+
 /**
  * App-level container around the shared dependency graph.
  *
@@ -22,7 +27,9 @@ final class AppContainer {
 
         self.graph = SharedDependencyGraph.shared.doInit(
             driverFactory: driverFactory,
-            appEnvironment: AppEnvironment.prelive
+            appEnvironment: AppEnvironment.prelive,
+            clientId: AuthCredentials.clientId,
+            clientSecret: AuthCredentials.clientSecret
         )
     }
 }

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/di/AppGraph.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/di/AppGraph.kt
@@ -1,8 +1,7 @@
 package com.quran.shared.pipeline.di
 
 import com.quran.shared.auth.di.AuthModule
-import com.quran.shared.auth.model.AuthEnvironment
-import com.quran.shared.auth.model.defaultAuthEnvironment
+import com.quran.shared.auth.model.AuthConfig
 import com.quran.shared.auth.service.AuthService
 import com.quran.shared.di.AppScope
 import com.quran.shared.persistence.DriverFactory
@@ -53,7 +52,7 @@ interface AppGraph {
         fun create(
             @Provides driverFactory: DriverFactory,
             @Provides environment: SynchronizationEnvironment,
-            @Provides authEnvironment: AuthEnvironment
+            @Provides authConfig: AuthConfig
         ): AppGraph
     }
 }
@@ -67,22 +66,42 @@ object SharedDependencyGraph {
     private fun doInit(
         driverFactory: DriverFactory,
         environment: SynchronizationEnvironment,
-        authEnvironment: AuthEnvironment
+        authConfig: AuthConfig
     ): AppGraph {
         return createGraphFactory<AppGraph.Factory>()
-            .create(driverFactory, environment, authEnvironment)
+            .create(driverFactory, environment, authConfig)
             .also { instance = it }
     }
 
     @OptIn(InternalCoroutinesApi::class)
     fun init(
         driverFactory: DriverFactory,
-        appEnvironment: AppEnvironment = defaultAppEnvironment()
+        clientId: String,
+        clientSecret: String? = null
+    ): AppGraph {
+        return init(
+            driverFactory = driverFactory,
+            appEnvironment = defaultAppEnvironment(),
+            clientId = clientId,
+            clientSecret = clientSecret
+        )
+    }
+
+    @OptIn(InternalCoroutinesApi::class)
+    fun init(
+        driverFactory: DriverFactory,
+        appEnvironment: AppEnvironment,
+        clientId: String,
+        clientSecret: String? = null
     ): AppGraph {
         return init(
             driverFactory = driverFactory,
             environment = appEnvironment.synchronizationEnvironment(),
-            authEnvironment = appEnvironment.authEnvironment
+            authConfig = AuthConfig(
+                environment = appEnvironment.authEnvironment,
+                clientId = clientId,
+                clientSecret = clientSecret
+            )
         )
     }
 
@@ -90,10 +109,10 @@ object SharedDependencyGraph {
     fun init(
         driverFactory: DriverFactory,
         environment: SynchronizationEnvironment,
-        authEnvironment: AuthEnvironment = defaultAuthEnvironment()
+        authConfig: AuthConfig
     ): AppGraph {
         return instance ?: synchronized(lock) {
-            instance ?: doInit(driverFactory, environment, authEnvironment)
+            instance ?: doInit(driverFactory, environment, authConfig)
         }
     }
 }


### PR DESCRIPTION
Require the customer to set their own auth tokens and do not pre-ship
the library with any.
