### PR TITLE
Fix collection bookmark deletion

### DIFF
--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
@@ -228,7 +228,7 @@ class CollectionBookmarksRepositoryImpl(
     override suspend fun removeAyahBookmarkFromCollection(collectionAyahBookmark: CollectionAyahBookmark): Boolean {
         return withContext(Dispatchers.IO) {
             bookmarkCollectionQueries.value.deleteBookmarkFromCollection(
-                bookmark_local_id = collectionAyahBookmark.localId,
+                bookmark_local_id = collectionAyahBookmark.bookmarkLocalId,
                 collection_local_id = collectionAyahBookmark.collectionLocalId.toLong()
             )
             true

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionBookmarksRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionBookmarksRepositoryTest.kt
@@ -17,6 +17,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -194,9 +195,11 @@ class CollectionBookmarksRepositoryTest {
     fun `removeAyahBookmarkFromCollection removes the link using model`() = runTest {
         database.collectionsQueries.addNewCollection(name = "TestRemoveModel", timestamp = null)
         val collection = database.collectionsQueries.getCollectionByName("TestRemoveModel").executeAsOne()
+        bookmarksRepository.addBookmark(3, 1)
         val cb = repository.addAyahBookmarkToCollection(collection.local_id.toString(), 2, 1)
 
         val removed = repository.removeAyahBookmarkFromCollection(cb)
+        assertNotEquals(cb.localId, cb.bookmarkLocalId)
         assertTrue(removed)
         assertTrue(repository.getBookmarksForCollection(collection.local_id.toString()).isEmpty())
     }


### PR DESCRIPTION
## Summary
- Fix collection bookmark deletion to delete by bookmark local id instead of collection-bookmark local id.
- Add regression coverage where both ids differ.

## Validation
- ./gradlew :persistence:jvmTest --tests com.quran.shared.persistence.repository.CollectionBookmarksRepositoryTest