### PR TITLE
Do not block making the graph on empty token

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,17 +131,14 @@ Do not declare or export
 If you override `AuthConfig.redirectUri` or `AuthConfig.postLogoutRedirectUri` on Android, keep
 the corresponding manifest placeholders aligned with those URIs.
 
+Graph construction does not require an Android `Activity`. Build the graph from application
+context and runtime configuration:
+
 ```kotlin
-import com.quran.shared.auth.di.AuthFlowFactoryProvider
 import com.quran.shared.persistence.DriverFactory
 import com.quran.shared.pipeline.AppEnvironment
 import com.quran.shared.pipeline.di.SharedDependencyGraph
 import com.quran.shared.pipeline.storage.createMobileSyncStorage
-import org.publicvalue.multiplatform.oidc.appsupport.AndroidCodeAuthFlowFactory
-
-val authFactory = AndroidCodeAuthFlowFactory(useWebView = false)
-authFactory.registerActivity(activity)
-AuthFlowFactoryProvider.initialize(authFactory)
 
 val graph = SharedDependencyGraph.init(
     driverFactory = DriverFactory(context = applicationContext),
@@ -152,6 +149,29 @@ val graph = SharedDependencyGraph.init(
 
 val authService = graph.authService
 val syncService = graph.syncService
+```
+
+If `clientId` is blank, the same initializer creates a managed local-only graph. `SyncService`
+continues to read and write local data, while `SyncAuthService.isAuthenticationConfigured` is
+`false` and sign-in fails with an authentication-not-configured error. This lets open-source builds
+run without bundled OAuth credentials.
+
+Register the Android browser auth flow only before interactive sign-in. The registered `Activity`
+handles browser launch and redirect delivery; it is not needed for graph construction or local data
+operations.
+
+```kotlin
+import com.quran.shared.auth.di.AuthFlowFactoryProvider
+import org.publicvalue.multiplatform.oidc.appsupport.AndroidCodeAuthFlowFactory
+
+if (graph.authService.isAuthenticationConfigured) {
+    val authFactory = AndroidCodeAuthFlowFactory(useWebView = false)
+    authFactory.registerActivity(activity)
+    AuthFlowFactoryProvider.initialize(authFactory)
+}
+
+// Later, from the login UI:
+graph.authService.login()
 ```
 
 ### 2. Initialize managed app graph (iOS/Swift)

--- a/auth/README.md
+++ b/auth/README.md
@@ -87,6 +87,10 @@ val graph = SharedDependencyGraph.init(
 )
 ```
 
+When `appClientId` is blank, the managed graph still initializes for local data usage. Sign-in is
+unavailable in that mode, and callers can check `graph.authService.isAuthenticationConfigured`
+before showing authentication UI.
+
 ### 3. 📦 Installation
 ```kotlin
 // auth/build.gradle.kts
