### PR TITLE
Sync collection bookmark deletions before bookmark

### DIFF
--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapter.kt
@@ -2,6 +2,7 @@ package com.quran.shared.syncengine
 
 import co.touchlab.kermit.Logger
 import com.quran.shared.mutations.LocalModelMutation
+import com.quran.shared.mutations.Mutation
 import com.quran.shared.mutations.RemoteModelMutation
 import com.quran.shared.syncengine.conflict.CollectionBookmarksConflictDetector
 import com.quran.shared.syncengine.conflict.CollectionBookmarksConflictResolver
@@ -22,7 +23,7 @@ import kotlin.time.Instant
 
 internal class CollectionBookmarksSyncAdapter(
     private val configurations: CollectionBookmarksSynchronizationConfigurations
-) : SyncResourceAdapter {
+) : SyncResourceAdapter, PreDependencyDeletionSyncResourceAdapter {
 
     override val resourceName: String = "COLLECTION_BOOKMARK"
     override val localModificationDateFetcher: LocalModificationDateFetcher =
@@ -69,6 +70,40 @@ internal class CollectionBookmarksSyncAdapter(
             localMutationsToClear = localMutations,
             remoteMutationsToPersist = mutationsToPersist,
             localMutationsToPush = mutationsToPush
+        )
+    }
+
+    override suspend fun buildPreDependencyDeletionPlan(
+        lastModificationDate: Long,
+        remoteMutations: List<SyncMutation>
+    ): ResourceSyncPlan? {
+        val localMutations = configurations.localDataFetcher.fetchLocalMutations(lastModificationDate)
+            .filter { mutation -> mutation.mutation == Mutation.DELETED }
+        if (localMutations.isEmpty()) {
+            return null
+        }
+
+        logger.i {
+            "Local deletion mutations fetched for pre-dependency $resourceName phase: " +
+                "lastModificationDate=$lastModificationDate, localMutations=${localMutations.size}"
+        }
+
+        val parsedRemote = parseRemoteMutations(remoteMutations)
+        val preprocessedRemote = preprocessRemoteMutations(parsedRemote)
+        val conflictDetection = detectConflicts(preprocessedRemote, localMutations)
+        val localMutationsToPush = conflictDetection.nonConflictingLocalMutations
+        if (localMutationsToPush.isEmpty()) {
+            logger.d {
+                "No non-conflicting deletion mutations for pre-dependency $resourceName phase: " +
+                    "conflicts=${conflictDetection.conflicts.size}"
+            }
+            return null
+        }
+
+        return CollectionBookmarksResourceSyncPlan(
+            localMutationsToClear = localMutationsToPush,
+            remoteMutationsToPersist = emptyList(),
+            localMutationsToPush = localMutationsToPush
         )
     }
 

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SyncResourceAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SyncResourceAdapter.kt
@@ -21,3 +21,10 @@ interface ResourceSyncPlan {
 
     suspend fun complete(newToken: Long, pushedMutations: List<SyncMutation>)
 }
