### PR TITLE
Use token storage for tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ import com.quran.shared.auth.di.AuthFlowFactoryProvider
 import com.quran.shared.persistence.DriverFactory
 import com.quran.shared.pipeline.AppEnvironment
 import com.quran.shared.pipeline.di.SharedDependencyGraph
+import com.quran.shared.pipeline.storage.createMobileSyncStorage
 import org.publicvalue.multiplatform.oidc.appsupport.AndroidCodeAuthFlowFactory
 
 val authFactory = AndroidCodeAuthFlowFactory(useWebView = false)
@@ -96,6 +97,7 @@ AuthFlowFactoryProvider.initialize(authFactory)
 
 val graph = SharedDependencyGraph.init(
     driverFactory = DriverFactory(context = applicationContext),
+    storage = createMobileSyncStorage(applicationContext),
     appEnvironment = AppEnvironment.PRELIVE,
     clientId = appClientId,
     clientSecret = appClientSecret
@@ -119,8 +121,10 @@ final class AppContainer {
     private init() {
         Shared.AuthFlowFactoryProvider.shared.doInitialize()
         let driverFactory = DriverFactory()
+        let storage = AppleMobileSyncStorageFactory.shared.create()
         graph = SharedDependencyGraph.shared.doInit(
             driverFactory: driverFactory,
+            storage: storage,
             appEnvironment: AppEnvironment.prelive,
             clientId: appClientId,
             clientSecret: appClientSecret
@@ -138,6 +142,7 @@ import com.quran.shared.syncengine.SynchronizationEnvironment
 
 val graph = SharedDependencyGraph.init(
     driverFactory = DriverFactory(context = applicationContext),
+    storage = createMobileSyncStorage(applicationContext),
     environment = SynchronizationEnvironment(
         endPointURL = "https://custom-sync.example.com/auth"
     ),
@@ -148,6 +153,19 @@ val graph = SharedDependencyGraph.init(
     )
 )
 ```
+
+### Android backup exclusions
+
+The shared Android storage uses stable DataStore file names so apps can exclude derived sync state
+and token-store data from backup or device transfer:
+
+```xml
+<exclude domain="file" path="datastore/quran_mobile_sync_settings.preferences_pb"/>
+<exclude domain="file" path="datastore/org.publicvalue.multiplatform.oidc.tokenstore.preferences_pb"/>
+```
+
+Add those entries to both `full-backup-content` and Android 12+ `data-extraction-rules` when app
+backup is enabled.
 
 ### 3. Use `SyncService`
 

--- a/auth/README.md
+++ b/auth/README.md
@@ -31,7 +31,8 @@ graph TD
 
     subgraph "External Dependencies"
         Ktor[Ktor Client]
-        Settings[Multiplatform Settings]
+        TokenStore[OIDC TokenStore]
+        DataStore[DataStore Settings]
         OIDC[Kalinjul OIDC Lib]
         NC[KMP-NativeCoroutines]
     end
@@ -41,6 +42,8 @@ graph TD
     Service --> Repo
     Repo --> NDS
     Repo --> Storage
+    Storage --> TokenStore
+    Storage --> DataStore
     Repo --> OIDC
     IVM -.-> NC
 ```
@@ -55,7 +58,8 @@ The central hub for authentication logic and state.
 - **iOS (`AuthViewModel`)**: A native Swift ViewModel that observes the `authStateFlow` from the shared service, allowing seamless integration with SwiftUI's `@Published` properties.
 
 ### 3. **Repository Layer (`OidcAuthRepository`)**
-Coordinates token lifecycles, automated refreshes, and process-death survival by persisting OAuth state.
+Coordinates token lifecycles and automated refreshes. OAuth token material is persisted through the
+OIDC `TokenStore`; non-token session metadata is stored in the app-provided DataStore settings.
 
 ---
 
@@ -70,8 +74,11 @@ Coordinates token lifecycles, automated refreshes, and process-death survival by
 Provide the app's OAuth client ID and optional client secret when initializing the shared graph. Credentials are runtime app configuration and are not embedded in the published auth artifact.
 
 ```kotlin
+val storage = createMobileSyncStorage(applicationContext)
+
 val graph = SharedDependencyGraph.init(
     driverFactory = driverFactory,
+    storage = storage,
     appEnvironment = AppEnvironment.PRELIVE,
     clientId = appClientId,
     clientSecret = appClientSecret
@@ -130,7 +137,7 @@ Task {
 
 // In View
 if let success = viewModel.authState as? AuthState.Success {
-    Text("Welcome, \(success.userInfo.displayName ?? "User")")
+    Text("Welcome, \(success.userInfo?.displayName ?? "User")")
 } else if let error = viewModel.authState as? AuthState.Error {
     Text(error.message)
 }

--- a/auth/build.gradle.kts
+++ b/auth/build.gradle.kts
@@ -61,7 +61,9 @@ kotlin {
             implementation(libs.ktor.client.content.negotiation)
             implementation(libs.ktor.serialization.json)
             implementation(libs.sha2)
-            api(libs.multiplatform.settings.no.arg)
+            api(libs.multiplatform.settings)
+            api(libs.multiplatform.settings.coroutines)
+            api(libs.oidc.tokenstore)
             implementation(libs.kermit)
             implementation(libs.kotlinx.serialization.json)
             api(libs.androidx.lifecycle.viewmodel) // using `api` for better access from swift code
@@ -72,6 +74,7 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.multiplatform.settings.test)
         }
         
         androidMain.dependencies {
@@ -87,6 +90,11 @@ kotlin {
                 implementation(libs.ktor.client.darwin)
             }
         }
+    }
+
+    sourceSets.all {
+        languageSettings.optIn("com.russhwolf.settings.ExperimentalSettingsApi")
+        languageSettings.optIn("org.publicvalue.multiplatform.oidc.ExperimentalOpenIdConnect")
     }
 }
 

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/di/AuthModule.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/di/AuthModule.kt
@@ -4,7 +4,6 @@ import com.quran.shared.auth.model.AuthConfig
 import com.quran.shared.auth.repository.AuthRepository
 import com.quran.shared.auth.repository.OidcAuthRepository
 import com.quran.shared.di.AppScope
-import com.russhwolf.settings.Settings
 import dev.zacsweers.metro.Binds
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
@@ -31,12 +30,6 @@ abstract class AuthModule {
     abstract fun bindAuthRepository(impl: OidcAuthRepository): AuthRepository
 
     companion object {
-        @Provides
-        @SingleIn(AppScope::class)
-        fun provideSettings(): Settings {
-            return Settings()
-        }
-
         @Provides
         @SingleIn(AppScope::class)
         fun provideJson(): Json {

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/model/AuthState.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/model/AuthState.kt
@@ -15,8 +15,14 @@ sealed class AuthState {
     /** Authentication in progress (browser may be open) */
     data object Loading : AuthState()
 
-    /** Successfully authenticated with user info */
-    data class Success(val userInfo: UserInfo) : AuthState()
+    /**
+     * Successfully authenticated.
+     *
+     * [userInfo] is optional because OAuth token validity and profile availability are separate
+     * concerns. A profile request can fail or cached profile data can be unavailable while the
+     * stored token session is still valid for authenticated sync calls.
+     */
+    data class Success(val userInfo: UserInfo?) : AuthState()
 
     /** Authentication failed with an exception */
     data class Error(val exception: Exception, val message: String) : AuthState()

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/persistence/AuthStorage.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/persistence/AuthStorage.kt
@@ -4,39 +4,37 @@ import com.quran.shared.auth.model.TokenResponse
 import com.quran.shared.auth.model.UserInfo
 import com.quran.shared.auth.utils.currentTimeMillis
 import com.quran.shared.di.AppScope
-import com.russhwolf.settings.Settings
-import com.russhwolf.settings.set
+import com.russhwolf.settings.coroutines.SuspendSettings
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlin.time.Instant
 import kotlinx.serialization.json.Json
+import org.publicvalue.multiplatform.oidc.tokenstore.TokenStore
 
 /**
- * Persists authentication tokens and OAuth state across app restarts.
+ * Persists authentication token material and non-secret session metadata across app restarts.
+ *
+ * OAuth tokens are stored through [TokenStore] so each platform can use its secure storage
+ * implementation. Metadata such as expiry, scope, and cached profile data remains outside the
+ * token store because the OIDC token-store API intentionally owns only token material.
  */
 @SingleIn(AppScope::class)
 class AuthStorage @Inject constructor(
-    private val settings: Settings,
+    private val tokenStore: TokenStore,
+    private val settings: SuspendSettings,
     private val json: Json
 ) {
 
-    fun retrieveStoredAccessToken(): String? = settings.getStringOrNull(KEY_ACCESS_TOKEN)
-    fun retrieveStoredRefreshToken(): String? = settings.getStringOrNull(KEY_REFRESH_TOKEN)
-    fun retrieveStoredIdToken(): String? = settings.getStringOrNull(KEY_ID_TOKEN)
-    fun retrieveStoredScope(): String? = settings.getStringOrNull(KEY_SCOPE)
-    fun retrieveTokenExpiration(): Long = settings.getLong(KEY_TOKEN_EXPIRATION, 0)
+    suspend fun retrieveStoredAccessToken(): String? = tokenStore.getAccessToken()
+    suspend fun retrieveStoredRefreshToken(): String? = tokenStore.getRefreshToken()
+    suspend fun retrieveStoredIdToken(): String? = tokenStore.getIdToken()
+    suspend fun retrieveStoredScope(): String? = settings.getStringOrNull(KEY_SCOPE)
+    suspend fun retrieveTokenExpiration(): Long = settings.getLong(KEY_TOKEN_EXPIRATION, 0)
 
     /**
-     * Retrieves stored code verifier for token exchange (survival after process death).
+     * Retrieves cached user profile data from non-token session metadata.
      */
-    fun retrieveStoredCodeVerifier(): String? = settings.getStringOrNull(KEY_CODE_VERIFIER)
-
-    /**
-     * Retrieves stored state parameter for validation (survival after process death).
-     */
-    fun retrieveStoredState(): String? = settings.getStringOrNull(KEY_STATE)
-
-    fun retrieveUserInfo(): UserInfo? {
+    suspend fun retrieveUserInfo(): UserInfo? {
         val userInfoJson = settings.getStringOrNull(KEY_USER_INFO) ?: return null
         return try {
             json.decodeFromString<UserInfo>(userInfoJson)
@@ -45,7 +43,38 @@ class AuthStorage @Inject constructor(
         }
     }
 
-    fun storeTokens(tokenResponse: TokenResponse) {
+    /**
+     * Stores token response data for an existing session while preserving stable refresh and ID
+     * tokens when a refresh response omits them.
+     *
+     * Some providers return only a new access token during refresh. Passing null directly to
+     * [TokenStore.saveTokens] would remove the previous refresh token, so this method reads the
+     * existing secure token values first and keeps them unless replacements are present.
+     *
+     * @param tokenResponse token response returned from a refresh or same-session update.
+     */
+    suspend fun storeTokens(tokenResponse: TokenResponse) {
+        storeTokens(tokenResponse, preserveExistingTokens = true)
+    }
+
+    /**
+     * Stores token response data for a newly completed interactive login session.
+     *
+     * This intentionally does not preserve existing refresh or ID tokens. A successful login or
+     * login-continuation is a session boundary, so stale identity metadata must be removed before
+     * the new token material is stored.
+     *
+     * @param tokenResponse token response returned from a successful interactive login.
+     */
+    suspend fun storeNewSessionTokens(tokenResponse: TokenResponse) {
+        clearSessionMetadata()
+        storeTokens(tokenResponse, preserveExistingTokens = false)
+    }
+
+    private suspend fun storeTokens(
+        tokenResponse: TokenResponse,
+        preserveExistingTokens: Boolean
+    ) {
         val expirationTime = if (tokenResponse.expiresAt != null) {
             try {
                 Instant.parse(tokenResponse.expiresAt).toEpochMilliseconds()
@@ -55,55 +84,46 @@ class AuthStorage @Inject constructor(
         } else {
             currentTimeMillis() + (tokenResponse.expiresIn * 1000)
         }
+        val refreshToken = tokenResponse.refreshToken
+            ?: if (preserveExistingTokens) tokenStore.getRefreshToken() else null
+        val idToken = tokenResponse.idToken
+            ?: if (preserveExistingTokens) tokenStore.getIdToken() else null
 
-        settings[KEY_ACCESS_TOKEN] = tokenResponse.accessToken
-        tokenResponse.refreshToken?.let { settings[KEY_REFRESH_TOKEN] = it }
-        tokenResponse.idToken?.let { settings[KEY_ID_TOKEN] = it }
-        tokenResponse.scope?.let { settings[KEY_SCOPE] = it }
-        settings[KEY_TOKEN_EXPIRATION] = expirationTime
-        settings[KEY_TOKEN_RETRIEVED_AT] = currentTimeMillis()
+        tokenStore.saveTokens(
+            accessToken = tokenResponse.accessToken,
+            refreshToken = refreshToken,
+            idToken = idToken
+        )
+        tokenResponse.scope?.let { settings.putString(KEY_SCOPE, it) }
+        settings.putLong(KEY_TOKEN_EXPIRATION, expirationTime)
+        settings.putLong(KEY_TOKEN_RETRIEVED_AT, currentTimeMillis())
     }
 
-    fun storeUserInfo(userInfo: UserInfo) {
-        settings[KEY_USER_INFO] = json.encodeToString(userInfo)
+    suspend fun storeUserInfo(userInfo: UserInfo) {
+        settings.putString(KEY_USER_INFO, json.encodeToString(userInfo))
     }
 
     /**
-     * Stores OAuth state (verifier and state) during login flow initiation.
+     * Clears secure token material and non-token auth metadata.
      */
-    fun storeOAuthState(codeVerifier: String, state: String) {
-        settings[KEY_CODE_VERIFIER] = codeVerifier
-        settings[KEY_STATE] = state
+    suspend fun clearAllTokens() {
+        tokenStore.removeAccessToken()
+        tokenStore.removeRefreshToken()
+        tokenStore.removeIdToken()
+        clearSessionMetadata()
     }
 
-    /**
-     * Clears OAuth state after successful or failed callback.
-     */
-    fun clearOAuthState() {
-        settings.remove(KEY_CODE_VERIFIER)
-        settings.remove(KEY_STATE)
-    }
-
-    fun clearAllTokens() {
-        settings.remove(KEY_ACCESS_TOKEN)
-        settings.remove(KEY_REFRESH_TOKEN)
-        settings.remove(KEY_ID_TOKEN)
+    private suspend fun clearSessionMetadata() {
         settings.remove(KEY_SCOPE)
         settings.remove(KEY_USER_INFO)
         settings.remove(KEY_TOKEN_EXPIRATION)
         settings.remove(KEY_TOKEN_RETRIEVED_AT)
-        clearOAuthState()
     }
 
     companion object {
-        private const val KEY_ACCESS_TOKEN = "access_token"
-        private const val KEY_REFRESH_TOKEN = "refresh_token"
-        private const val KEY_ID_TOKEN = "id_token"
         private const val KEY_SCOPE = "scope"
         private const val KEY_TOKEN_EXPIRATION = "token_expiration"
         private const val KEY_TOKEN_RETRIEVED_AT = "token_retrieved_at"
         private const val KEY_USER_INFO = "user_info"
-        private const val KEY_CODE_VERIFIER = "code_verifier"
-        private const val KEY_STATE = "state"
     }
 }

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/repository/AuthRepository.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/repository/AuthRepository.kt
@@ -39,17 +39,17 @@ interface AuthRepository {
     /**
      * Returns the current access token if available.
      */
-    fun getAccessToken(): String?
+    suspend fun getAccessToken(): String?
 
     /**
      * Checks if the user is currently authenticated with a valid session.
      */
-    fun isLoggedIn(): Boolean
+    suspend fun isLoggedIn(): Boolean
 
     /**
      * Returns the current authenticated user info if available.
      */
-    fun getCurrentUser(): UserInfo?
+    suspend fun getCurrentUser(): UserInfo?
 
     /**
      * Provides the headers required for authorized requests, refreshing the token if needed.

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/repository/OidcAuthRepository.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/repository/OidcAuthRepository.kt
@@ -14,6 +14,8 @@ import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.header
 import io.ktor.http.HttpHeaders
 import kotlin.io.encoding.Base64
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.publicvalue.multiplatform.oidc.OpenIdConnectClient
 import org.publicvalue.multiplatform.oidc.types.remote.AccessTokenResponse
 
@@ -30,6 +32,7 @@ class OidcAuthRepository @Inject constructor(
 ) : AuthRepository {
 
     private var isExchangingToken = false
+    private val refreshMutex = Mutex()
 
     // Safety margin to refresh tokens before they actually expire (5 minutes)
     private val REFRESH_SAFETY_MARGIN_MS = 5 * 60_000
@@ -42,7 +45,10 @@ class OidcAuthRepository @Inject constructor(
     }
 
     override suspend fun getAuthHeaders(): Map<String, String> {
-        refreshTokensIfNeeded()
+        if (!refreshTokensIfNeeded()) {
+            return emptyMap()
+        }
+
         val token = getAccessToken()
         return if (token != null) {
             mapOf(
@@ -76,7 +82,7 @@ class OidcAuthRepository @Inject constructor(
                 },
                 configureTokenExchange = configureTokenExchange
             )
-            handleTokenResponse(response)
+            handleTokenResponse(response, replaceSession = true)
         } catch (e: Exception) {
             logger.e(e) { "Login failed" }
             throw e
@@ -86,27 +92,39 @@ class OidcAuthRepository @Inject constructor(
     }
 
     override suspend fun refreshTokensIfNeeded(): Boolean {
-        val refreshToken = authStorage.retrieveStoredRefreshToken() ?: return false
-        val expirationTime = authStorage.retrieveTokenExpiration()
-        val currentTime = currentTimeMillis()
+        return refreshMutex.withLock {
+            if (authStorage.retrieveStoredAccessToken() == null) {
+                return@withLock false
+            }
 
-        // If current time is before the safety window, no refresh needed
-        if (currentTime < expirationTime - REFRESH_SAFETY_MARGIN_MS) {
-            return true
-        }
+            val refreshToken = authStorage.retrieveStoredRefreshToken()
+            val expirationTime = authStorage.retrieveTokenExpiration()
+            val currentTime = currentTimeMillis()
 
-        return try {
-            val response = oidcClient.refreshToken(
-                refreshToken = refreshToken,
-                configure = configureTokenExchange
-            )
-            handleTokenResponse(response)
-            true
-        } catch (e: Exception) {
-            logger.e(e) { "Token refresh failed, clearing session" }
-            // Critical: If refresh fails, session is invalid. Clear everything.
-            authStorage.clearAllTokens()
-            false
+            // If current time is before the safety window, no refresh needed.
+            if (currentTime < expirationTime - REFRESH_SAFETY_MARGIN_MS) {
+                return@withLock true
+            }
+
+            if (refreshToken == null) {
+                logger.e { "Token refresh required but no refresh token is stored, clearing session" }
+                authStorage.clearAllTokens()
+                return@withLock false
+            }
+
+            try {
+                val response = oidcClient.refreshToken(
+                    refreshToken = refreshToken,
+                    configure = configureTokenExchange
+                )
+                handleTokenResponse(response, replaceSession = false)
+                true
+            } catch (e: Exception) {
+                logger.e(e) { "Token refresh failed, clearing session" }
+                // Critical: If refresh fails, session is invalid. Clear everything.
+                authStorage.clearAllTokens()
+                false
+            }
         }
     }
 
@@ -133,13 +151,21 @@ class OidcAuthRepository @Inject constructor(
         authStorage.clearAllTokens()
     }
 
-    override fun getAccessToken(): String? = authStorage.retrieveStoredAccessToken()
-    override fun isLoggedIn(): Boolean = getAccessToken() != null
-    override fun getCurrentUser(): UserInfo? =
+    override suspend fun getAccessToken(): String? = authStorage.retrieveStoredAccessToken()
+    override suspend fun isLoggedIn(): Boolean = getAccessToken() != null
+    override suspend fun getCurrentUser(): UserInfo? =
         authStorage.retrieveUserInfo() ?: tryParseUserFromToken()
 
-    private suspend fun handleTokenResponse(response: AccessTokenResponse) {
-        authStorage.storeTokens(TokenResponse.fromOidc(response))
+    private suspend fun handleTokenResponse(
+        response: AccessTokenResponse,
+        replaceSession: Boolean
+    ) {
+        val tokenResponse = TokenResponse.fromOidc(response)
+        if (replaceSession) {
+            authStorage.storeNewSessionTokens(tokenResponse)
+        } else {
+            authStorage.storeTokens(tokenResponse)
+        }
         fetchAndStoreUserInfo()
     }
 
@@ -154,7 +180,7 @@ class OidcAuthRepository @Inject constructor(
         }
     }
 
-    private fun tryParseUserFromToken(): UserInfo? {
+    private suspend fun tryParseUserFromToken(): UserInfo? {
         val idToken = authStorage.retrieveStoredIdToken() ?: getAccessToken() ?: return null
         return UserInfo.fromJwt(idToken)
     }
@@ -173,7 +199,7 @@ class OidcAuthRepository @Inject constructor(
         try {
             val authFlow = AuthFlowFactoryProvider.factory.createAuthFlow(oidcClient)
             val response = authFlow.continueLogin(configureTokenExchange)
-            handleTokenResponse(response)
+            handleTokenResponse(response, replaceSession = true)
         } finally {
             isExchangingToken = false
         }

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/service/AuthService.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/service/AuthService.kt
@@ -30,40 +30,36 @@ class AuthService @Inject constructor(
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
     private val _authState = MutableStateFlow<AuthState>(AuthState.Idle)
+    private var cachedAccessToken: String? = null
 
     @NativeCoroutinesState
     val authState: StateFlow<AuthState> = _authState.asStateFlow()
 
     init {
-        checkCurrentSession()
-        checkPendingLogin()
-    }
-
-    private fun checkCurrentSession() {
-        if (authRepository.isLoggedIn()) {
-            val user = authRepository.getCurrentUser()
-            if (user != null) {
-                _authState.value = AuthState.Success(user)
-            }
+        scope.launch {
+            checkCurrentSession()
+            checkPendingLogin()
         }
     }
 
-    private fun checkPendingLogin() {
-        scope.launch {
-            try {
-                val oidcRepo = authRepository as? OidcAuthRepository
-                if (oidcRepo?.canContinueLogin() == true) {
-                    _authState.value = AuthState.Loading
-                    oidcRepo.continueLogin()
+    private suspend fun checkCurrentSession() {
+        if (!publishCurrentSession()) {
+            cachedAccessToken = null
+            _authState.value = AuthState.Idle
+        }
+    }
 
-                    val user = authRepository.getCurrentUser()
-                    if (user != null) {
-                        _authState.value = AuthState.Success(user)
-                    }
-                }
-            } catch (e: Exception) {
-                // Ignore - no pending login
+    private suspend fun checkPendingLogin() {
+        try {
+            val oidcRepo = authRepository as? OidcAuthRepository
+            if (oidcRepo?.canContinueLogin() == true) {
+                _authState.value = AuthState.Loading
+                oidcRepo.continueLogin()
+
+                publishCurrentSession()
             }
+        } catch (e: Exception) {
+            // Ignore - no pending login
         }
     }
 
@@ -73,11 +69,8 @@ class AuthService @Inject constructor(
         try {
             _authState.value = AuthState.Loading
             authRepository.login()
-            val user = authRepository.getCurrentUser()
-            if (user != null) {
-                _authState.value = AuthState.Success(user)
-            } else {
-                throw Exception("Failed to retrieve user info after login")
+            if (!publishCurrentSession()) {
+                throw Exception("Failed to persist authentication tokens after login")
             }
         } catch (e: Exception) {
             handleError(e, "Login failed")
@@ -90,11 +83,8 @@ class AuthService @Inject constructor(
         try {
             _authState.value = AuthState.Loading
             authRepository.loginWithReauthentication()
-            val user = authRepository.getCurrentUser()
-            if (user != null) {
-                _authState.value = AuthState.Success(user)
-            } else {
-                throw Exception("Failed to retrieve user info after login")
+            if (!publishCurrentSession()) {
+                throw Exception("Failed to persist authentication tokens after login")
             }
         } catch (e: Exception) {
             handleError(e, "Login failed")
@@ -106,6 +96,7 @@ class AuthService @Inject constructor(
     suspend fun logout(): Unit {
         try {
             authRepository.logout()
+            cachedAccessToken = null
             _authState.value = AuthState.Idle
         } catch (e: Exception) {
             handleError(e, "Logout failed")
@@ -115,23 +106,56 @@ class AuthService @Inject constructor(
 
     @NativeCoroutines
     suspend fun refreshAccessTokenIfNeeded(): Boolean {
-        return authRepository.refreshTokensIfNeeded()
+        val refreshed = authRepository.refreshTokensIfNeeded()
+        if (refreshed) {
+            publishCurrentSession()
+        } else {
+            cachedAccessToken = null
+            _authState.value = AuthState.Idle
+        }
+        return refreshed
     }
 
-    fun isLoggedIn(): Boolean = authRepository.isLoggedIn()
+    fun isLoggedIn(): Boolean = _authState.value is AuthState.Success
 
-    fun getAccessToken(): String? = authRepository.getAccessToken()
+    fun getAccessToken(): String? = cachedAccessToken
 
     @NativeCoroutines
-    suspend fun getAuthHeaders(): Map<String, String> = authRepository.getAuthHeaders()
+    suspend fun getAuthHeaders(): Map<String, String> {
+        val headers = authRepository.getAuthHeaders()
+        if (headers.isEmpty()) {
+            cachedAccessToken = null
+            _authState.value = AuthState.Idle
+        } else {
+            cachedAccessToken = authRepository.getAccessToken()
+        }
+        return headers
+    }
+
+    /**
+     * Publishes an authenticated session when token material is available, regardless of whether
+     * profile metadata is currently cached or fetchable.
+     */
+    private suspend fun publishCurrentSession(): Boolean {
+        if (!authRepository.isLoggedIn()) {
+            return false
+        }
+
+        cachedAccessToken = authRepository.getAccessToken()
+        if (cachedAccessToken == null) {
+            return false
+        }
+
+        _authState.value = AuthState.Success(authRepository.getCurrentUser())
+        return true
+    }
 
 
     fun clearError() {
         if (_authState.value is AuthState.Error) {
-            checkCurrentSession()
-            // If checkCurrentSession didn't find a session, default to Idle
-            if (_authState.value is AuthState.Error) {
-                _authState.value = AuthState.Idle
+            _authState.value = AuthState.Idle
+            scope.launch {
+                checkCurrentSession()
             }
         }
     }

--- a/auth/src/commonTest/kotlin/com/quran/shared/auth/persistence/AuthStorageTest.kt
+++ b/auth/src/commonTest/kotlin/com/quran/shared/auth/persistence/AuthStorageTest.kt
@@ -1,0 +1,180 @@
+package com.quran.shared.auth.persistence
+
+import com.quran.shared.auth.model.TokenResponse
+import com.quran.shared.auth.model.UserInfo
+import com.russhwolf.settings.MapSettings
+import com.russhwolf.settings.coroutines.toSuspendSettings
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.publicvalue.multiplatform.oidc.tokenstore.TokenStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AuthStorageTest {
+
+    @Test
+    fun `storeTokens persists OAuth tokens through TokenStore`() = runTest {
+        val tokenStore = RecordingTokenStore()
+        val storage = authStorage(tokenStore)
+
+        storage.storeTokens(
+            TokenResponse(
+                accessToken = "access-token",
+                refreshToken = "refresh-token",
+                idToken = "id-token",
+                expiresIn = 3600,
+                tokenType = "Bearer",
+                scope = "openid profile"
+            )
+        )
+
+        assertEquals("access-token", tokenStore.accessToken)
+        assertEquals("refresh-token", tokenStore.refreshToken)
+        assertEquals("id-token", tokenStore.idToken)
+        assertEquals("openid profile", storage.retrieveStoredScope())
+        assertEquals("access-token", storage.retrieveStoredAccessToken())
+        assertEquals("refresh-token", storage.retrieveStoredRefreshToken())
+        assertEquals("id-token", storage.retrieveStoredIdToken())
+    }
+
+    @Test
+    fun `storeTokens preserves refresh token when refresh response omits one`() = runTest {
+        val tokenStore = RecordingTokenStore(
+            accessToken = "old-access-token",
+            refreshToken = "stable-refresh-token",
+            idToken = "old-id-token"
+        )
+        val storage = authStorage(tokenStore)
+
+        storage.storeTokens(
+            TokenResponse(
+                accessToken = "new-access-token",
+                refreshToken = null,
+                idToken = null,
+                expiresIn = 3600,
+                tokenType = "Bearer"
+            )
+        )
+
+        assertEquals("new-access-token", tokenStore.accessToken)
+        assertEquals("stable-refresh-token", tokenStore.refreshToken)
+        assertEquals("old-id-token", tokenStore.idToken)
+    }
+
+    @Test
+    fun `storeNewSessionTokens clears stale identity metadata and does not preserve old tokens`() = runTest {
+        val tokenStore = RecordingTokenStore(
+            accessToken = "old-access-token",
+            refreshToken = "old-refresh-token",
+            idToken = "old-id-token"
+        )
+        val storage = authStorage(tokenStore)
+        storage.storeUserInfo(UserInfo(id = "old-user", name = "Old User"))
+
+        storage.storeNewSessionTokens(
+            TokenResponse(
+                accessToken = "new-access-token",
+                refreshToken = null,
+                idToken = null,
+                expiresIn = 3600,
+                tokenType = "Bearer"
+            )
+        )
+
+        assertEquals("new-access-token", tokenStore.accessToken)
+        assertNull(tokenStore.refreshToken)
+        assertNull(tokenStore.idToken)
+        assertNull(storage.retrieveUserInfo())
+    }
+
+    @Test
+    fun `clearAllTokens clears token store and auth metadata`() = runTest {
+        val tokenStore = RecordingTokenStore(
+            accessToken = "access-token",
+            refreshToken = "refresh-token",
+            idToken = "id-token"
+        )
+        val storage = authStorage(tokenStore)
+
+        storage.storeTokens(
+            TokenResponse(
+                accessToken = "access-token",
+                refreshToken = "refresh-token",
+                idToken = "id-token",
+                expiresIn = 3600,
+                tokenType = "Bearer",
+                scope = "openid profile"
+            )
+        )
+
+        storage.clearAllTokens()
+
+        assertNull(tokenStore.accessToken)
+        assertNull(tokenStore.refreshToken)
+        assertNull(tokenStore.idToken)
+        assertNull(storage.retrieveStoredScope())
+        assertEquals(0, storage.retrieveTokenExpiration())
+    }
+
+    private fun authStorage(tokenStore: RecordingTokenStore): AuthStorage {
+        return AuthStorage(
+            tokenStore = tokenStore,
+            settings = MapSettings().toSuspendSettings(),
+            json = Json { ignoreUnknownKeys = true }
+        )
+    }
+}
+
+private class RecordingTokenStore(
+    accessToken: String? = null,
+    refreshToken: String? = null,
+    idToken: String? = null
+) : TokenStore() {
+    private val accessTokenState = MutableStateFlow(accessToken)
+    private val refreshTokenState = MutableStateFlow(refreshToken)
+    private val idTokenState = MutableStateFlow(idToken)
+
+    var accessToken: String? = accessToken
+        private set
+    var refreshToken: String? = refreshToken
+        private set
+    var idToken: String? = idToken
+        private set
+
+    override val accessTokenFlow: StateFlow<String?> = accessTokenState
+    override val refreshTokenFlow: StateFlow<String?> = refreshTokenState
+    override val idTokenFlow: StateFlow<String?> = idTokenState
+
+    override suspend fun getAccessToken(): String? = accessToken
+
+    override suspend fun getRefreshToken(): String? = refreshToken
+
+    override suspend fun getIdToken(): String? = idToken
+
+    override suspend fun removeAccessToken() {
+        accessToken = null
+        accessTokenState.value = null
+    }
+
+    override suspend fun removeRefreshToken() {
+        refreshToken = null
+        refreshTokenState.value = null
+    }
+
+    override suspend fun removeIdToken() {
+        idToken = null
+        idTokenState.value = null
+    }
+
+    override suspend fun saveTokens(accessToken: String, refreshToken: String?, idToken: String?) {
+        this.accessToken = accessToken
+        this.refreshToken = refreshToken
+        this.idToken = idToken
+        accessTokenState.value = accessToken
+        refreshTokenState.value = refreshToken
+        idTokenState.value = idToken
+    }
+}

--- a/auth/src/commonTest/kotlin/com/quran/shared/auth/service/AuthServiceTest.kt
+++ b/auth/src/commonTest/kotlin/com/quran/shared/auth/service/AuthServiceTest.kt
@@ -1,0 +1,101 @@
+package com.quran.shared.auth.service
+
+import com.quran.shared.auth.model.AuthState
+import com.quran.shared.auth.model.UserInfo
+import com.quran.shared.auth.repository.AuthRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthServiceTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `stored token keeps session authenticated when profile is missing`() = runTest(dispatcher) {
+        val repository = RecordingAuthRepository(
+            accessToken = "access-token",
+            currentUser = null
+        )
+        val service = AuthService(repository)
+
+        advanceUntilIdle()
+
+        val state = assertIs<AuthState.Success>(service.authState.value)
+        assertNull(state.userInfo)
+        assertTrue(service.isLoggedIn())
+        assertEquals("access-token", service.getAccessToken())
+        assertEquals(
+            mapOf("Authorization" to "Bearer access-token"),
+            service.getAuthHeaders()
+        )
+    }
+
+    @Test
+    fun `login succeeds when profile fetch leaves user info missing`() = runTest(dispatcher) {
+        val repository = RecordingAuthRepository(
+            accessToken = null,
+            loginAccessToken = "login-access-token",
+            currentUser = null
+        )
+        val service = AuthService(repository)
+        advanceUntilIdle()
+
+        service.login()
+
+        val state = assertIs<AuthState.Success>(service.authState.value)
+        assertNull(state.userInfo)
+        assertTrue(service.isLoggedIn())
+        assertEquals("login-access-token", service.getAccessToken())
+    }
+}
+
+private class RecordingAuthRepository(
+    private var accessToken: String?,
+    private val loginAccessToken: String? = accessToken,
+    private val currentUser: UserInfo?
+) : AuthRepository {
+    override suspend fun login() {
+        accessToken = loginAccessToken
+    }
+
+    override suspend fun loginWithReauthentication() = Unit
+
+    override suspend fun refreshTokensIfNeeded(): Boolean = accessToken != null
+
+    override suspend fun logout() {
+        accessToken = null
+    }
+
+    override suspend fun getAccessToken(): String? = accessToken
+
+    override suspend fun isLoggedIn(): Boolean = accessToken != null
+
+    override suspend fun getCurrentUser(): UserInfo? = currentUser
+
+    override suspend fun getAuthHeaders(): Map<String, String> {
+        val token = accessToken ?: return emptyMap()
+        return mapOf("Authorization" to "Bearer $token")
+    }
+}

--- a/demo/android/src/main/kotlin/com/quran/shared/demo/android/MainActivity.kt
+++ b/demo/android/src/main/kotlin/com/quran/shared/demo/android/MainActivity.kt
@@ -8,6 +8,7 @@ import com.quran.shared.demo.android.ui.auth.AuthScreen
 import com.quran.shared.persistence.DriverFactory
 import com.quran.shared.pipeline.AppEnvironment
 import com.quran.shared.pipeline.di.SharedDependencyGraph
+import com.quran.shared.pipeline.storage.createMobileSyncStorage
 import com.quran.shared.demo.android.ui.SyncViewModel
 import org.publicvalue.multiplatform.oidc.appsupport.AndroidCodeAuthFlowFactory
 
@@ -31,6 +32,7 @@ class MainActivity : ComponentActivity() {
         val driverFactory = DriverFactory(context = this.applicationContext)
         val graph = SharedDependencyGraph.init(
             driverFactory = driverFactory,
+            storage = createMobileSyncStorage(this.applicationContext),
             appEnvironment = AppEnvironment.PRELIVE,
             clientId = BuildConfig.OAUTH_CLIENT_ID,
             clientSecret = BuildConfig.OAUTH_CLIENT_SECRET.takeIf { it.isNotBlank() }

--- a/demo/android/src/main/kotlin/com/quran/shared/demo/android/ui/auth/AuthScreen.kt
+++ b/demo/android/src/main/kotlin/com/quran/shared/demo/android/ui/auth/AuthScreen.kt
@@ -240,7 +240,7 @@ fun AuthScreen(
 
 @Composable
 private fun SuccessContent(
-    userInfo: UserInfo,
+    userInfo: UserInfo?,
     bookmarks: List<AyahBookmark>,
     readingBookmark: ReadingBookmark?,
     collectionsWithBookmarks: List<CollectionWithAyahBookmarks>,
@@ -286,11 +286,11 @@ private fun SuccessContent(
                 Spacer(modifier = Modifier.height(8.dp))
 
                 Text(
-                    text = "Welcome, ${userInfo.displayName ?: "User"}!",
+                    text = "Welcome, ${userInfo?.displayName ?: "User"}!",
                     style = MaterialTheme.typography.headlineSmall
                 )
 
-                userInfo.email?.let {
+                userInfo?.email?.let {
                     Text(
                         text = it,
                         style = MaterialTheme.typography.bodyMedium,

--- a/demo/android/src/main/res/xml/backup_rules.xml
+++ b/demo/android/src/main/res/xml/backup_rules.xml
@@ -6,6 +6,8 @@
    See https://developer.android.com/about/versions/12/backup-restore
 -->
 <full-backup-content>
+    <exclude domain="file" path="datastore/quran_mobile_sync_settings.preferences_pb"/>
+    <exclude domain="file" path="datastore/org.publicvalue.multiplatform.oidc.tokenstore.preferences_pb"/>
     <!--
    <include domain="sharedpref" path="."/>
    <exclude domain="sharedpref" path="device.xml"/>

--- a/demo/android/src/main/res/xml/data_extraction_rules.xml
+++ b/demo/android/src/main/res/xml/data_extraction_rules.xml
@@ -5,15 +5,11 @@
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <exclude domain="file" path="datastore/quran_mobile_sync_settings.preferences_pb"/>
+        <exclude domain="file" path="datastore/org.publicvalue.multiplatform.oidc.tokenstore.preferences_pb"/>
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <exclude domain="file" path="datastore/quran_mobile_sync_settings.preferences_pb"/>
+        <exclude domain="file" path="datastore/org.publicvalue.multiplatform.oidc.tokenstore.preferences_pb"/>
     </device-transfer>
-    -->
 </data-extraction-rules>

--- a/demo/apple/QuranSyncDemo/QuranSyncDemo/AppContainer.swift
+++ b/demo/apple/QuranSyncDemo/QuranSyncDemo/AppContainer.swift
@@ -24,9 +24,11 @@ final class AppContainer {
         Shared.AuthFlowFactoryProvider.shared.doInitialize()
 
         let driverFactory = DriverFactory()
+        let storage = AppleMobileSyncStorageFactory.shared.create()
 
         self.graph = SharedDependencyGraph.shared.doInit(
             driverFactory: driverFactory,
+            storage: storage,
             appEnvironment: AppEnvironment.prelive,
             clientId: AuthCredentials.clientId,
             clientSecret: AuthCredentials.clientSecret

--- a/demo/apple/QuranSyncDemo/QuranSyncDemo/AuthView.swift
+++ b/demo/apple/QuranSyncDemo/QuranSyncDemo/AuthView.swift
@@ -76,7 +76,7 @@ struct AuthView: View {
 
 struct SuccessTabView: View {
     @ObservedObject var viewModel: SyncViewModel
-    let userInfo: Shared.UserInfo
+    let userInfo: Shared.UserInfo?
     @State private var selectedTab = 0
     @State private var clearLocalData = false
     
@@ -85,9 +85,9 @@ struct SuccessTabView: View {
             // Mini Header
             HStack {
                 VStack(alignment: .leading) {
-                    Text("Welcome, \(userInfo.displayName ?? "User")!")
+                    Text("Welcome, \(userInfo?.displayName ?? "User")!")
                         .font(.headline)
-                    if let email = userInfo.email {
+                    if let email = userInfo?.email {
                         Text(email)
                             .font(.caption)
                             .foregroundColor(.secondary)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ oidc = "0.16.5"
 androidx-viewmodel = "2.10.0"
 androidx-appcompat = "1.7.1"
 androidx-activity = "1.13.0"
+androidx-datastore = "1.2.1"
 multiplatform-settings = "1.3.0"
 
 #KMP alternative to BuildConfig
@@ -83,6 +84,7 @@ compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview"
 
 #OIDC lib
 oidc-appsupport = { module = "io.github.kalinjul.kotlin.multiplatform:oidc-appsupport", version.ref = "oidc" }
+oidc-tokenstore = { module = "io.github.kalinjul.kotlin.multiplatform:oidc-tokenstore", version.ref = "oidc" }
 
 #KMP viewmodel
 androidx-lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-viewmodel" }
@@ -90,12 +92,16 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-viewmodel" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-viewmodel" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
+androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "androidx-datastore" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
 
 compose-material-icons-core = { module = "androidx.compose.material:material-icons-core" }
 compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 
 # KMP Settings
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatform-settings" }
+multiplatform-settings-coroutines = { module = "com.russhwolf:multiplatform-settings-coroutines", version.ref = "multiplatform-settings" }
+multiplatform-settings-datastore = { module = "com.russhwolf:multiplatform-settings-datastore", version.ref = "multiplatform-settings" }
 multiplatform-settings-no-arg = { module = "com.russhwolf:multiplatform-settings-no-arg", version.ref = "multiplatform-settings" }
 multiplatform-settings-test = { module = "com.russhwolf:multiplatform-settings-test", version.ref = "multiplatform-settings" }
 

--- a/sync-pipelines/build.gradle.kts
+++ b/sync-pipelines/build.gradle.kts
@@ -33,7 +33,12 @@ kotlin {
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.datetime)
             implementation(libs.kermit)
-            implementation(libs.multiplatform.settings.no.arg)
+            implementation(libs.androidx.datastore)
+            implementation(libs.androidx.datastore.preferences)
+            implementation(libs.multiplatform.settings)
+            implementation(libs.multiplatform.settings.coroutines)
+            implementation(libs.multiplatform.settings.datastore)
+            implementation(libs.oidc.tokenstore)
             api(libs.androidx.lifecycle.viewmodel)
             api(projects.syncengine)
             api(projects.persistence)
@@ -44,10 +49,15 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.multiplatform.settings.test)
         }
+
     }
 
     sourceSets.all {
+        languageSettings.optIn("com.russhwolf.settings.ExperimentalSettingsApi")
+        languageSettings.optIn("com.russhwolf.settings.ExperimentalSettingsImplementation")
+        languageSettings.optIn("org.publicvalue.multiplatform.oidc.ExperimentalOpenIdConnect")
         languageSettings.optIn("kotlin.time.ExperimentalTime")
     }
 

--- a/sync-pipelines/src/androidMain/kotlin/com/quran/shared/pipeline/storage/MobileSyncStorage.android.kt
+++ b/sync-pipelines/src/androidMain/kotlin/com/quran/shared/pipeline/storage/MobileSyncStorage.android.kt
@@ -1,0 +1,57 @@
+package com.quran.shared.pipeline.storage
+
+import android.content.Context
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.russhwolf.settings.datastore.DataStoreSettings
+import java.io.File
+import kotlin.concurrent.Volatile
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.internal.SynchronizedObject
+import kotlinx.coroutines.internal.synchronized
+import okio.Path.Companion.toPath
+import org.publicvalue.multiplatform.oidc.tokenstore.AndroidSettingsTokenStore
+
+@OptIn(InternalCoroutinesApi::class)
+private val storageLock = SynchronizedObject()
+
+@Volatile
+private var cachedStorage: MobileSyncStorage? = null
+
+/**
+ * Creates the Android storage configuration for [com.quran.shared.pipeline.di.SharedDependencyGraph].
+ *
+ * The returned instance is process-singleton so repeated Activity creation does not create multiple
+ * DataStore instances for the same file.
+ *
+ * @param context application or activity context. The application context is retained.
+ */
+@OptIn(InternalCoroutinesApi::class)
+fun createMobileSyncStorage(context: Context): MobileSyncStorage {
+    val appContext = context.applicationContext
+    return cachedStorage ?: synchronized(storageLock) {
+        cachedStorage ?: buildMobileSyncStorage(appContext).also { cachedStorage = it }
+    }
+}
+
+/**
+ * Object-style factory for Java and Android call sites that prefer a named owner.
+ */
+object AndroidMobileSyncStorageFactory {
+    fun create(context: Context): MobileSyncStorage = createMobileSyncStorage(context)
+}
+
+private fun buildMobileSyncStorage(context: Context): MobileSyncStorage {
+    val dataStore = PreferenceDataStoreFactory.createWithPath {
+        val file = File(
+            context.filesDir,
+            MobileSyncStorageNames.ANDROID_SYNC_SETTINGS_BACKUP_PATH
+        )
+        file.parentFile?.mkdirs()
+        file.absolutePath.toPath()
+    }
+
+    return MobileSyncStorage(
+        tokenStore = AndroidSettingsTokenStore(context),
+        settings = DataStoreSettings(dataStore)
+    )
+}

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncEnginePipeline.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncEnginePipeline.kt
@@ -50,8 +50,8 @@ import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 
 interface SyncEngineCallback {
-    fun synchronizationDone(newLastModificationDate: Long)
-    fun encounteredError(errorMsg: String)
+    suspend fun synchronizationDone(newLastModificationDate: Long)
+    suspend fun encounteredError(errorMsg: String)
 }
 
 @Inject

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncService.kt
@@ -24,13 +24,10 @@ import com.quran.shared.persistence.repository.note.repository.NotesRepository
 import com.quran.shared.persistence.repository.readingbookmark.repository.ReadingBookmarksRepository
 import com.quran.shared.persistence.repository.readingsession.repository.ReadingSessionsRepository
 import com.quran.shared.syncengine.AuthenticationDataFetcher
-import com.quran.shared.syncengine.LocalModificationDateFetcher
 import com.quran.shared.syncengine.SynchronizationClient
 import com.quran.shared.syncengine.SynchronizationEnvironment
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutinesState
-import com.russhwolf.settings.Settings
-import com.russhwolf.settings.set
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.CoroutineScope
@@ -59,7 +56,7 @@ class SyncService(
     private val environment: SynchronizationEnvironment,
     private val persistenceResetRepository: PersistenceResetRepository,
     private val persistenceImportRepository: PersistenceImportRepository,
-    private val settings: Settings
+    private val syncLocalModificationDateStore: SyncLocalModificationDateStore
 ) {
 
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
@@ -126,7 +123,6 @@ class SyncService(
     val readingSessions: Flow<List<ReadingSession>> get() = readingSessionsRepository.getReadingSessionsFlow()
 
     init {
-        val dateFetcher = SettingsLocalModificationDateFetcher(settings)
         val authFetcher = object : AuthenticationDataFetcher {
             override suspend fun fetchAuthenticationHeaders(): Map<String, String> {
                 return authService.getAuthHeaders()
@@ -139,15 +135,15 @@ class SyncService(
 
         syncClient = pipeline.setup(
             environment = environment,
-            localModificationDateFetcher = dateFetcher,
+            localModificationDateFetcher = syncLocalModificationDateStore,
             authenticationDataFetcher = authFetcher,
             callback = object : SyncEngineCallback {
-                override fun synchronizationDone(newLastModificationDate: Long) {
+                override suspend fun synchronizationDone(newLastModificationDate: Long) {
                     Logger.i { "Sync completed. New last modified: $newLastModificationDate" }
-                    dateFetcher.updateLastModificationDate(newLastModificationDate)
+                    syncLocalModificationDateStore.updateLastModificationDate(newLastModificationDate)
                 }
 
-                override fun encounteredError(errorMsg: String) {
+                override suspend fun encounteredError(errorMsg: String) {
                     Logger.e { "Sync error: $errorMsg" }
                 }
             }
@@ -174,7 +170,7 @@ class SyncService(
             syncClient.cancelSyncing()
             if (clearLocalData) {
                 persistenceResetRepository.deleteAllData()
-                SettingsLocalModificationDateFetcher(settings).updateLastModificationDate(0L)
+                syncLocalModificationDateStore.updateLastModificationDate(0L)
             }
         } catch (e: Exception) {
             Logger.e(e) { "Logout failed" }
@@ -504,19 +500,4 @@ class SyncService(
         collectionBookmarksRepository.getBookmarksForCollectionFlow(collectionLocalId)
 
     val pipelineForIos: SyncEnginePipeline get() = pipeline
-}
-
-fun makeSettings(): Settings = Settings()
-
-class SettingsLocalModificationDateFetcher(private val settings: Settings) :
-    LocalModificationDateFetcher {
-    private val KEY_LAST_MODIFIED = "com.quran.sync.last_modified_date"
-
-    override suspend fun localLastModificationDate(): Long {
-        return settings.getLong(KEY_LAST_MODIFIED, 0L)
-    }
-
-    fun updateLastModificationDate(date: Long) {
-        settings[KEY_LAST_MODIFIED] = date
-    }
 }

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncSettingsLocalModificationDateStore.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncSettingsLocalModificationDateStore.kt
@@ -1,0 +1,40 @@
+package com.quran.shared.pipeline
+
+import com.quran.shared.di.AppScope
+import com.quran.shared.syncengine.LocalModificationDateFetcher
+import com.russhwolf.settings.coroutines.SuspendSettings
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+
+/**
+ * Persists the shared remote sync token used to fetch incremental mutations.
+ */
+interface SyncLocalModificationDateStore : LocalModificationDateFetcher {
+    /**
+     * Stores the newest completed remote mutation timestamp.
+     *
+     * @param date epoch-millisecond mutation timestamp returned by the sync API.
+     */
+    suspend fun updateLastModificationDate(date: Long)
+}
+
+/**
+ * [SyncLocalModificationDateStore] backed by the graph-provided DataStore settings instance.
+ */
+@SingleIn(AppScope::class)
+class SyncSettingsLocalModificationDateStore @Inject constructor(
+    private val settings: SuspendSettings
+) : SyncLocalModificationDateStore {
+
+    override suspend fun localLastModificationDate(): Long {
+        return settings.getLong(KEY_LAST_MODIFIED, 0L)
+    }
+
+    override suspend fun updateLastModificationDate(date: Long) {
+        settings.putLong(KEY_LAST_MODIFIED, date)
+    }
+
+    private companion object {
+        const val KEY_LAST_MODIFIED = "com.quran.sync.last_modified_date"
+    }
+}

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/di/AppGraph.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/di/AppGraph.kt
@@ -15,6 +15,8 @@ import com.quran.shared.persistence.repository.readingsession.repository.Reading
 import com.quran.shared.pipeline.AppEnvironment
 import com.quran.shared.pipeline.SyncService
 import com.quran.shared.pipeline.defaultAppEnvironment
+import com.quran.shared.pipeline.storage.MobileSyncStorage
+import com.quran.shared.pipeline.storage.MobileSyncStorageModule
 import com.quran.shared.syncengine.SynchronizationEnvironment
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
@@ -35,7 +37,7 @@ import kotlin.concurrent.Volatile
  */
 @DependencyGraph(
     AppScope::class,
-    bindingContainers = [PersistenceModule::class, AuthModule::class]
+    bindingContainers = [PersistenceModule::class, AuthModule::class, MobileSyncStorageModule::class]
 )
 interface AppGraph {
     val syncService: SyncService
@@ -51,6 +53,7 @@ interface AppGraph {
     fun interface Factory {
         fun create(
             @Provides driverFactory: DriverFactory,
+            @Provides storage: MobileSyncStorage,
             @Provides environment: SynchronizationEnvironment,
             @Provides authConfig: AuthConfig
         ): AppGraph
@@ -65,22 +68,25 @@ object SharedDependencyGraph {
 
     private fun doInit(
         driverFactory: DriverFactory,
+        storage: MobileSyncStorage,
         environment: SynchronizationEnvironment,
         authConfig: AuthConfig
     ): AppGraph {
         return createGraphFactory<AppGraph.Factory>()
-            .create(driverFactory, environment, authConfig)
+            .create(driverFactory, storage, environment, authConfig)
             .also { instance = it }
     }
 
     @OptIn(InternalCoroutinesApi::class)
     fun init(
         driverFactory: DriverFactory,
+        storage: MobileSyncStorage,
         clientId: String,
         clientSecret: String? = null
     ): AppGraph {
         return init(
             driverFactory = driverFactory,
+            storage = storage,
             appEnvironment = defaultAppEnvironment(),
             clientId = clientId,
             clientSecret = clientSecret
@@ -90,12 +96,14 @@ object SharedDependencyGraph {
     @OptIn(InternalCoroutinesApi::class)
     fun init(
         driverFactory: DriverFactory,
+        storage: MobileSyncStorage,
         appEnvironment: AppEnvironment,
         clientId: String,
         clientSecret: String? = null
     ): AppGraph {
         return init(
             driverFactory = driverFactory,
+            storage = storage,
             environment = appEnvironment.synchronizationEnvironment(),
             authConfig = AuthConfig(
                 environment = appEnvironment.authEnvironment,
@@ -108,11 +116,12 @@ object SharedDependencyGraph {
     @OptIn(InternalCoroutinesApi::class)
     fun init(
         driverFactory: DriverFactory,
+        storage: MobileSyncStorage,
         environment: SynchronizationEnvironment,
         authConfig: AuthConfig
     ): AppGraph {
         return instance ?: synchronized(lock) {
-            instance ?: doInit(driverFactory, environment, authConfig)
+            instance ?: doInit(driverFactory, storage, environment, authConfig)
         }
     }
 }

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/storage/MobileSyncStorage.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/storage/MobileSyncStorage.kt
@@ -1,0 +1,31 @@
+package com.quran.shared.pipeline.storage
+
+import com.russhwolf.settings.coroutines.FlowSettings
+import org.publicvalue.multiplatform.oidc.tokenstore.TokenStore
+
+/**
+ * App-provided storage dependencies used by the shared sync graph.
+ *
+ * The public surface is intentionally opaque so app code does not need to depend on raw DataStore
+ * APIs. Platform factory helpers create a secure [TokenStore] for OAuth tokens and a named
+ * DataStore-backed settings instance for non-token sync/session metadata.
+ */
+class MobileSyncStorage internal constructor(
+    internal val tokenStore: TokenStore,
+    internal val settings: FlowSettings
+)
+
+/**
+ * Stable storage names and Android backup paths used by the shared library.
+ *
+ * Android apps that enable backup can exclude [ANDROID_SYNC_SETTINGS_BACKUP_PATH] and
+ * [ANDROID_OIDC_TOKENSTORE_BACKUP_PATH] from cloud backup and device transfer. The sync timestamp is
+ * derived remote-state cache, and restored token-store data can be invalid after Android keystore
+ * changes, so both files should normally be excluded.
+ */
+object MobileSyncStorageNames {
+    const val SYNC_SETTINGS_DATASTORE_FILE_NAME = "quran_mobile_sync_settings.preferences_pb"
+    const val ANDROID_SYNC_SETTINGS_BACKUP_PATH = "datastore/$SYNC_SETTINGS_DATASTORE_FILE_NAME"
+    const val ANDROID_OIDC_TOKENSTORE_BACKUP_PATH =
+        "datastore/org.publicvalue.multiplatform.oidc.tokenstore.preferences_pb"
+}

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/storage/MobileSyncStorageModule.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/storage/MobileSyncStorageModule.kt
@@ -1,0 +1,36 @@
+package com.quran.shared.pipeline.storage
+
+import com.quran.shared.di.AppScope
+import com.quran.shared.pipeline.SyncLocalModificationDateStore
+import com.quran.shared.pipeline.SyncSettingsLocalModificationDateStore
+import com.russhwolf.settings.coroutines.SuspendSettings
+import dev.zacsweers.metro.Binds
+import dev.zacsweers.metro.BindingContainer
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+import org.publicvalue.multiplatform.oidc.tokenstore.TokenStore
+
+@ContributesTo(AppScope::class)
+@BindingContainer
+abstract class MobileSyncStorageModule {
+
+    @Binds
+    abstract fun bindSyncLocalModificationDateStore(
+        impl: SyncSettingsLocalModificationDateStore
+    ): SyncLocalModificationDateStore
+
+    companion object {
+        @Provides
+        @SingleIn(AppScope::class)
+        fun provideTokenStore(storage: MobileSyncStorage): TokenStore {
+            return storage.tokenStore
+        }
+
+        @Provides
+        @SingleIn(AppScope::class)
+        fun provideSettings(storage: MobileSyncStorage): SuspendSettings {
+            return storage.settings
+        }
+    }
+}

--- a/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/ResultReceiverTest.kt
+++ b/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/ResultReceiverTest.kt
@@ -24,11 +24,11 @@ class ResultReceiverTest {
             bookmarksRepository = RecordingBookmarksRepository(events),
             readingBookmarksRepository = RecordingReadingBookmarksRepository(events),
             callback = object : SyncEngineCallback {
-                override fun synchronizationDone(newLastModificationDate: Long) {
+                override suspend fun synchronizationDone(newLastModificationDate: Long) {
                     events += "done-$newLastModificationDate"
                 }
 
-                override fun encounteredError(errorMsg: String) {
+                override suspend fun encounteredError(errorMsg: String) {
                     events += "error-$errorMsg"
                 }
             }
@@ -63,8 +63,8 @@ class ResultReceiverTest {
                 remoteUpdates = readingUpdates
             ),
             callback = object : SyncEngineCallback {
-                override fun synchronizationDone(newLastModificationDate: Long) = Unit
-                override fun encounteredError(errorMsg: String) = Unit
+                override suspend fun synchronizationDone(newLastModificationDate: Long) = Unit
+                override suspend fun encounteredError(errorMsg: String) = Unit
             }
         )
 

--- a/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/SyncSettingsLocalModificationDateStoreTest.kt
+++ b/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/SyncSettingsLocalModificationDateStoreTest.kt
@@ -1,0 +1,21 @@
+package com.quran.shared.pipeline
+
+import com.russhwolf.settings.MapSettings
+import com.russhwolf.settings.coroutines.toSuspendSettings
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SyncSettingsLocalModificationDateStoreTest {
+
+    @Test
+    fun `last modification date defaults to zero and persists updates`() = runTest {
+        val store = SyncSettingsLocalModificationDateStore(MapSettings().toSuspendSettings())
+
+        assertEquals(0L, store.localLastModificationDate())
+
+        store.updateLastModificationDate(1234L)
+
+        assertEquals(1234L, store.localLastModificationDate())
+    }
+}

--- a/sync-pipelines/src/iosMain/kotlin/com/quran/shared/pipeline/storage/MobileSyncStorage.apple.kt
+++ b/sync-pipelines/src/iosMain/kotlin/com/quran/shared/pipeline/storage/MobileSyncStorage.apple.kt
@@ -1,0 +1,63 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
+package com.quran.shared.pipeline.storage
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.russhwolf.settings.datastore.DataStoreSettings
+import kotlin.concurrent.Volatile
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.internal.SynchronizedObject
+import kotlinx.coroutines.internal.synchronized
+import okio.Path.Companion.toPath
+import org.publicvalue.multiplatform.oidc.tokenstore.IosKeychainTokenStore
+import platform.Foundation.NSApplicationSupportDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSURL
+import platform.Foundation.NSUserDomainMask
+
+@OptIn(InternalCoroutinesApi::class)
+private val storageLock = SynchronizedObject()
+
+@Volatile
+private var cachedStorage: MobileSyncStorage? = null
+
+/**
+ * Creates the Apple storage configuration for [com.quran.shared.pipeline.di.SharedDependencyGraph].
+ *
+ * The returned instance is process-singleton so app setup cannot accidentally create more than one
+ * DataStore for the sync metadata file.
+ */
+@OptIn(InternalCoroutinesApi::class)
+fun createMobileSyncStorage(): MobileSyncStorage {
+    return cachedStorage ?: synchronized(storageLock) {
+        cachedStorage ?: buildMobileSyncStorage().also { cachedStorage = it }
+    }
+}
+
+/**
+ * Object-style factory for Swift call sites.
+ */
+object AppleMobileSyncStorageFactory {
+    fun create(): MobileSyncStorage = createMobileSyncStorage()
+}
+
+private fun buildMobileSyncStorage(): MobileSyncStorage {
+    val dataStore = PreferenceDataStoreFactory.createWithPath {
+        "${applicationSupportDirectory().path}/${MobileSyncStorageNames.SYNC_SETTINGS_DATASTORE_FILE_NAME}".toPath()
+    }
+
+    return MobileSyncStorage(
+        tokenStore = IosKeychainTokenStore(),
+        settings = DataStoreSettings(dataStore)
+    )
+}
+
+private fun applicationSupportDirectory(): NSURL {
+    return NSFileManager.defaultManager.URLForDirectory(
+        directory = NSApplicationSupportDirectory,
+        inDomain = NSUserDomainMask,
+        appropriateForURL = null,
+        create = true,
+        error = null
+    ) ?: error("Unable to resolve Application Support directory for mobile-sync storage")
+}

--- a/sync-pipelines/src/jvmMain/kotlin/com/quran/shared/pipeline/storage/MobileSyncStorage.jvm.kt
+++ b/sync-pipelines/src/jvmMain/kotlin/com/quran/shared/pipeline/storage/MobileSyncStorage.jvm.kt
@@ -1,0 +1,72 @@
+package com.quran.shared.pipeline.storage
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.russhwolf.settings.datastore.DataStoreSettings
+import java.io.File
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.internal.SynchronizedObject
+import kotlinx.coroutines.internal.synchronized
+import okio.Path.Companion.toPath
+import org.publicvalue.multiplatform.oidc.tokenstore.SettingsStore
+import org.publicvalue.multiplatform.oidc.tokenstore.SettingsTokenStore
+
+@OptIn(InternalCoroutinesApi::class)
+private val storageLock = SynchronizedObject()
+
+private val cachedStorageByDirectory = mutableMapOf<String, MobileSyncStorage>()
+
+/**
+ * Creates a JVM storage configuration for tests and JVM sample hosts.
+ *
+ * Calls using the same normalized directory share one storage instance so DataStore does not
+ * create competing active stores for the same file. Different directories receive independent
+ * storage instances.
+ *
+ * @param directory directory where the sync metadata DataStore file should live.
+ */
+@OptIn(InternalCoroutinesApi::class)
+fun createMobileSyncStorage(
+    directory: File = File(System.getProperty("java.io.tmpdir"), "quran-mobile-sync")
+): MobileSyncStorage {
+    val storageDirectory = directory.toPath().toAbsolutePath().normalize().toFile()
+    val cacheKey = storageDirectory.absolutePath
+
+    return synchronized(storageLock) {
+        cachedStorageByDirectory.getOrPut(cacheKey) {
+            buildMobileSyncStorage(storageDirectory)
+        }
+    }
+}
+
+private fun buildMobileSyncStorage(directory: File): MobileSyncStorage {
+    val dataStore = PreferenceDataStoreFactory.createWithPath {
+        directory.mkdirs()
+        File(
+            directory,
+            MobileSyncStorageNames.SYNC_SETTINGS_DATASTORE_FILE_NAME
+        ).absolutePath.toPath()
+    }
+
+    return MobileSyncStorage(
+        tokenStore = SettingsTokenStore(InMemorySettingsStore()),
+        settings = DataStoreSettings(dataStore)
+    )
+}
+
+private class InMemorySettingsStore : SettingsStore {
+    private val values = mutableMapOf<String, String>()
+
+    override suspend fun get(key: String): String? = values[key]
+
+    override suspend fun put(key: String, value: String) {
+        values[key] = value
+    }
+
+    override suspend fun remove(key: String) {
+        values.remove(key)
+    }
+
+    override suspend fun clear() {
+        values.clear()
+    }
+}

--- a/sync-pipelines/src/jvmTest/kotlin/com/quran/shared/pipeline/storage/MobileSyncStorageJvmTest.kt
+++ b/sync-pipelines/src/jvmTest/kotlin/com/quran/shared/pipeline/storage/MobileSyncStorageJvmTest.kt
@@ -1,0 +1,28 @@
+package com.quran.shared.pipeline.storage
+
+import java.nio.file.Files
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MobileSyncStorageJvmTest {
+
+    @Test
+    fun `storage cache is scoped by requested directory`() = runTest {
+        val directoryA = Files.createTempDirectory("mobile-sync-a").toFile()
+        val directoryB = Files.createTempDirectory("mobile-sync-b").toFile()
+
+        val storageA = createMobileSyncStorage(directoryA)
+        val storageAAgain = createMobileSyncStorage(directoryA)
+        val storageB = createMobileSyncStorage(directoryB)
+
+        storageA.settings.putLong("test-key", 1L)
+        storageB.settings.putLong("test-key", 2L)
+
+        assertTrue(storageA === storageAAgain)
+        assertTrue(storageA !== storageB)
+        assertEquals(1L, storageAAgain.settings.getLong("test-key", 0L))
+        assertEquals(2L, storageB.settings.getLong("test-key", 0L))
+    }
+}

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClientImpl.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClientImpl.kt
@@ -70,6 +70,11 @@ internal class SynchronizationClientImpl(
         logger.i { "Starting sync operation for ${resourceAdapters.size} resource(s)" }
 
         val authHeaders = getAuthHeaders()
+        if (authHeaders.isEmpty()) {
+            logger.i { "No authentication headers available, skipping sync operation" }
+            return
+        }
+
         // Assume a shared sync token across resources.
         val lastModificationDate = resourceAdapters.first()
             .localModificationDateFetcher


### PR DESCRIPTION
This patch updates the library to use token storage for storage,
resulting in secure storage on both Android and iOS, instead of
SharedPreferences and NSUserDefaults. In iOS, it's stored in the
KeyChain, in Android, it's stored in DataStore but encrypted.

This also updates the normal storage to be stored in DataStore. On iOS,
this is a preference file in Application Support.
