### PR TITLE
Expose reading session update API

### DIFF
--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncService.kt
@@ -315,6 +315,35 @@ class SyncService(
     }
 
     @NativeCoroutines
+    suspend fun updateReadingSession(localId: String, sura: Int, ayah: Int): ReadingSession {
+        try {
+            val readingSession = readingSessionsRepository.updateReadingSession(localId, sura, ayah)
+            triggerSync()
+            return readingSession
+        } catch (e: Exception) {
+            Logger.e(e) { "Failed to update reading session" }
+            throw e
+        }
+    }
+
+    @NativeCoroutines
+    suspend fun updateReadingSession(
+        localId: String,
+        sura: Int,
+        ayah: Int,
+        timestamp: PlatformDateTime
+    ): ReadingSession {
+        try {
+            val readingSession = readingSessionsRepository.updateReadingSession(localId, sura, ayah, timestamp)
+            triggerSync()
+            return readingSession
+        } catch (e: Exception) {
+            Logger.e(e) { "Failed to update reading session" }
+            throw e
+        }
+    }
+
+    @NativeCoroutines
     suspend fun deleteReadingBookmark(): Boolean {
         try {
             val deleted = readingBookmarksRepository.deleteReadingBookmark()


### PR DESCRIPTION
## Summary
- Add `SyncService.updateReadingSession(...)` overloads.
- Route updates through the existing reading sessions repository.
- Trigger sync after reading session updates.

## Validation
- `./gradlew :sync-pipelines:compileKotlinJvm :persistence:jvmTest --tests com.quran.shared.persistence.repository.ReadingSessionsRepositoryTest`
- Local iOS simulator validation with the SPM/iOS branches confirmed selected reading session updates in place.