+
+internal interface PreDependencyDeletionSyncResourceAdapter : SyncResourceAdapter {
+    suspend fun buildPreDependencyDeletionPlan(
+        lastModificationDate: Long,
+        remoteMutations: List<SyncMutation>
+    ): ResourceSyncPlan?
+}

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClientImpl.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClientImpl.kt
@@ -162,12 +162,17 @@ internal suspend fun executeDependencyAwareSync(
 ) {
     var mutationToken = remoteResponse.lastModificationDate
     val safeCompletionToken = remoteResponse.lastModificationDate
+    val preDependencyDeletionPlans = resourceAdapters
+        .mapNotNull { adapter ->
+            (adapter as? PreDependencyDeletionSyncResourceAdapter)
+                ?.buildPreDependencyDeletionPlan(initialLastModificationDate, remoteResponse.mutations)
+        }
     val phases = resourceAdapters.dependencyAwareSyncPhases()
-    val totalPlans = phases.sumOf { it.size }
+    val totalPlans = phases.sumOf { it.size } + preDependencyDeletionPlans.size
 
-    phases.forEach { phaseAdapters ->
-        val plans = phaseAdapters.map { adapter ->
-            adapter.buildPlan(initialLastModificationDate, remoteResponse.mutations)
+    suspend fun executePlans(plans: List<ResourceSyncPlan>) {
+        if (plans.isEmpty()) {
+            return
         }
 
         val mutationsToPush = plans.flatMap { it.mutationsToPush() }
@@ -180,6 +185,15 @@ internal suspend fun executeDependencyAwareSync(
             val completionToken = if (totalPlans == 1) mutationToken else initialLastModificationDate
             plan.complete(completionToken, pushedForResource)
         }
+    }
+
+    executePlans(preDependencyDeletionPlans)
+
+    phases.forEach { phaseAdapters ->
+        val plans = phaseAdapters.map { adapter ->
+            adapter.buildPlan(initialLastModificationDate, remoteResponse.mutations)
+        }
+        executePlans(plans)
     }
 
     if (totalPlans > 1) {

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapterTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapterTest.kt
@@ -21,6 +21,100 @@ import kotlin.time.Instant
 class CollectionBookmarksSyncAdapterTest {
 
     @Test
+    fun `pre-dependency deletion plan skips deletes that conflict with remote mutations`() = runTest {
+        val remoteId = collectionBookmarkRemoteId("remote-collection-1", "remote-bookmark-1")
+        val localMutation = LocalModelMutation<SyncCollectionBookmark>(
+            model = SyncCollectionBookmark.AyahBookmark(
+                collectionId = "remote-collection-1",
+                sura = 2,
+                ayah = 255,
+                lastModified = Instant.fromEpochMilliseconds(1000),
+                bookmarkId = "remote-bookmark-1"
+            ),
+            remoteID = remoteId,
+            localID = "local-1",
+            mutation = Mutation.DELETED
+        )
+        val remoteMutation = SyncMutation(
+            resource = "COLLECTION_BOOKMARK",
+            resourceId = remoteId,
+            mutation = Mutation.CREATED,
+            data = buildJsonObject {
+                put("collectionId", "remote-collection-1")
+                put("type", "ayah")
+                put("key", 2)
+                put("verseNumber", 255)
+                put("mushaf", 4)
+            },
+            timestamp = 2000L
+        )
+
+        val localDataFetcher = object : LocalDataFetcher<SyncCollectionBookmark> {
+            override suspend fun fetchLocalMutations(lastModified: Long): List<LocalModelMutation<SyncCollectionBookmark>> =
+                listOf(localMutation)
+
+            override suspend fun checkLocalExistence(remoteIDs: List<String>): Map<String, Boolean> =
+                remoteIDs.associateWith { true }
+
+            override suspend fun fetchLocalModel(remoteId: String): SyncCollectionBookmark? = null
+        }
+
+        var capturedRemote: List<RemoteModelMutation<SyncCollectionBookmark>>? = null
+        var capturedLocal: List<LocalModelMutation<SyncCollectionBookmark>>? = null
+
+        val resultNotifier = object : ResultNotifier<SyncCollectionBookmark> {
+            override suspend fun didSucceed(
+                newToken: Long,
+                newRemoteMutations: List<RemoteModelMutation<SyncCollectionBookmark>>,
+                processedLocalMutations: List<LocalModelMutation<SyncCollectionBookmark>>
+            ) {
+                capturedRemote = newRemoteMutations
+                capturedLocal = processedLocalMutations
+            }
+
+            override suspend fun didFail(message: String) {
+                fail("didFail called: $message")
+            }
+        }
+
+        val localModificationDateFetcher = object : LocalModificationDateFetcher {
+            override suspend fun localLastModificationDate(): Long? = 0L
+        }
+
+        val adapter = CollectionBookmarksSyncAdapter(
+            CollectionBookmarksSynchronizationConfigurations(
+                localDataFetcher = localDataFetcher,
+                resultNotifier = resultNotifier,
+                localModificationDateFetcher = localModificationDateFetcher
+            )
+        )
+
+        assertNull(
+            adapter.buildPreDependencyDeletionPlan(
+                lastModificationDate = 0L,
+                remoteMutations = listOf(remoteMutation)
+            )
+        )
+
+        val plan = adapter.buildPlan(
+            lastModificationDate = 0L,
+            remoteMutations = listOf(remoteMutation)
+        )
+        assertEquals(emptyList(), plan.mutationsToPush())
+
+        plan.complete(newToken = 5L, pushedMutations = emptyList())
+
+        val remote = assertNotNull(capturedRemote)
+        assertEquals(1, remote.size)
+        assertEquals(remoteId, remote.single().remoteID)
+        assertEquals(Mutation.CREATED, remote.single().mutation)
+
+        val local = assertNotNull(capturedLocal)
+        assertEquals(1, local.size)
+        assertEquals("local-1", local.single().localID)
+    }
+
+    @Test
     fun `mutations to push omit bookmarkId payload field`() = runTest {
         val localMutation = LocalModelMutation<SyncCollectionBookmark>(
             model = SyncCollectionBookmark.AyahBookmark(

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/SynchronizationClientPhasingTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/SynchronizationClientPhasingTest.kt
@@ -10,6 +10,85 @@ import kotlin.test.assertFailsWith
 class SynchronizationClientPhasingTest {
 
     @Test
+    fun `collection bookmark deletions are pushed before primary resources`() = runTest {
+        val events = mutableListOf<String>()
+        val pushedMutations = mutableListOf<List<SyncMutation>>()
+        val pushedTokens = mutableListOf<Long>()
+        var preDependencyDeleteCompleted = false
+
+        val bookmarkAdapter = RecordingAdapter(
+            resourceName = "BOOKMARK",
+            events = events,
+            onBuild = {
+                assertEquals(
+                    true,
+                    preDependencyDeleteCompleted,
+                    "Bookmark planning should run after collection bookmark deletions complete."
+                )
+            },
+            onSyncComplete = { token -> events += "sync-complete-BOOKMARK-$token" }
+        )
+        val collectionBookmarkAdapter = RecordingAdapter(
+            resourceName = "COLLECTION_BOOKMARK",
+            events = events,
+            preDependencyDeletionMutation = SyncMutation(
+                resource = "COLLECTION_BOOKMARK",
+                resourceId = "remote-collection-bookmark-1",
+                mutation = Mutation.DELETED,
+                data = null,
+                timestamp = null
+            ),
+            onPreDependencyDeletionComplete = {
+                preDependencyDeleteCompleted = true
+            },
+            onSyncComplete = { token -> events += "sync-complete-COLLECTION_BOOKMARK-$token" }
+        )
+
+        executeDependencyAwareSync(
+            resourceAdapters = listOf(
+                bookmarkAdapter,
+                collectionBookmarkAdapter
+            ),
+            initialLastModificationDate = 1L,
+            remoteResponse = MutationsResponse(
+                lastModificationDate = 10L,
+                mutations = emptyList()
+            ),
+            pushMutations = { mutations, mutationToken ->
+                pushedTokens += mutationToken
+                pushedMutations += mutations
+                MutationsResponse(
+                    lastModificationDate = mutationToken + 1,
+                    mutations = mutations.mapIndexed { index, mutation ->
+                        mutation.copy(resourceId = mutation.resourceId ?: "${mutation.resource.lowercase()}-$index")
+                    }
+                )
+            }
+        )
+
+        assertEquals(
+            listOf(
+                "build-pre-COLLECTION_BOOKMARK",
+                "complete-pre-COLLECTION_BOOKMARK-1",
+                "build-BOOKMARK",
+                "complete-BOOKMARK-1",
+                "build-COLLECTION_BOOKMARK",
+                "complete-COLLECTION_BOOKMARK-1",
+                "sync-complete-BOOKMARK-10",
+                "sync-complete-COLLECTION_BOOKMARK-10"
+            ),
+            events
+        )
+        assertEquals(listOf(10L, 11L, 12L), pushedTokens)
+        assertEquals(listOf("COLLECTION_BOOKMARK"), pushedMutations[0].map { it.resource })
+        assertEquals(listOf(Mutation.DELETED), pushedMutations[0].map { it.mutation })
+        assertEquals(listOf("BOOKMARK"), pushedMutations[1].map { it.resource })
+        assertEquals(listOf(Mutation.CREATED), pushedMutations[1].map { it.mutation })
+        assertEquals(listOf("COLLECTION_BOOKMARK"), pushedMutations[2].map { it.resource })
+        assertEquals(listOf(Mutation.CREATED), pushedMutations[2].map { it.mutation })
+    }
+
+    @Test
     fun `collection bookmark plan is built after primary resources complete`() = runTest {
         val events = mutableListOf<String>()
         var completedPrimaryResources = 0
@@ -170,12 +249,29 @@ private class RecordingAdapter(
     private val events: MutableList<String>,
     private val onBuild: () -> Unit = {},
     private val onComplete: () -> Unit = {},
-    private val onSyncComplete: (Long) -> Unit = {}
-) : SyncResourceAdapter {
+    private val onSyncComplete: (Long) -> Unit = {},
+    private val preDependencyDeletionMutation: SyncMutation? = null,
+    private val onPreDependencyDeletionComplete: () -> Unit = {}
+) : SyncResourceAdapter, PreDependencyDeletionSyncResourceAdapter {
     override val localModificationDateFetcher: LocalModificationDateFetcher =
         object : LocalModificationDateFetcher {
             override suspend fun localLastModificationDate(): Long = 0L
         }
+
+    override suspend fun buildPreDependencyDeletionPlan(
+        lastModificationDate: Long,
+        remoteMutations: List<SyncMutation>
+    ): ResourceSyncPlan? {
+        val mutation = preDependencyDeletionMutation ?: return null
+        events += "build-pre-$resourceName"
+        return RecordingPlan(
+            resourceName = resourceName,
+            events = events,
+            onComplete = onPreDependencyDeletionComplete,
+            eventName = "pre-$resourceName",
+            mutation = mutation
+        )
+    }
 
     override suspend fun buildPlan(
         lastModificationDate: Long,
@@ -196,21 +292,21 @@ private class RecordingAdapter(
 private class RecordingPlan(
     override val resourceName: String,
     private val events: MutableList<String>,
-    private val onComplete: () -> Unit
+    private val onComplete: () -> Unit,
+    private val eventName: String = resourceName,
+    private val mutation: SyncMutation = SyncMutation(
+        resource = resourceName,
+        resourceId = null,
+        mutation = Mutation.CREATED,
+        data = null,
+        timestamp = null
+    )
 ) : ResourceSyncPlan {
     override fun mutationsToPush(): List<SyncMutation> =
-        listOf(
-            SyncMutation(
-                resource = resourceName,
-                resourceId = null,
-                mutation = Mutation.CREATED,
-                data = null,
-                timestamp = null
-            )
-        )
+        listOf(mutation)
 
     override suspend fun complete(newToken: Long, pushedMutations: List<SyncMutation>) {
-        events += "complete-$resourceName-$newToken"
+        events += "complete-$eventName-$newToken"
         onComplete()
     }
 }


### PR DESCRIPTION
When syncing a deleted bookmark, collection bookmark relationship
deletions need to be synced first. Without this, we sync the bookmark
deletion, remove the bookmark, then try to sync the collection change,
but the bookmark has been locally removed and no longer exists, so it
fails. This patch fixes this case.