@@ -98,7 +102,7 @@ plugins {
 implementation(project(":auth"))
 ```
 
-### 4. ⚙️ Platform Initialization
+### 4. ⚙️ Platform Login Setup
 
 #### **Android (`MainActivity.kt`)**
 
@@ -122,9 +126,15 @@ Do not declare or export
 If you override `AuthConfig.redirectUri` or `AuthConfig.postLogoutRedirectUri` on Android, keep
 the corresponding manifest placeholders aligned with those URIs.
 
+Graph construction does not require an Android `Activity`. Register the Activity-backed browser
+auth flow only before calling `graph.authService.login()`:
+
 ```kotlin
-val factory = AndroidCodeAuthFlowFactory(this)
-AuthFlowFactoryProvider.initialize(factory)
+if (graph.authService.isAuthenticationConfigured) {
+    val factory = AndroidCodeAuthFlowFactory(useWebView = false)
+    factory.registerActivity(activity)
+    AuthFlowFactoryProvider.initialize(factory)
+}
 ```
 
 #### **iOS (App Entry Point)**

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/di/AuthModule.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/di/AuthModule.kt
@@ -1,10 +1,13 @@
 package com.quran.shared.auth.di
 
 import com.quran.shared.auth.model.AuthConfig
+import com.quran.shared.auth.model.AuthRuntimeConfig
+import com.quran.shared.auth.persistence.AuthStorage
 import com.quran.shared.auth.repository.AuthRepository
+import com.quran.shared.auth.repository.AuthNetworkDataSource
 import com.quran.shared.auth.repository.OidcAuthRepository
+import com.quran.shared.auth.repository.UnconfiguredAuthRepository
 import com.quran.shared.di.AppScope
-import dev.zacsweers.metro.Binds
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Provides
@@ -28,9 +31,6 @@ import org.publicvalue.multiplatform.oidc.types.CodeChallengeMethod
 @HiddenFromObjC
 abstract class AuthModule {
 
-    @Binds
-    abstract fun bindAuthRepository(impl: OidcAuthRepository): AuthRepository
-
     companion object {
         @Provides
         @SingleIn(AppScope::class)
@@ -43,7 +43,30 @@ abstract class AuthModule {
 
         @Provides
         @SingleIn(AppScope::class)
-        fun provideHttpClient(json: Json, config: AuthConfig): HttpClient {
+        fun provideAuthRepository(
+            runtimeConfig: AuthRuntimeConfig,
+            authStorage: AuthStorage,
+            json: Json
+        ): AuthRepository {
+            return when (runtimeConfig) {
+                is AuthRuntimeConfig.Configured -> {
+                    val httpClient = createHttpClient(json, runtimeConfig.config)
+                    val oidcClient = createOpenIdConnectClient(runtimeConfig.config, httpClient)
+                    OidcAuthRepository(
+                        authConfig = runtimeConfig.config,
+                        authStorage = authStorage,
+                        oidcClient = oidcClient,
+                        networkDataSource = AuthNetworkDataSource(
+                            authConfig = runtimeConfig.config,
+                            httpClient = httpClient
+                        )
+                    )
+                }
+                AuthRuntimeConfig.Unconfigured -> UnconfiguredAuthRepository(authStorage)
+            }
+        }
+
+        private fun createHttpClient(json: Json, config: AuthConfig): HttpClient {
             return HttpClient {
                 install(Logging) {
                     logger = object : Logger {
@@ -57,9 +80,7 @@ abstract class AuthModule {
             }
         }
 
-        @Provides
-        @SingleIn(AppScope::class)
-        fun provideOpenIdConnectClient(
+        private fun createOpenIdConnectClient(
             config: AuthConfig,
             httpClient: HttpClient
         ): OpenIdConnectClient {

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/model/AuthRuntimeConfig.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/model/AuthRuntimeConfig.kt
@@ -1,0 +1,29 @@
+package com.quran.shared.auth.model
+
+import kotlin.native.HiddenFromObjC
+
+/**
+ * Runtime authentication mode for a managed mobile-sync graph.
+ *
+ * [Configured] is used when the consuming app provides valid OIDC metadata and interactive
+ * authentication can run. [Unconfigured] keeps the managed graph usable for local-first data in
+ * open-source or otherwise uncredentialed builds while making sign-in unavailable.
+ */
+@HiddenFromObjC
+sealed interface AuthRuntimeConfig {
+    /**
+     * Authentication is backed by the supplied OIDC configuration.
+     */
+    data class Configured(val config: AuthConfig) : AuthRuntimeConfig
+
+    /**
+     * Authentication credentials are not available for this build.
+     */
+    data object Unconfigured : AuthRuntimeConfig
+
+    /**
+     * Returns true when interactive authentication can be attempted.
+     */
+    val isConfigured: Boolean
+        get() = this is Configured
+}

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/repository/UnconfiguredAuthRepository.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/repository/UnconfiguredAuthRepository.kt
@@ -1,0 +1,65 @@
+package com.quran.shared.auth.repository
+
+import com.quran.shared.auth.model.UserInfo
+import com.quran.shared.auth.persistence.AuthStorage
+import com.quran.shared.di.AppScope
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlin.native.HiddenFromObjC
+
+/**
+ * Thrown when a build without authentication credentials attempts an interactive auth operation.
+ */
+class AuthNotConfiguredException : IllegalStateException(
+    "Authentication is not configured for this build."
+)
+
+/**
+ * Auth repository used when the managed graph is initialized without OIDC credentials.
+ *
+ * It keeps sync-capable apps on the managed [com.quran.shared.pipeline.SyncService] path while
+ * making remote authentication unavailable. Sync attempts receive empty headers and no-op before
+ * network work starts.
+ */
+@SingleIn(AppScope::class)
+@HiddenFromObjC
+class UnconfiguredAuthRepository @Inject constructor(
+    private val authStorage: AuthStorage
+) : AuthRepository {
+    override suspend fun login() {
+        throw AuthNotConfiguredException()
+    }
+
+    override suspend fun loginWithReauthentication() {
+        throw AuthNotConfiguredException()
+    }
+
+    override suspend fun refreshTokensIfNeeded(): Boolean {
+        clearLocalSession()
+        return false
+    }
+
+    override suspend fun logout() {
+        clearLocalSession()
+    }
+
+    override suspend fun captureLogoutTokenMaterial(): LogoutTokenMaterial =
+        LogoutTokenMaterial(refreshToken = null, idToken = null)
+
+    override suspend fun clearLocalSession() {
+        // Clear stale token material so an install that moves between configured and unconfigured
+        // builds cannot publish or reuse an old session without explicit credentials.
+        authStorage.clearAllTokens()
+    }
+
+    override suspend fun attemptRemoteLogout(tokenMaterial: LogoutTokenMaterial): List<RemoteLogoutFailure> =
+        emptyList()
+
+    override suspend fun getAccessToken(): String? = null
+
+    override suspend fun isLoggedIn(): Boolean = false
+
+    override suspend fun getCurrentUser(): UserInfo? = null
+
+    override suspend fun getAuthHeaders(): Map<String, String> = emptyMap()
+}

--- a/auth/src/commonTest/kotlin/com/quran/shared/auth/repository/UnconfiguredAuthRepositoryTest.kt
+++ b/auth/src/commonTest/kotlin/com/quran/shared/auth/repository/UnconfiguredAuthRepositoryTest.kt
@@ -1,0 +1,160 @@
+package com.quran.shared.auth.repository
+
+import com.quran.shared.auth.di.AuthModule
+import com.quran.shared.auth.model.AuthRuntimeConfig
+import com.quran.shared.auth.model.TokenResponse
+import com.quran.shared.auth.persistence.AuthStorage
+import com.russhwolf.settings.MapSettings
+import com.russhwolf.settings.coroutines.toSuspendSettings
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.publicvalue.multiplatform.oidc.tokenstore.TokenStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class UnconfiguredAuthRepositoryTest {
+    @Test
+    fun `auth module provides unconfigured repository without oidc metadata`() = runTest {
+        val repository = AuthModule.provideAuthRepository(
+            runtimeConfig = AuthRuntimeConfig.Unconfigured,
+            authStorage = authStorage(UnconfiguredRecordingTokenStore()),
+            json = Json { ignoreUnknownKeys = true }
+        )
+
+        assertTrue(repository is UnconfiguredAuthRepository)
+        assertEquals(emptyMap(), repository.getAuthHeaders())
+    }
+
+    @Test
+    fun `unconfigured auth exposes no authenticated session`() = runTest {
+        val repository = UnconfiguredAuthRepository(authStorage = authStorage(UnconfiguredRecordingTokenStore()))
+
+        assertFailsWith<AuthNotConfiguredException> {
+            repository.login()
+        }
+        assertFailsWith<AuthNotConfiguredException> {
+            repository.loginWithReauthentication()
+        }
+        assertFalse(repository.refreshTokensIfNeeded())
+        assertFalse(repository.isLoggedIn())
+        assertEquals(emptyMap(), repository.getAuthHeaders())
+        assertNull(repository.getAccessToken())
+        assertNull(repository.getCurrentUser())
+        assertEquals(
+            LogoutTokenMaterial(refreshToken = null, idToken = null),
+            repository.captureLogoutTokenMaterial()
+        )
+        assertEquals(
+            emptyList(),
+            repository.attemptRemoteLogout(LogoutTokenMaterial(refreshToken = "refresh", idToken = "id"))
+        )
+    }
+
+    @Test
+    fun `unconfigured auth clears stale stored token data`() = runTest {
+        val tokenStore = UnconfiguredRecordingTokenStore()
+        val storage = authStorage(tokenStore)
+        storage.storeNewSessionTokens(
+            TokenResponse(
+                accessToken = "access-token",
+                refreshToken = "refresh-token",
+                idToken = "id-token",
+                expiresIn = 3600,
+                tokenType = "Bearer",
+                scope = "openid"
+            )
+        )
+
+        UnconfiguredAuthRepository(storage).clearLocalSession()
+
+        assertNull(tokenStore.accessToken)
+        assertNull(tokenStore.refreshToken)
+        assertNull(tokenStore.idToken)
+        assertNull(storage.retrieveStoredScope())
+        assertNull(storage.retrieveCommittedTokenGeneration())
+    }
+
+    @Test
+    fun `unconfigured startup refresh clears stale stored token data`() = runTest {
+        val tokenStore = UnconfiguredRecordingTokenStore()
+        val storage = authStorage(tokenStore)
+        storage.storeNewSessionTokens(
+            TokenResponse(
+                accessToken = "access-token",
+                refreshToken = "refresh-token",
+                idToken = "id-token",
+                expiresIn = 3600,
+                tokenType = "Bearer",
+                scope = "openid"
+            )
+        )
+
+        assertFalse(UnconfiguredAuthRepository(storage).refreshTokensIfNeeded())
+
+        assertNull(tokenStore.accessToken)
+        assertNull(tokenStore.refreshToken)
+        assertNull(tokenStore.idToken)
+        assertNull(storage.retrieveStoredScope())
+        assertNull(storage.retrieveCommittedTokenGeneration())
+    }
+
+    private fun authStorage(tokenStore: UnconfiguredRecordingTokenStore): AuthStorage =
+        AuthStorage(
+            tokenStore = tokenStore,
+            settings = MapSettings().toSuspendSettings(),
+            json = Json { ignoreUnknownKeys = true }
+        )
+}
+
+private class UnconfiguredRecordingTokenStore : TokenStore() {
+    private val accessTokenState = MutableStateFlow<String?>(null)
+    private val refreshTokenState = MutableStateFlow<String?>(null)
+    private val idTokenState = MutableStateFlow<String?>(null)
+
+    var accessToken: String? = null
+        private set
+    var refreshToken: String? = null
+        private set
+    var idToken: String? = null
+        private set
+
+    override val accessTokenFlow: StateFlow<String?> = accessTokenState
+    override val refreshTokenFlow: StateFlow<String?> = refreshTokenState
+    override val idTokenFlow: StateFlow<String?> = idTokenState
+
+    override suspend fun getAccessToken(): String? = accessToken
+
+    override suspend fun getRefreshToken(): String? = refreshToken
+
+    override suspend fun getIdToken(): String? = idToken
+
+    override suspend fun removeAccessToken() {
+        accessToken = null
+        accessTokenState.value = null
+    }
+
+    override suspend fun removeRefreshToken() {
+        refreshToken = null
+        refreshTokenState.value = null
+    }
+
+    override suspend fun removeIdToken() {
+        idToken = null
+        idTokenState.value = null
+    }
+
+    override suspend fun saveTokens(accessToken: String, refreshToken: String?, idToken: String?) {
+        this.accessToken = accessToken
+        this.refreshToken = refreshToken
+        this.idToken = idToken
+        accessTokenState.value = accessToken
+        refreshTokenState.value = refreshToken
+        idTokenState.value = idToken
+    }
+}

--- a/demo/android/src/main/kotlin/com/quran/shared/demo/android/MainActivity.kt
+++ b/demo/android/src/main/kotlin/com/quran/shared/demo/android/MainActivity.kt
@@ -16,8 +16,8 @@ import org.publicvalue.multiplatform.oidc.appsupport.AndroidCodeAuthFlowFactory
  * Main activity for the Android demo app.
  *
  * Key responsibilities:
- * - Initialize the AndroidCodeAuthFlowFactory for OAuth browser flow
- * - Register the factory with AuthFlowFactoryProvider for use by the auth module
+ * - Build the managed sync graph without requiring an Activity
+ * - Register the Activity-backed OAuth browser flow before interactive login
  * - Display the authentication screen
  * - Initialize and Start Sync Engine
  *
@@ -43,19 +43,22 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        
-        // Register this activity with the factory for browser auth
-        codeAuthFlowFactory.registerActivity(this)
-        
-        // Initialize the global factory provider so the auth module can access it
-        AuthFlowFactoryProvider.initialize(codeAuthFlowFactory)
+
+        val viewModel = mainViewModel
+
+        if (viewModel.isAuthenticationConfigured) {
+            // Graph construction above is Activity-free. The Activity-backed factory is only
+            // required for interactive browser login and redirect handling.
+            codeAuthFlowFactory.registerActivity(this)
+            AuthFlowFactoryProvider.initialize(codeAuthFlowFactory)
+        }
 
         setContent {
             AuthScreen(
-                viewModel = mainViewModel,
+                viewModel = viewModel,
                 onAuthenticationSuccess = {
                     println("Authentication successful!")
-                    mainViewModel.triggerSync()
+                    viewModel.triggerSync()
                 }
             )
         }

--- a/demo/android/src/main/kotlin/com/quran/shared/demo/android/ui/SyncViewModel.kt
+++ b/demo/android/src/main/kotlin/com/quran/shared/demo/android/ui/SyncViewModel.kt
@@ -20,6 +20,7 @@ class SyncViewModel(
 ) : ViewModel() {
 
     val authState: StateFlow<com.quran.shared.auth.model.AuthState> = service.authState
+    val isAuthenticationConfigured: Boolean = authService.isAuthenticationConfigured
     
     val bookmarks: Flow<List<AyahBookmark>> = service.bookmarks
     val readingBookmark: Flow<ReadingBookmark?> = service.readingBookmark

--- a/demo/android/src/main/kotlin/com/quran/shared/demo/android/ui/auth/AuthScreen.kt
+++ b/demo/android/src/main/kotlin/com/quran/shared/demo/android/ui/auth/AuthScreen.kt
@@ -20,6 +20,7 @@ import com.quran.shared.demo.common.util.QuranActionsUtils.getRandomAyah
 import com.quran.shared.demo.common.util.QuranActionsUtils.getRandomPage
 import com.quran.shared.demo.common.util.QuranActionsUtils.getRandomSura
 import com.quran.shared.demo.android.ui.SyncViewModel
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 /**
@@ -36,6 +37,7 @@ fun AuthScreen(
     val collectionsWithBookmarks by viewModel.collectionsWithBookmarks.collectAsState(initial = emptyList())
     val notes by viewModel.notes.collectAsState(initial = emptyList())
     val readingSessions by viewModel.readingSessions.collectAsState(initial = emptyList())
+    val authenticationConfigured = viewModel.isAuthenticationConfigured
 
     val scope = rememberCoroutineScope()
     Box(
@@ -59,7 +61,11 @@ fun AuthScreen(
             )
 
             Text(
-                text = "Sign in with Quran Foundation",
+                text = if (authenticationConfigured) {
+                    "Sign in with Quran Foundation"
+                } else {
+                    "Local demo storage"
+                },
                 style = MaterialTheme.typography.bodyLarge,
                 textAlign = TextAlign.Center,
                 modifier = Modifier.padding(bottom = 32.dp),
@@ -69,24 +75,59 @@ fun AuthScreen(
             // Content based on auth state
             when (val state = authState) {
                 is AuthState.Idle -> {
-                    LoginButtonContent(
-                        onLoginClick = {
-                            scope.launch {
-                                try {
-                                    viewModel.login()
-                                } catch (e: Exception) {
+                    if (authenticationConfigured) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            LoginButtonContent(
+                                onLoginClick = {
+                                    scope.launch {
+                                        try {
+                                            viewModel.login()
+                                        } catch (e: Exception) {
+                                        }
+                                    }
+                                },
+                                onReauthenticateLoginClick = {
+                                    scope.launch {
+                                        try {
+                                            viewModel.loginWithReauthentication()
+                                        } catch (e: Exception) {
+                                        }
+                                    }
                                 }
-                            }
-                        },
-                        onReauthenticateLoginClick = {
-                            scope.launch {
-                                try {
-                                    viewModel.loginWithReauthentication()
-                                } catch (e: Exception) {
-                                }
-                            }
+                            )
+
+                            Spacer(modifier = Modifier.height(24.dp))
+
+                            LocalDataContent(
+                                eventScope = scope,
+                                viewModel = viewModel,
+                                userInfo = null,
+                                signedIn = false,
+                                statusMessage = "Signed out. Local changes are available before sign-in.",
+                                bookmarks = bookmarks,
+                                readingBookmark = readingBookmark,
+                                collectionsWithBookmarks = collectionsWithBookmarks,
+                                notes = notes,
+                                readingSessions = readingSessions
+                            )
                         }
-                    )
+                    } else {
+                        LocalDataContent(
+                            eventScope = scope,
+                            viewModel = viewModel,
+                            userInfo = null,
+                            signedIn = false,
+                            statusMessage = "OAuth credentials are not configured for this build.",
+                            bookmarks = bookmarks,
+                            readingBookmark = readingBookmark,
+                            collectionsWithBookmarks = collectionsWithBookmarks,
+                            notes = notes,
+                            readingSessions = readingSessions
+                        )
+                    }
                 }
 
                 is AuthState.Loading -> {
@@ -94,126 +135,17 @@ fun AuthScreen(
                 }
 
                 is AuthState.Success -> {
-                    SuccessContent(
+                    LocalDataContent(
+                        eventScope = scope,
+                        viewModel = viewModel,
                         userInfo = state.userInfo,
+                        signedIn = true,
+                        statusMessage = null,
                         bookmarks = bookmarks,
                         readingBookmark = readingBookmark,
                         collectionsWithBookmarks = collectionsWithBookmarks,
                         notes = notes,
-                        onAddAyahBookmark = {
-                            val sura = getRandomSura()
-                            val ayah = getRandomAyah(sura)
-                            scope.launch {
-                                try {
-                                    viewModel.addBookmark(sura, ayah)
-                                } catch (e: Exception) {
-                                }
-                            }
-                        },
-                        onAddReadingAyahBookmark = {
-                            val sura = getRandomSura()
-                            val ayah = getRandomAyah(sura)
-                            scope.launch {
-                                try {
-                                    viewModel.addAyahReadingBookmark(sura, ayah)
-                                } catch (e: Exception) {
-                                }
-                            }
-                        },
-                        onAddReadingPageBookmark = {
-                            val page = getRandomPage()
-                            scope.launch {
-                                try {
-                                    viewModel.addPageReadingBookmark(page)
-                                } catch (e: Exception) {
-                                }
-                            }
-                        },
-                        onDeleteBookmark = {
-                            scope.launch {
-                                try {
-                                    viewModel.deleteBookmark(it)
-                                } catch (e: Exception) {
-                                }
-                            }
-                        },
-                        onDeleteReadingBookmark = {
-                            scope.launch {
-                                try {
-                                    viewModel.deleteReadingBookmark()
-                                } catch (e: Exception) {
-                                }
-                            }
-                        },
-                        onAddCollection = { name ->
-                            scope.launch {
-                                try {
-                                    viewModel.addCollection(name)
-                                } catch (e: Exception) {
-                                }
-                            }
-                        },
-                        onDeleteCollection = { id ->
-                            scope.launch {
-                                try {
-                                    viewModel.deleteCollection(id)
-                                } catch (e: Exception) {
-                                }
-                            }
-                        },
-                        onAddNote = { body ->
-                            val sura = getRandomSura()
-                            val ayah = getRandomAyah(sura)
-                            scope.launch {
-                                try {
-                                    viewModel.addNote(
-                                        body,
-                                        sura,
-                                        ayah,
-                                        sura,
-                                        ayah
-                                    )
-                                } catch (e: Exception) {
-                                }
-                            } // Just dummy range for now
-                        },
-                        onDeleteNote = { id ->
-                            scope.launch {
-                                try {
-                                    viewModel.deleteNote(id)
-                                } catch (e: Exception) {
-                                }
-                            }
-                        },
-                        onLogout = {
-                            scope.launch {
-                                try {
-                                    viewModel.logout()
-                                } catch (e: Exception) {
-                                }
-                            }
-                        },
-                        onAddRandomBookmarkToCollection = { id ->
-                            scope.launch {
-                                try {
-                                    val sura = getRandomSura()
-                                    val ayah = getRandomAyah(sura)
-                                    viewModel.addAyahBookmarkToCollection(id, sura, ayah)
-                                } catch (e: Exception) {
-                                }
-                            }
-                        },
-                        readingSessions = readingSessions,
-                        onAddReadingSession = {
-                            val sura = getRandomSura()
-                            val ayah = getRandomAyah(sura)
-                            scope.launch {
-                                try {
-                                    viewModel.addReadingSession(sura, ayah)
-                                } catch (e: Exception) {
-                                }
-                            }
-                        }
+                        readingSessions = readingSessions
                     )
                 }
 
@@ -239,8 +171,148 @@ fun AuthScreen(
 }
 
 @Composable
-private fun SuccessContent(
+private fun LocalDataContent(
+    eventScope: CoroutineScope,
+    viewModel: SyncViewModel,
     userInfo: UserInfo?,
+    signedIn: Boolean,
+    statusMessage: String?,
+    bookmarks: List<AyahBookmark>,
+    readingBookmark: ReadingBookmark?,
+    collectionsWithBookmarks: List<CollectionWithAyahBookmarks>,
+    notes: List<Note>,
+    readingSessions: List<ReadingSession>
+) {
+    DataContent(
+        userInfo = userInfo,
+        signedIn = signedIn,
+        statusMessage = statusMessage,
+        bookmarks = bookmarks,
+        readingBookmark = readingBookmark,
+        collectionsWithBookmarks = collectionsWithBookmarks,
+        notes = notes,
+        onAddAyahBookmark = {
+            val sura = getRandomSura()
+            val ayah = getRandomAyah(sura)
+            eventScope.launch {
+                try {
+                    viewModel.addBookmark(sura, ayah)
+                } catch (e: Exception) {
+                }
+            }
+        },
+        onAddReadingAyahBookmark = {
+            val sura = getRandomSura()
+            val ayah = getRandomAyah(sura)
+            eventScope.launch {
+                try {
+                    viewModel.addAyahReadingBookmark(sura, ayah)
+                } catch (e: Exception) {
+                }
+            }
+        },
+        onAddReadingPageBookmark = {
+            val page = getRandomPage()
+            eventScope.launch {
+                try {
+                    viewModel.addPageReadingBookmark(page)
+                } catch (e: Exception) {
+                }
+            }
+        },
+        onDeleteBookmark = {
+            eventScope.launch {
+                try {
+                    viewModel.deleteBookmark(it)
+                } catch (e: Exception) {
+                }
+            }
+        },
+        onDeleteReadingBookmark = {
+            eventScope.launch {
+                try {
+                    viewModel.deleteReadingBookmark()
+                } catch (e: Exception) {
+                }
+            }
+        },
+        onAddCollection = { name ->
+            eventScope.launch {
+                try {
+                    viewModel.addCollection(name)
+                } catch (e: Exception) {
+                }
+            }
+        },
+        onDeleteCollection = { id ->
+            eventScope.launch {
+                try {
+                    viewModel.deleteCollection(id)
+                } catch (e: Exception) {
+                }
+            }
+        },
+        onAddNote = { body ->
+            val sura = getRandomSura()
+            val ayah = getRandomAyah(sura)
+            eventScope.launch {
+                try {
+                    viewModel.addNote(
+                        body,
+                        sura,
+                        ayah,
+                        sura,
+                        ayah
+                    )
+                } catch (e: Exception) {
+                }
+            }
+        },
+        onDeleteNote = { id ->
+            eventScope.launch {
+                try {
+                    viewModel.deleteNote(id)
+                } catch (e: Exception) {
+                }
+            }
+        },
+        onLogout = {
+            eventScope.launch {
+                try {
+                    viewModel.logout()
+                } catch (e: Exception) {
+                }
+            }
+        },
+        onAddRandomBookmarkToCollection = { id ->
+            eventScope.launch {
+                try {
+                    val sura = getRandomSura()
+                    val ayah = getRandomAyah(sura)
+                    viewModel.addAyahBookmarkToCollection(id, sura, ayah)
+                } catch (e: Exception) {
+                }
+            }
+        },
+        readingSessions = readingSessions,
+        onAddReadingSession = {
+            val sura = getRandomSura()
+            val ayah = getRandomAyah(sura)
+            eventScope.launch {
+                try {
+                    viewModel.addReadingSession(sura, ayah)
+                } catch (e: Exception) {
+                }
+            }
+        }
+    )
+}
+
+@Composable
+private fun DataContent(
+    userInfo: UserInfo?,
+    signedIn: Boolean,
+    statusMessage: String?,
     bookmarks: List<AyahBookmark>,
     readingBookmark: ReadingBookmark?,
     collectionsWithBookmarks: List<CollectionWithAyahBookmarks>,
@@ -286,9 +358,22 @@ private fun SuccessContent(
                 Spacer(modifier = Modifier.height(8.dp))
 
                 Text(
-                    text = "Welcome, ${userInfo?.displayName ?: "User"}!",
+                    text = if (signedIn) {
+                        "Welcome, ${userInfo?.displayName ?: "User"}!"
+                    } else {
+                        "Local data mode"
+                    },
                     style = MaterialTheme.typography.headlineSmall
                 )
+
+                if (!signedIn && statusMessage != null) {
+                    Text(
+                        text = statusMessage,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+                        textAlign = TextAlign.Center
+                    )
+                }
 
                 userInfo?.email?.let {
                     Text(
@@ -348,11 +433,13 @@ private fun SuccessContent(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        TextButton(
-            onClick = onLogout,
-            colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
-        ) {
-            Text("Sign Out")
+        if (signedIn) {
+            TextButton(
+                onClick = onLogout,
+                colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
+            ) {
+                Text("Sign Out")
+            }
         }
     }
 }

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncAuthService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncAuthService.kt
@@ -1,6 +1,7 @@
 package com.quran.shared.pipeline
 
 import com.quran.shared.auth.model.AuthState
+import com.quran.shared.auth.model.AuthRuntimeConfig
 import com.quran.shared.auth.model.UserInfo
 import com.quran.shared.auth.service.AuthService
 import com.quran.shared.di.AppScope
@@ -21,10 +22,20 @@ import kotlinx.coroutines.flow.StateFlow
 class SyncAuthService internal constructor(
     private val authService: AuthService,
     private val syncService: SyncService,
-    private val sessionLifecycleCoordinator: SessionLifecycleCoordinator
+    private val sessionLifecycleCoordinator: SessionLifecycleCoordinator,
+    private val authRuntimeConfig: AuthRuntimeConfig = AuthRuntimeConfig.Unconfigured
 ) {
     @NativeCoroutinesState
     val authState: StateFlow<AuthState> get() = authService.authState
+
+    /**
+     * True when this graph was initialized with usable authentication client metadata.
+     *
+     * When false, [SyncService] still supports local-first data operations, but interactive sign-in
+     * is not available for this build.
+     */
+    val isAuthenticationConfigured: Boolean
+        get() = authRuntimeConfig.isConfigured
 
     val loggedInUser: UserInfo?
         get() = (authService.authState.value as? AuthState.Success)?.userInfo

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/di/AppGraph.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/di/AppGraph.kt
@@ -2,6 +2,7 @@ package com.quran.shared.pipeline.di
 
 import com.quran.shared.auth.di.AuthModule
 import com.quran.shared.auth.model.AuthConfig
+import com.quran.shared.auth.model.AuthRuntimeConfig
 import com.quran.shared.di.AppScope
 import com.quran.shared.persistence.DriverFactory
 import com.quran.shared.persistence.di.PersistenceModule
@@ -43,7 +44,7 @@ interface AppGraph {
             @Provides driverFactory: DriverFactory,
             @Provides storage: MobileSyncStorage,
             @Provides environment: SynchronizationEnvironment,
-            @Provides authConfig: AuthConfig
+            @Provides authRuntimeConfig: AuthRuntimeConfig
         ): AppGraph
     }
 }
@@ -58,10 +59,10 @@ object SharedDependencyGraph {
         driverFactory: DriverFactory,
         storage: MobileSyncStorage,
         environment: SynchronizationEnvironment,
-        authConfig: AuthConfig
+        authRuntimeConfig: AuthRuntimeConfig
     ): AppGraph {
         return createGraphFactory<AppGraph.Factory>()
-            .create(driverFactory, storage, environment, authConfig)
+            .create(driverFactory, storage, environment, authRuntimeConfig)
             .also { instance = it }
     }
 
@@ -81,6 +82,13 @@ object SharedDependencyGraph {
         )
     }
 
+    /**
+     * Initializes the managed graph using app-level OIDC client metadata when available.
+     *
+     * Blank [clientId] values are treated as an uncredentialed open-source build: the graph still
+     * exposes [SyncService] for local-first data, while [SyncAuthService] reports authentication as
+     * unavailable and sign-in fails clearly. Non-blank client IDs keep the configured OIDC path.
+     */
     @OptIn(InternalCoroutinesApi::class)
     fun init(
         driverFactory: DriverFactory,
@@ -93,23 +101,70 @@ object SharedDependencyGraph {
             driverFactory = driverFactory,
             storage = storage,
             environment = appEnvironment.synchronizationEnvironment(),
-            authConfig = AuthConfig(
-                environment = appEnvironment.authEnvironment,
+            authRuntimeConfig = authRuntimeConfigForClientId(
+                appEnvironment = appEnvironment,
                 clientId = clientId,
                 clientSecret = clientSecret
             )
         )
     }
 
+    /**
+     * Initializes the managed graph with explicit OIDC credentials.
+     *
+     * Use this overload when the app has already constructed a valid [AuthConfig]. Blank client
+     * IDs still fail fast through [AuthConfig]; only the string-based convenience overloads
+     * automatically fall back to local-only managed mode.
+     */
     @OptIn(InternalCoroutinesApi::class)
     fun init(
         driverFactory: DriverFactory,
         storage: MobileSyncStorage,
         environment: SynchronizationEnvironment,
         authConfig: AuthConfig
+    ): AppGraph =
+        init(
+            driverFactory = driverFactory,
+            storage = storage,
+            environment = environment,
+            authRuntimeConfig = AuthRuntimeConfig.Configured(authConfig)
+        )
+
+    @OptIn(InternalCoroutinesApi::class)
+    private fun init(
+        driverFactory: DriverFactory,
+        storage: MobileSyncStorage,
+        environment: SynchronizationEnvironment,
+        authRuntimeConfig: AuthRuntimeConfig
     ): AppGraph {
         return instance ?: synchronized(lock) {
-            instance ?: doInit(driverFactory, storage, environment, authConfig)
+            instance ?: doInit(driverFactory, storage, environment, authRuntimeConfig)
         }
+    }
+}
+
+/**
+ * Converts app-provided client metadata into the auth mode used by the managed graph.
+ *
+ * The convenience graph API accepts blank client IDs so open-source builds can boot without
+ * credentials. The explicit [AuthConfig] path remains strict and should be used when callers want
+ * invalid OIDC metadata to fail immediately.
+ */
+internal fun authRuntimeConfigForClientId(
+    appEnvironment: AppEnvironment,
+    clientId: String,
+    clientSecret: String?
+): AuthRuntimeConfig {
+    val normalizedClientId = clientId.trim()
+    return if (normalizedClientId.isEmpty()) {
+        AuthRuntimeConfig.Unconfigured
+    } else {
+        AuthRuntimeConfig.Configured(
+            AuthConfig(
+                environment = appEnvironment.authEnvironment,
+                clientId = normalizedClientId,
+                clientSecret = clientSecret
+            )
+        )
     }
 }

--- a/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/SyncServiceLifecycleTest.kt
+++ b/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/SyncServiceLifecycleTest.kt
@@ -3,6 +3,8 @@
 package com.quran.shared.pipeline
 
 import com.quran.shared.auth.model.AuthState
+import com.quran.shared.auth.model.AuthConfig
+import com.quran.shared.auth.model.AuthRuntimeConfig
 import com.quran.shared.auth.model.UserInfo
 import com.quran.shared.auth.repository.AuthRepository
 import com.quran.shared.auth.repository.LogoutTokenMaterial
@@ -67,6 +69,8 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.time.Instant
 
 class SyncServiceLifecycleTest {
@@ -314,6 +318,27 @@ class SyncServiceLifecycleTest {
         assertEquals(null, fixture.authRepository.getAccessToken())
         assertEquals(1, fixture.resetRepository.deleteCount)
         assertEquals(0L, fixture.tokenStore.localLastModificationDate())
+        fixture.clearAndJoin()
+    }
+
+    @Test
+    fun `sync auth facade reports whether authentication is configured`() = runTest(dispatcher) {
+        val fixture = syncServiceFixture()
+
+        val unconfiguredAuthFacade = SyncAuthService(
+            fixture.authService,
+            fixture.service,
+            fixture.lifecycleCoordinator
+        )
+        val configuredAuthFacade = SyncAuthService(
+            fixture.authService,
+            fixture.service,
+            fixture.lifecycleCoordinator,
+            AuthRuntimeConfig.Configured(AuthConfig(clientId = "client-id"))
+        )
+
+        assertFalse(unconfiguredAuthFacade.isAuthenticationConfigured)
+        assertTrue(configuredAuthFacade.isAuthenticationConfigured)
         fixture.clearAndJoin()
     }
 

--- a/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/di/AuthRuntimeConfigForClientIdTest.kt
+++ b/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/di/AuthRuntimeConfigForClientIdTest.kt
@@ -1,0 +1,34 @@
+package com.quran.shared.pipeline.di
+
+import com.quran.shared.auth.model.AuthRuntimeConfig
+import com.quran.shared.pipeline.AppEnvironment
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AuthRuntimeConfigForClientIdTest {
+    @Test
+    fun `blank client id maps to unconfigured auth`() {
+        val runtimeConfig = authRuntimeConfigForClientId(
+            appEnvironment = AppEnvironment.PRELIVE,
+            clientId = "   ",
+            clientSecret = null
+        )
+
+        assertEquals(AuthRuntimeConfig.Unconfigured, runtimeConfig)
+    }
+
+    @Test
+    fun `nonblank client id maps to configured auth`() {
+        val runtimeConfig = authRuntimeConfigForClientId(
+            appEnvironment = AppEnvironment.PRELIVE,
+            clientId = " client-id ",
+            clientSecret = "client-secret"
+        )
+
+        assertTrue(runtimeConfig is AuthRuntimeConfig.Configured)
+        assertEquals("client-id", runtimeConfig.config.clientId)
+        assertEquals("client-secret", runtimeConfig.config.clientSecret)
+        assertEquals(AppEnvironment.PRELIVE.authEnvironment, runtimeConfig.config.environment)
+    }
+}


### PR DESCRIPTION
Allow a token to be empty for making the graph, because there are
legitimate cases (ex open source app being built by someone from the
general public) where the app should continue working properly (but
without sync). Also don't block on an activity since it's not needed for
making the graph itself, but later on is needed for login.
