### PR TITLE
Clean up timestamp handling

### DIFF
--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/BookmarkDependencyReconciler.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/BookmarkDependencyReconciler.kt
@@ -1,19 +1,20 @@
 package com.quran.shared.persistence.repository.bookmark
 
 import com.quran.shared.persistence.QuranDatabase
+import com.quran.shared.persistence.util.currentEpochMilliseconds
 import dev.zacsweers.metro.Inject
 
 @Inject
 class BookmarkDependencyReconciler(
     private val database: QuranDatabase
 ) {
-    fun reconcile() {
+    fun reconcile(timestampMillis: Long = currentEpochMilliseconds()) {
         val bookmarkQueries = database.bookmarksQueries
         val linkQueries = database.bookmark_collectionsQueries
 
-        linkQueries.markActiveLinksWithChangedSnapshots()
+        linkQueries.markActiveLinksWithChangedSnapshots(modified_at = timestampMillis)
         linkQueries.deleteLinksForInactiveParents()
-        linkQueries.markSyncedLinksForInactiveParents()
+        linkQueries.markSyncedLinksForInactiveParents(modified_at = timestampMillis)
         linkQueries.deleteInactiveClearedLinks()
 
         val activeReadingRows = bookmarkQueries.getReadingBookmarks().executeAsList()

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
@@ -23,8 +23,10 @@ import com.quran.shared.persistence.repository.bookmark.BookmarkDependencyReconc
 import com.quran.shared.persistence.repository.bookmark.extension.toAyahBookmark
 import com.quran.shared.persistence.util.PlatformDateTime
 import com.quran.shared.persistence.util.QuranData
+import com.quran.shared.persistence.util.currentEpochMilliseconds
+import com.quran.shared.persistence.util.currentPlatformDateTime
 import com.quran.shared.persistence.util.fromPlatform
-import com.quran.shared.persistence.util.toEpochMillisecondsOrNull
+import com.quran.shared.persistence.util.toEpochMillisecondsFromPlatform
 import com.quran.shared.persistence.util.toPlatform
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
@@ -63,7 +65,7 @@ class BookmarksRepositoryImpl(
     }
 
     override suspend fun addBookmark(sura: Int, ayah: Int): AyahBookmark {
-        return addBookmark(sura = sura, ayah = ayah, collectionIds = emptyList())
+        return addBookmark(sura = sura, ayah = ayah, timestamp = currentPlatformDateTime())
     }
 
     override suspend fun addBookmark(sura: Int, ayah: Int, timestamp: PlatformDateTime): AyahBookmark {
@@ -80,12 +82,7 @@ class BookmarksRepositoryImpl(
         ayah: Int,
         collectionIds: List<String>
     ): AyahBookmark {
-        return addBookmarkWithTimestampMillis(
-            sura = sura,
-            ayah = ayah,
-            collectionLocalIds = collectionIds,
-            timestampMillis = null
-        )
+        return addBookmark(sura, ayah, collectionIds, currentPlatformDateTime())
     }
 
     override suspend fun addBookmark(
@@ -98,7 +95,7 @@ class BookmarksRepositoryImpl(
             sura = sura,
             ayah = ayah,
             collectionLocalIds = collectionIds,
-            timestampMillis = timestamp.toEpochMillisecondsOrNull()
+            timestampMillis = timestamp.toEpochMillisecondsFromPlatform()
         )
     }
 
@@ -106,7 +103,7 @@ class BookmarksRepositoryImpl(
         sura: Int,
         ayah: Int,
         collectionLocalIds: List<String>,
-        timestampMillis: Long?
+        timestampMillis: Long
     ): AyahBookmark {
         logger.i { "Adding ayah bookmark for $sura:$ayah" }
         return withContext(Dispatchers.IO) {
@@ -114,7 +111,6 @@ class BookmarksRepositoryImpl(
             database.transaction {
                 val normalizedCollectionIds = normalizeCollectionIds(collectionLocalIds)
                 val ayahId = getAyahId(sura, ayah).toLong()
-
                 bookmarkQueries.value.upsertAyahBookmark(
                     remote_id = null,
                     ayah_id = ayahId,
@@ -151,7 +147,7 @@ class BookmarksRepositoryImpl(
                         )
                     }
 
-                reconciler.reconcile()
+                reconciler.reconcile(timestampMillis)
                 created = bookmarkQueries.value
                     .getBookmarkForAyah(sura.toLong(), ayah.toLong())
                     .executeAsOne()
@@ -165,11 +161,7 @@ class BookmarksRepositoryImpl(
         id: String,
         collectionIds: List<String>
     ): Boolean {
-        return replaceBookmarkCollectionsWithTimestampMillis(
-            localId = id,
-            collectionLocalIds = collectionIds,
-            timestampMillis = null
-        )
+        return replaceBookmarkCollections(id, collectionIds, currentPlatformDateTime())
     }
 
     override suspend fun replaceBookmarkCollections(
@@ -180,14 +172,14 @@ class BookmarksRepositoryImpl(
         return replaceBookmarkCollectionsWithTimestampMillis(
             localId = id,
             collectionLocalIds = collectionIds,
-            timestampMillis = timestamp.toEpochMillisecondsOrNull()
+            timestampMillis = timestamp.toEpochMillisecondsFromPlatform()
         )
     }
 
     private suspend fun replaceBookmarkCollectionsWithTimestampMillis(
         localId: String,
         collectionLocalIds: List<String>,
-        timestampMillis: Long?
+        timestampMillis: Long
     ): Boolean {
         logger.i { "Replacing ayah bookmark collection memberships localId=$localId" }
         return withContext(Dispatchers.IO) {
@@ -212,12 +204,7 @@ class BookmarksRepositoryImpl(
         ayah: Int,
         collectionIds: List<String>
     ): BookmarkCollectionsReplacementResult {
-        return replaceAyahBookmarkCollectionsWithTimestampMillis(
-            sura = sura,
-            ayah = ayah,
-            collectionLocalIds = collectionIds,
-            timestampMillis = null
-        )
+        return replaceAyahBookmarkCollections(sura, ayah, collectionIds, currentPlatformDateTime())
     }
 
     override suspend fun replaceAyahBookmarkCollections(
@@ -230,7 +217,7 @@ class BookmarksRepositoryImpl(
             sura = sura,
             ayah = ayah,
             collectionLocalIds = collectionIds,
-            timestampMillis = timestamp.toEpochMillisecondsOrNull()
+            timestampMillis = timestamp.toEpochMillisecondsFromPlatform()
         )
     }
 
@@ -238,7 +225,7 @@ class BookmarksRepositoryImpl(
         sura: Int,
         ayah: Int,
         collectionLocalIds: List<String>,
-        timestampMillis: Long?
+        timestampMillis: Long
     ): BookmarkCollectionsReplacementResult {
         logger.i { "Replacing ayah bookmark collection memberships for $sura:$ayah" }
         return withContext(Dispatchers.IO) {
@@ -280,13 +267,14 @@ class BookmarksRepositoryImpl(
     override suspend fun deleteBookmark(sura: Int, ayah: Int): Boolean {
         logger.i { "Deleting ayah bookmark for $sura:$ayah" }
         return withContext(Dispatchers.IO) {
+            val timestampMillis = currentEpochMilliseconds()
             var deleted = false
             database.transaction {
                 val bookmark = bookmarkQueries.value
                     .getBookmarkForAyah(sura.toLong(), ayah.toLong())
                     .executeAsOneOrNull()
                 if (bookmark?.hasSavedBookmarkMembership() == true) {
-                    deleteSavedBookmarkByLocalIdInTransaction(bookmark.local_id, null)
+                    deleteSavedBookmarkByLocalIdInTransaction(bookmark.local_id, timestampMillis)
                     deleted = true
                 }
             }
@@ -306,12 +294,13 @@ class BookmarksRepositoryImpl(
 
     private suspend fun deleteBookmarkWithLocalId(localId: String): Boolean {
         return withContext(Dispatchers.IO) {
+            val timestampMillis = currentEpochMilliseconds()
             var deleted = false
             database.transaction {
                 val id = localId.toLong()
                 val bookmark = bookmarkQueries.value.getBookmarkByLocalId(id).executeAsOneOrNull()
                 if (bookmark?.hasSavedBookmarkMembership() == true) {
-                    deleteSavedBookmarkByLocalIdInTransaction(id, null)
+                    deleteSavedBookmarkByLocalIdInTransaction(id, timestampMillis)
                     deleted = true
                 }
             }
@@ -327,7 +316,7 @@ class BookmarksRepositoryImpl(
     private fun replaceBookmarkCollectionsInTransaction(
         bookmark: DatabaseBookmark,
         collectionLocalIds: List<String>,
-        timestampMillis: Long?
+        timestampMillis: Long
     ): Boolean {
         require(bookmark.bookmark_type == "AYAH") {
             "Expected ayah bookmark localId=${bookmark.local_id} before replacing collections."
@@ -395,7 +384,7 @@ class BookmarksRepositoryImpl(
                 timestamp = timestampMillis
             )
         }
-        reconciler.reconcile()
+        reconciler.reconcile(timestampMillis)
         return true
     }
 
@@ -412,7 +401,7 @@ class BookmarksRepositoryImpl(
         }
     }
 
-    private fun deleteSavedBookmarkByLocalIdInTransaction(localId: Long, timestampMillis: Long?) {
+    private fun deleteSavedBookmarkByLocalIdInTransaction(localId: Long, timestampMillis: Long) {
         bookmarkQueries.value.clearDefaultCollection(
             local_id = localId,
             timestamp = timestampMillis
@@ -421,7 +410,7 @@ class BookmarksRepositoryImpl(
             bookmark_local_id = localId,
             timestamp = timestampMillis
         )
-        reconciler.reconcile()
+        reconciler.reconcile(timestampMillis)
     }
 
     override suspend fun fetchMutatedBookmarks(): List<LocalModelMutation<RemoteBookmark>> {

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collection/repository/CollectionsRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collection/repository/CollectionsRepositoryImpl.kt
@@ -20,8 +20,10 @@ import com.quran.shared.persistence.repository.bookmark.BookmarkDependencyReconc
 import com.quran.shared.persistence.repository.collection.extension.toCollection
 import com.quran.shared.persistence.repository.collection.extension.toCollectionMutation
 import com.quran.shared.persistence.util.PlatformDateTime
+import com.quran.shared.persistence.util.currentEpochMilliseconds
+import com.quran.shared.persistence.util.currentPlatformDateTime
 import com.quran.shared.persistence.util.fromPlatform
-import com.quran.shared.persistence.util.toEpochMillisecondsOrNull
+import com.quran.shared.persistence.util.toEpochMillisecondsFromPlatform
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.Dispatchers
@@ -59,14 +61,14 @@ class CollectionsRepositoryImpl(
     }
 
     override suspend fun addCollection(name: String): Collection {
-        return addCollectionWithTimestampMillis(name, timestampMillis = null)
+        return addCollection(name, currentPlatformDateTime())
     }
 
     override suspend fun addCollection(name: String, timestamp: PlatformDateTime): Collection {
-        return addCollectionWithTimestampMillis(name, timestamp.toEpochMillisecondsOrNull())
+        return addCollectionWithTimestampMillis(name, timestamp.toEpochMillisecondsFromPlatform())
     }
 
-    private suspend fun addCollectionWithTimestampMillis(name: String, timestampMillis: Long?): Collection {
+    private suspend fun addCollectionWithTimestampMillis(name: String, timestampMillis: Long): Collection {
         logger.i { "Adding collection with name=$name" }
         return withContext(Dispatchers.IO) {
             collectionQueries.value.addNewCollection(
@@ -81,17 +83,17 @@ class CollectionsRepositoryImpl(
     }
 
     override suspend fun updateCollection(id: String, name: String): Collection {
-        return updateCollectionWithTimestampMillis(id, name, timestampMillis = null)
+        return updateCollection(id, name, currentPlatformDateTime())
     }
 
     override suspend fun updateCollection(id: String, name: String, timestamp: PlatformDateTime): Collection {
-        return updateCollectionWithTimestampMillis(id, name, timestamp.toEpochMillisecondsOrNull())
+        return updateCollectionWithTimestampMillis(id, name, timestamp.toEpochMillisecondsFromPlatform())
     }
 
     private suspend fun updateCollectionWithTimestampMillis(
         id: String,
         name: String,
-        timestampMillis: Long?
+        timestampMillis: Long
     ): Collection {
         logger.i { "Updating collection id=$id with name=$name" }
         return withContext(Dispatchers.IO) {
@@ -125,6 +127,7 @@ class CollectionsRepositoryImpl(
     override suspend fun deleteCollection(id: String): Boolean {
         logger.i { "Deleting collection id=$id" }
         return withContext(Dispatchers.IO) {
+            val timestampMillis = currentEpochMilliseconds()
             var deleted = false
             database.transaction {
                 val localId = id.toLong()
@@ -133,9 +136,10 @@ class CollectionsRepositoryImpl(
                     return@transaction
                 }
                 collectionQueries.value.deleteCollection(
-                    id = localId
+                    id = localId,
+                    timestamp = timestampMillis
                 )
-                reconciler.reconcile()
+                reconciler.reconcile(timestampMillis)
                 deleted = true
             }
             deleted
@@ -332,6 +336,7 @@ class CollectionsRepositoryImpl(
         }
         collectionQueries.value.clearLocalMutationFor(
             id = local.localID.toLong(),
+            modified_at = local.model.lastUpdated.fromPlatform().toEpochMilliseconds(),
             pending_version = ack.observedPendingVersion,
             pending_op = ack.observedPendingOp.name
         )

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
@@ -25,8 +25,10 @@ import com.quran.shared.persistence.repository.bookmark.BookmarkDependencyReconc
 import com.quran.shared.persistence.repository.bookmark.extension.toAyahBookmark
 import com.quran.shared.persistence.util.PlatformDateTime
 import com.quran.shared.persistence.util.QuranData
+import com.quran.shared.persistence.util.currentEpochMilliseconds
+import com.quran.shared.persistence.util.currentPlatformDateTime
 import com.quran.shared.persistence.util.fromPlatform
-import com.quran.shared.persistence.util.toEpochMillisecondsOrNull
+import com.quran.shared.persistence.util.toEpochMillisecondsFromPlatform
 import com.quran.shared.persistence.util.toPlatform
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
@@ -114,7 +116,7 @@ class CollectionBookmarksRepositoryImpl(
         collectionId: String,
         bookmark: AyahBookmark
     ): CollectionAyahBookmark {
-        return addBookmarkToCollectionWithTimestampMillis(collectionId, bookmark, timestampMillis = null)
+        return addBookmarkToCollection(collectionId, bookmark, currentPlatformDateTime())
     }
 
     override suspend fun addBookmarkToCollection(
@@ -125,14 +127,14 @@ class CollectionBookmarksRepositoryImpl(
         return addBookmarkToCollectionWithTimestampMillis(
             collectionId,
             bookmark,
-            timestamp.toEpochMillisecondsOrNull()
+            timestamp.toEpochMillisecondsFromPlatform()
         )
     }
 
     private suspend fun addBookmarkToCollectionWithTimestampMillis(
         collectionId: String,
         bookmark: AyahBookmark,
-        timestampMillis: Long?
+        timestampMillis: Long
     ): CollectionAyahBookmark {
         return withContext(Dispatchers.IO) {
             var created: CollectionAyahBookmark? = null
@@ -148,7 +150,7 @@ class CollectionBookmarksRepositoryImpl(
                         ayah = bookmark.ayah.toLong(),
                         timestamp = timestampMillis
                     )
-                    reconciler.reconcile()
+                    reconciler.reconcile(timestampMillis)
                     created = bookmarkQueries.value.getBookmarkByLocalId(row.local_id)
                         .executeAsOne()
                         .toDefaultCollectionBookmark()
@@ -165,7 +167,7 @@ class CollectionBookmarksRepositoryImpl(
                     collection_local_id = collection.local_id,
                     timestamp = timestampMillis
                 )
-                reconciler.reconcile()
+                reconciler.reconcile(timestampMillis)
                 val record = bookmarkCollectionQueries.value
                     .getCollectionBookmarksForCollectionWithDetails(collection.local_id)
                     .executeAsList()
@@ -193,7 +195,7 @@ class CollectionBookmarksRepositoryImpl(
         sura: Int,
         ayah: Int
     ): CollectionAyahBookmark {
-        return addAyahBookmarkToCollectionWithTimestampMillis(collectionId, sura, ayah, timestampMillis = null)
+        return addAyahBookmarkToCollection(collectionId, sura, ayah, currentPlatformDateTime())
     }
 
     override suspend fun addAyahBookmarkToCollection(
@@ -206,7 +208,7 @@ class CollectionBookmarksRepositoryImpl(
             collectionId,
             sura,
             ayah,
-            timestamp.toEpochMillisecondsOrNull()
+            timestamp.toEpochMillisecondsFromPlatform()
         )
     }
 
@@ -214,7 +216,7 @@ class CollectionBookmarksRepositoryImpl(
         collectionId: String,
         sura: Int,
         ayah: Int,
-        timestampMillis: Long?
+        timestampMillis: Long
     ): CollectionAyahBookmark {
         return withContext(Dispatchers.IO) {
             var created: CollectionAyahBookmark? = null
@@ -227,7 +229,7 @@ class CollectionBookmarksRepositoryImpl(
                         ayah = ayah.toLong(),
                         timestamp = timestampMillis
                     )
-                    reconciler.reconcile()
+                    reconciler.reconcile(timestampMillis)
                     created = bookmarkQueries.value.getBookmarkForAyah(sura.toLong(), ayah.toLong())
                         .executeAsOne()
                         .toDefaultCollectionBookmark()
@@ -255,7 +257,7 @@ class CollectionBookmarksRepositoryImpl(
                     collection_local_id = collection.local_id,
                     timestamp = timestampMillis
                 )
-                reconciler.reconcile()
+                reconciler.reconcile(timestampMillis)
                 val record = bookmarkCollectionQueries.value
                     .getCollectionBookmarksForCollectionWithDetails(collection.local_id)
                     .executeAsList()
@@ -283,20 +285,21 @@ class CollectionBookmarksRepositoryImpl(
         bookmark: AyahBookmark
     ): Boolean {
         return withContext(Dispatchers.IO) {
+            val timestampMillis = currentEpochMilliseconds()
             database.transaction {
                 if (collectionId == DEFAULT_COLLECTION_ID) {
                     bookmarkQueries.value.clearDefaultCollection(
                         local_id = bookmark.id.toLong(),
-                        timestamp = null
+                        timestamp = timestampMillis
                     )
                 } else {
                     bookmarkCollectionQueries.value.markBookmarkCollectionDeleted(
                         bookmark_local_id = bookmark.id.toLong(),
                         collection_local_id = collectionId.toLong(),
-                        timestamp = null
+                        timestamp = timestampMillis
                     )
                 }
-                reconciler.reconcile()
+                reconciler.reconcile(timestampMillis)
             }
             true
         }
@@ -304,20 +307,21 @@ class CollectionBookmarksRepositoryImpl(
 
     override suspend fun removeAyahBookmarkFromCollection(collectionAyahBookmark: CollectionAyahBookmark): Boolean {
         return withContext(Dispatchers.IO) {
+            val timestampMillis = currentEpochMilliseconds()
             database.transaction {
                 if (collectionAyahBookmark.collectionId == DEFAULT_COLLECTION_ID) {
                     bookmarkQueries.value.clearDefaultCollection(
                         local_id = collectionAyahBookmark.bookmarkId.toLong(),
-                        timestamp = null
+                        timestamp = timestampMillis
                     )
                 } else {
                     bookmarkCollectionQueries.value.markBookmarkCollectionDeleted(
                         bookmark_local_id = collectionAyahBookmark.bookmarkId.toLong(),
                         collection_local_id = collectionAyahBookmark.collectionId.toLong(),
-                        timestamp = null
+                        timestamp = timestampMillis
                     )
                 }
-                reconciler.reconcile()
+                reconciler.reconcile(timestampMillis)
             }
             true
         }
@@ -713,7 +717,7 @@ class CollectionBookmarksRepositoryImpl(
             ) {
                 bookmarkQueries.value.markDefaultRelationForRecreation(
                     local_id = bookmarkLocalId,
-                    modified_at = updatedAt
+                    modified_at = row.default_modified_at ?: row.modified_at
                 )
             }
             return
@@ -727,8 +731,7 @@ class CollectionBookmarksRepositoryImpl(
             bookmarkQueries.value.bindDefaultRemoteSnapshotForCreatedAck(
                 local_id = bookmarkLocalId,
                 remote_id = local.model.bookmarkRemoteId,
-                default_last_synced_bookmark_remote_id = relationBookmarkRemoteId,
-                modified_at = updatedAt
+                default_last_synced_bookmark_remote_id = relationBookmarkRemoteId
             )
             return
         }
@@ -742,7 +745,7 @@ class CollectionBookmarksRepositoryImpl(
                 local_id = bookmarkLocalId,
                 remote_id = local.model.bookmarkRemoteId,
                 default_last_synced_bookmark_remote_id = relationBookmarkRemoteId,
-                modified_at = updatedAt
+                modified_at = row.default_modified_at ?: row.modified_at
             )
             return
         }
@@ -777,8 +780,7 @@ class CollectionBookmarksRepositoryImpl(
         bookmarkCollectionQueries.value.bindRemoteSnapshotForCreatedAck(
             id = relationRow.local_id,
             bookmark_remote_id = relationBookmarkRemoteId,
-            collection_remote_id = local.model.collectionRemoteId,
-            modified_at = updatedAt
+            collection_remote_id = local.model.collectionRemoteId
         )
         if (!local.model.bookmarkRemoteId.isNullOrEmpty()) {
             bookmarkQueries.value.getBookmarkByLocalId(relationRow.bookmark_local_id)
@@ -844,7 +846,7 @@ class CollectionBookmarksRepositoryImpl(
         } else if (relationRow.pending_op == null && relationRow.is_active == 1L) {
             bookmarkCollectionQueries.value.markBookmarkCollectionForRecreation(
                 id = relationRow.local_id,
-                modified_at = updatedAt
+                modified_at = relationRow.modified_at
             )
         }
     }
@@ -1285,7 +1287,7 @@ class CollectionBookmarksRepositoryImpl(
             sura = sura,
             ayah = ayah,
             membershipModifiedAt = default_modified_at ?: modified_at,
-            bookmarkModifiedAt = modified_at,
+            bookmarkModifiedAt = bookmark_modified_at,
             bookmarkCreatedAt = created_at
         )
     }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/note/repository/NotesRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/note/repository/NotesRepositoryImpl.kt
@@ -20,8 +20,10 @@ import com.quran.shared.persistence.repository.note.extension.toNote
 import com.quran.shared.persistence.repository.note.extension.toNoteMutation
 import com.quran.shared.persistence.util.PlatformDateTime
 import com.quran.shared.persistence.util.QuranData
+import com.quran.shared.persistence.util.currentEpochMilliseconds
+import com.quran.shared.persistence.util.currentPlatformDateTime
 import com.quran.shared.persistence.util.fromPlatform
-import com.quran.shared.persistence.util.toEpochMillisecondsOrNull
+import com.quran.shared.persistence.util.toEpochMillisecondsFromPlatform
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.Dispatchers
@@ -57,7 +59,7 @@ class NotesRepositoryImpl(
     }
 
     override suspend fun addNote(body: String, startSura: Int, startAyah: Int, endSura: Int, endAyah: Int): Note {
-        return addNoteWithTimestampMillis(body, startSura, startAyah, endSura, endAyah, timestampMillis = null)
+        return addNote(body, startSura, startAyah, endSura, endAyah, currentPlatformDateTime())
     }
 
     override suspend fun addNote(
@@ -74,7 +76,7 @@ class NotesRepositoryImpl(
             startAyah,
             endSura,
             endAyah,
-            timestamp.toEpochMillisecondsOrNull()
+            timestamp.toEpochMillisecondsFromPlatform()
         )
     }
 
@@ -84,7 +86,7 @@ class NotesRepositoryImpl(
         startAyah: Int,
         endSura: Int,
         endAyah: Int,
-        timestampMillis: Long?
+        timestampMillis: Long
     ): Note {
         logger.i { "Adding note for range=$startSura:$startAyah-$endSura:$endAyah" }
         return withContext(Dispatchers.IO) {
@@ -114,15 +116,7 @@ class NotesRepositoryImpl(
         endSura: Int,
         endAyah: Int
     ): Note {
-        return updateNoteWithTimestampMillis(
-            id,
-            body,
-            startSura,
-            startAyah,
-            endSura,
-            endAyah,
-            timestampMillis = null
-        )
+        return updateNote(id, body, startSura, startAyah, endSura, endAyah, currentPlatformDateTime())
     }
 
     override suspend fun updateNote(
@@ -141,7 +135,7 @@ class NotesRepositoryImpl(
             startAyah,
             endSura,
             endAyah,
-            timestamp.toEpochMillisecondsOrNull()
+            timestamp.toEpochMillisecondsFromPlatform()
         )
     }
 
@@ -152,7 +146,7 @@ class NotesRepositoryImpl(
         startAyah: Int,
         endSura: Int,
         endAyah: Int,
-        timestampMillis: Long?
+        timestampMillis: Long
     ): Note {
         logger.i { "Updating note id=$id" }
         return withContext(Dispatchers.IO) {
@@ -177,7 +171,8 @@ class NotesRepositoryImpl(
         logger.i { "Deleting note id=$id" }
         withContext(Dispatchers.IO) {
             notesQueries.value.deleteNote(
-                id = id.toLong()
+                id = id.toLong(),
+                timestamp = currentEpochMilliseconds()
             )
         }
         return true
@@ -353,6 +348,7 @@ class NotesRepositoryImpl(
         val ack = local.ack ?: return
         notesQueries.value.clearLocalMutationFor(
             id = local.localID.toLong(),
+            modified_at = local.model.lastUpdated.fromPlatform().toEpochMilliseconds(),
             pending_version = ack.observedPendingVersion,
             pending_op = ack.observedPendingOp.name
         )

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/readingbookmark/repository/ReadingBookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/readingbookmark/repository/ReadingBookmarksRepositoryImpl.kt
@@ -14,7 +14,9 @@ import com.quran.shared.persistence.repository.readingbookmark.extension.toPageR
 import com.quran.shared.persistence.repository.readingbookmark.extension.toReadingBookmark
 import com.quran.shared.persistence.util.PlatformDateTime
 import com.quran.shared.persistence.util.QuranData
-import com.quran.shared.persistence.util.toEpochMillisecondsOrNull
+import com.quran.shared.persistence.util.currentEpochMilliseconds
+import com.quran.shared.persistence.util.currentPlatformDateTime
+import com.quran.shared.persistence.util.toEpochMillisecondsFromPlatform
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.Dispatchers
@@ -50,7 +52,7 @@ class ReadingBookmarksRepositoryImpl(
     }
 
     override suspend fun addAyahReadingBookmark(sura: Int, ayah: Int): AyahReadingBookmark {
-        return addAyahReadingBookmarkWithTimestampMillis(sura, ayah, timestampMillis = null)
+        return addAyahReadingBookmark(sura, ayah, currentPlatformDateTime())
     }
 
     override suspend fun addAyahReadingBookmark(
@@ -58,13 +60,13 @@ class ReadingBookmarksRepositoryImpl(
         ayah: Int,
         timestamp: PlatformDateTime
     ): AyahReadingBookmark {
-        return addAyahReadingBookmarkWithTimestampMillis(sura, ayah, timestamp.toEpochMillisecondsOrNull())
+        return addAyahReadingBookmarkWithTimestampMillis(sura, ayah, timestamp.toEpochMillisecondsFromPlatform())
     }
 
     private suspend fun addAyahReadingBookmarkWithTimestampMillis(
         sura: Int,
         ayah: Int,
-        timestampMillis: Long?
+        timestampMillis: Long
     ): AyahReadingBookmark {
         logger.i { "Adding ayah reading bookmark for $sura:$ayah" }
         return withContext(Dispatchers.IO) {
@@ -83,7 +85,7 @@ class ReadingBookmarksRepositoryImpl(
                     local_id = row.local_id,
                     timestamp = timestampMillis
                 )
-                reconciler.reconcile()
+                reconciler.reconcile(timestampMillis)
                 created = bookmarkQueries.value
                     .getBookmarkForAyah(sura.toLong(), ayah.toLong())
                     .executeAsOne()
@@ -94,16 +96,16 @@ class ReadingBookmarksRepositoryImpl(
     }
 
     override suspend fun addPageReadingBookmark(page: Int): PageReadingBookmark {
-        return addPageReadingBookmarkWithTimestampMillis(page, timestampMillis = null)
+        return addPageReadingBookmark(page, currentPlatformDateTime())
     }
 
     override suspend fun addPageReadingBookmark(page: Int, timestamp: PlatformDateTime): PageReadingBookmark {
-        return addPageReadingBookmarkWithTimestampMillis(page, timestamp.toEpochMillisecondsOrNull())
+        return addPageReadingBookmarkWithTimestampMillis(page, timestamp.toEpochMillisecondsFromPlatform())
     }
 
     private suspend fun addPageReadingBookmarkWithTimestampMillis(
         page: Int,
-        timestampMillis: Long?
+        timestampMillis: Long
     ): PageReadingBookmark {
         logger.i { "Adding page reading bookmark for page=$page" }
         return withContext(Dispatchers.IO) {
@@ -120,7 +122,7 @@ class ReadingBookmarksRepositoryImpl(
                     local_id = row.local_id,
                     timestamp = timestampMillis
                 )
-                reconciler.reconcile()
+                reconciler.reconcile(timestampMillis)
                 created = bookmarkQueries.value
                     .getBookmarkForPage(page.toLong())
                     .executeAsOne()
@@ -133,6 +135,7 @@ class ReadingBookmarksRepositoryImpl(
     override suspend fun deleteReadingBookmark(): Boolean {
         logger.i { "Deleting current reading bookmark" }
         return withContext(Dispatchers.IO) {
+            val timestampMillis = currentEpochMilliseconds()
             var deleted = false
             database.transaction {
                 val row = bookmarkQueries.value.getCurrentReadingBookmark().executeAsOneOrNull()
@@ -143,21 +146,21 @@ class ReadingBookmarksRepositoryImpl(
                 when {
                     hasSavedMembership -> bookmarkQueries.value.clearReadingBookmark(
                         local_id = row.local_id,
-                        timestamp = null
+                        timestamp = timestampMillis
                     )
                     row.remote_id == null && row.reading_pending_op == "CREATED" &&
                         row.reading_pending_version > 1L ->
                         bookmarkQueries.value.markPendingReadingBookmarkDeleted(
                             local_id = row.local_id,
-                            timestamp = null
+                            timestamp = timestampMillis
                         )
                     row.remote_id == null -> bookmarkQueries.value.hardDeleteBookmarkByLocalId(row.local_id)
                     else -> bookmarkQueries.value.markBookmarkDeleted(
                         local_id = row.local_id,
-                        timestamp = null
+                        timestamp = timestampMillis
                     )
                 }
-                reconciler.reconcile()
+                reconciler.reconcile(timestampMillis)
                 deleted = true
             }
             deleted

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/readingsession/repository/ReadingSessionsRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/readingsession/repository/ReadingSessionsRepositoryImpl.kt
@@ -19,8 +19,10 @@ import com.quran.shared.persistence.repository.buildRemoteResourceExistenceMap
 import com.quran.shared.persistence.repository.readingsession.extension.toReadingSession
 import com.quran.shared.persistence.repository.readingsession.extension.toReadingSessionMutation
 import com.quran.shared.persistence.util.PlatformDateTime
+import com.quran.shared.persistence.util.currentEpochMilliseconds
 import com.quran.shared.persistence.util.fromPlatform
-import com.quran.shared.persistence.util.toEpochMillisecondsOrNull
+import com.quran.shared.persistence.util.toEpochMillisecondsFromPlatform
+import com.quran.shared.persistence.util.toPlatform
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.Dispatchers
@@ -28,8 +30,7 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
-import kotlin.time.Clock
-import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 @Inject
 @SingleIn(AppScope::class)
@@ -68,21 +69,21 @@ class ReadingSessionsRepositoryImpl(
     }
 
     override suspend fun addReadingSession(sura: Int, ayah: Int): ReadingSession {
-        return addReadingSessionWithTimestampMillis(sura, ayah, timestampMillis = null)
+        return addReadingSession(sura, ayah, currentRepositoryPlatformDateTime())
     }
 
     override suspend fun addReadingSession(sura: Int, ayah: Int, timestamp: PlatformDateTime): ReadingSession {
-        return addReadingSessionWithTimestampMillis(sura, ayah, timestamp.toEpochMillisecondsOrNull())
+        return addReadingSessionWithTimestampMillis(sura, ayah, timestamp.toEpochMillisecondsFromPlatform())
     }
 
     private suspend fun addReadingSessionWithTimestampMillis(
         sura: Int,
         ayah: Int,
-        timestampMillis: Long?
+        timestampMillis: Long
     ): ReadingSession {
         logger.i { "Adding reading session ($sura:$ayah)" }
         return withContext(Dispatchers.IO) {
-            val updatedAt = timestampMillis ?: currentTimeMillis()
+            val updatedAt = timestampMillis
             var readingSession: ReadingSession? = null
 
             database.transaction {
@@ -107,7 +108,7 @@ class ReadingSessionsRepositoryImpl(
     }
 
     override suspend fun updateReadingSession(id: String, sura: Int, ayah: Int): ReadingSession {
-        return updateReadingSessionWithTimestampMillis(id, sura, ayah, timestampMillis = null)
+        return updateReadingSession(id, sura, ayah, currentRepositoryPlatformDateTime())
     }
 
     override suspend fun updateReadingSession(
@@ -116,19 +117,19 @@ class ReadingSessionsRepositoryImpl(
         ayah: Int,
         timestamp: PlatformDateTime
     ): ReadingSession {
-        return updateReadingSessionWithTimestampMillis(id, sura, ayah, timestamp.toEpochMillisecondsOrNull())
+        return updateReadingSessionWithTimestampMillis(id, sura, ayah, timestamp.toEpochMillisecondsFromPlatform())
     }
 
     private suspend fun updateReadingSessionWithTimestampMillis(
         id: String,
         sura: Int,
         ayah: Int,
-        timestampMillis: Long?
+        timestampMillis: Long
     ): ReadingSession {
         logger.i { "Updating reading session id=$id to $sura:$ayah" }
         return withContext(Dispatchers.IO) {
             val localId = id.toLong()
-            val updatedAt = timestampMillis ?: currentTimeMillis()
+            val updatedAt = timestampMillis
             var updatedSession: ReadingSession? = null
 
             database.transaction {
@@ -168,6 +169,7 @@ class ReadingSessionsRepositoryImpl(
     override suspend fun deleteReadingSession(sura: Int, ayah: Int): Boolean {
         logger.i { "Deleting reading session for $sura:$ayah" }
         return withContext(Dispatchers.IO) {
+            val timestampMillis = currentTimeMillis()
             var deleted = false
             database.transaction {
                 val existing = readingSessionsQueries.value.getReadingSessionForChapterVerse(
@@ -177,7 +179,8 @@ class ReadingSessionsRepositoryImpl(
                 if (existing != null) {
                     readingSessionsQueries.value.deleteReadingSession(
                         chapter_number = sura.toLong(),
-                        verse_number = ayah.toLong()
+                        verse_number = ayah.toLong(),
+                        timestamp = timestampMillis
                     )
                     deleted = true
                 }
@@ -440,7 +443,7 @@ class ReadingSessionsRepositoryImpl(
         val localId: Long,
         val pendingVersion: Long
     )
-}
 
-@OptIn(ExperimentalTime::class)
-private fun currentEpochMilliseconds(): Long = Clock.System.now().toEpochMilliseconds()
+    private fun currentRepositoryPlatformDateTime(): PlatformDateTime =
+        Instant.fromEpochMilliseconds(currentTimeMillis()).toPlatform()
+}

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/util/Timestamps.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/util/Timestamps.kt
@@ -1,5 +1,18 @@
 package com.quran.shared.persistence.util
 
-internal fun PlatformDateTime?.toEpochMillisecondsOrNull(): Long? {
-    return this?.fromPlatform()?.toEpochMilliseconds()
+import kotlin.time.Clock
+
+/**
+ * Returns the current system time converted to the platform date type used by public APIs.
+ */
+fun currentPlatformDateTime(): PlatformDateTime {
+    return Clock.System.now().toPlatform()
+}
+
+internal fun currentEpochMilliseconds(): Long {
+    return Clock.System.now().toEpochMilliseconds()
+}
+
+internal fun PlatformDateTime.toEpochMillisecondsFromPlatform(): Long {
+    return fromPlatform().toEpochMilliseconds()
 }

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmark_collections.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmark_collections.sq
@@ -90,7 +90,7 @@ getCollectionBookmarksWithDetails:
     b.sura AS sura,
     b.ayah AS ayah,
     b.page AS page,
-    b.modified_at AS bookmark_last_updated_at,
+    b.bookmark_modified_at AS bookmark_last_updated_at,
     b.created_at AS bookmark_added_at
   FROM bookmark_collection bc
   JOIN collection c ON c.local_id = bc.collection_local_id
@@ -119,7 +119,7 @@ getCollectionBookmarksForCollectionWithDetails:
     b.sura AS sura,
     b.ayah AS ayah,
     b.page AS page,
-    b.modified_at AS bookmark_last_updated_at,
+    b.bookmark_modified_at AS bookmark_last_updated_at,
     b.created_at AS bookmark_added_at
   FROM bookmark_collection bc
   JOIN collection c ON c.local_id = bc.collection_local_id
@@ -232,8 +232,8 @@ addBookmarkToCollection {
     1,
     'CREATED',
     0,
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    :timestamp,
+    :timestamp
   );
   UPDATE bookmark_collection
   SET is_active = 1,
@@ -251,7 +251,7 @@ addBookmarkToCollection {
       ELSE 'CREATED'
     END,
     pending_version = pending_version + 1,
-    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    modified_at = :timestamp
   WHERE bookmark_local_id = :bookmark_local_id
     AND collection_local_id = :collection_local_id;
 }
@@ -295,7 +295,7 @@ markBookmarkCollectionDeleted {
   SET is_active = 0,
     pending_op = 'DELETED',
     pending_version = CASE WHEN pending_op = 'DELETED' THEN pending_version ELSE pending_version + 1 END,
-    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    modified_at = :timestamp
   WHERE bookmark_local_id = :bookmark_local_id
     AND collection_local_id = :collection_local_id;
 }
@@ -310,7 +310,7 @@ markBookmarkCollectionsDeletedForBookmark {
   SET is_active = 0,
     pending_op = 'DELETED',
     pending_version = CASE WHEN pending_op = 'DELETED' THEN pending_version ELSE pending_version + 1 END,
-    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    modified_at = :timestamp
   WHERE bookmark_local_id = :bookmark_local_id;
 }
 
@@ -328,8 +328,7 @@ clearLocalMutationFor {
 bindRemoteSnapshotForCreatedAck:
   UPDATE bookmark_collection
   SET last_synced_bookmark_remote_id = COALESCE(:bookmark_remote_id, last_synced_bookmark_remote_id),
-    last_synced_collection_remote_id = COALESCE(:collection_remote_id, last_synced_collection_remote_id),
-    modified_at = :modified_at
+    last_synced_collection_remote_id = COALESCE(:collection_remote_id, last_synced_collection_remote_id)
   WHERE local_id = :id
     AND is_active = 0
     AND pending_op = 'DELETED';
@@ -405,8 +404,7 @@ persistRemoteBookmarkCollection {
 deleteRemoteBookmarkCollectionBySnapshot {
   UPDATE bookmark_collection
   SET last_synced_bookmark_remote_id = NULL,
-    last_synced_collection_remote_id = NULL,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+    last_synced_collection_remote_id = NULL
   WHERE last_synced_bookmark_remote_id = :bookmark_remote_id
     AND last_synced_collection_remote_id = :collection_remote_id
     AND is_active = 1
@@ -440,7 +438,7 @@ markActiveLinksWithChangedSnapshots:
   UPDATE bookmark_collection
   SET pending_op = 'CREATED',
     pending_version = pending_version + 1,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+    modified_at = :modified_at
   WHERE is_active = 1
     AND pending_op IS NULL
     AND (
@@ -517,7 +515,7 @@ markSyncedLinksForInactiveParents:
   SET is_active = 0,
     pending_op = 'DELETED',
     pending_version = CASE WHEN pending_op = 'DELETED' THEN pending_version ELSE pending_version + 1 END,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+    modified_at = CASE WHEN pending_op = 'DELETED' THEN modified_at ELSE :modified_at END
   WHERE (
       last_synced_bookmark_remote_id IS NOT NULL
       OR last_synced_collection_remote_id IS NOT NULL

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks.sq
@@ -180,9 +180,9 @@ upsertAyahBookmark {
     0,
     0,
     0,
-    COALESCE(:created_at, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    COALESCE(:modified_at, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    COALESCE(:modified_at, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    :created_at,
+    :modified_at,
+    :modified_at
   );
   UPDATE bookmark
   SET remote_id = CASE
@@ -204,8 +204,8 @@ upsertAyahBookmark {
       WHEN :remote_id IS NULL AND bookmark_pending_op = 'DELETED' THEN bookmark_pending_version + 1
       ELSE bookmark_pending_version
     END,
-    modified_at = COALESCE(:modified_at, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    bookmark_modified_at = COALESCE(:modified_at, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    modified_at = :modified_at,
+    bookmark_modified_at = :modified_at
   WHERE bookmark_type = 'AYAH' AND sura = :sura AND ayah = :ayah AND mushaf_id = 1;
 }
 
@@ -236,9 +236,9 @@ upsertPageBookmark {
     0,
     0,
     0,
-    COALESCE(:created_at, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    COALESCE(:modified_at, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    COALESCE(:modified_at, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    :created_at,
+    :modified_at,
+    :modified_at
   );
   UPDATE bookmark
   SET remote_id = CASE
@@ -259,8 +259,8 @@ upsertPageBookmark {
       WHEN :remote_id IS NULL AND bookmark_pending_op = 'DELETED' THEN bookmark_pending_version + 1
       ELSE bookmark_pending_version
     END,
-    modified_at = COALESCE(:modified_at, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    bookmark_modified_at = COALESCE(:modified_at, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    modified_at = :modified_at,
+    bookmark_modified_at = :modified_at
   WHERE bookmark_type = 'PAGE' AND page = :page AND mushaf_id = 1;
 }
 
@@ -292,10 +292,10 @@ addAyahToDefaultCollection {
     0,
     1,
     0,
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    :timestamp,
+    :timestamp,
+    :timestamp,
+    :timestamp,
     'CREATED',
     1
   );
@@ -327,8 +327,8 @@ addAyahToDefaultCollection {
       WHEN default_pending_op = 'CREATED' THEN default_pending_version
       ELSE default_pending_version + 1
     END,
-    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    default_modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    modified_at = :timestamp,
+    default_modified_at = :timestamp
   WHERE bookmark_type = 'AYAH' AND sura = :sura AND ayah = :ayah AND mushaf_id = 1;
 }
 
@@ -356,8 +356,8 @@ clearDefaultCollection {
         AND default_pending_op IS NULL THEN default_pending_version + 1
       ELSE default_pending_version
     END,
-    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    default_modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    modified_at = :timestamp,
+    default_modified_at = :timestamp
   WHERE local_id = :local_id;
 }
 
@@ -395,9 +395,7 @@ bindDefaultRemoteSnapshotForCreatedAck:
       WHEN remote_id IS NULL THEN :remote_id
       ELSE remote_id
     END,
-    default_last_synced_bookmark_remote_id = :default_last_synced_bookmark_remote_id,
-    modified_at = :modified_at,
-    default_modified_at = :modified_at
+    default_last_synced_bookmark_remote_id = :default_last_synced_bookmark_remote_id
   WHERE local_id = :local_id
     AND is_in_default_collection = 0
     AND default_pending_op = 'DELETED';
@@ -494,10 +492,10 @@ setAyahReadingBookmark {
     0,
     'CREATED',
     1,
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    :timestamp,
+    :timestamp,
+    :timestamp,
+    :timestamp
   );
   UPDATE bookmark
   SET ayah_id = :ayah_id,
@@ -516,8 +514,8 @@ setAyahReadingBookmark {
       WHEN is_reading = 1 AND reading_pending_op = 'CREATED' THEN reading_pending_version
       ELSE reading_pending_version + 1
     END,
-    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    reading_modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    modified_at = :timestamp,
+    reading_modified_at = :timestamp
   WHERE bookmark_type = 'AYAH' AND sura = :sura AND ayah = :ayah AND mushaf_id = 1;
 }
 
@@ -551,10 +549,10 @@ setPageReadingBookmark {
     0,
     'CREATED',
     1,
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    :timestamp,
+    :timestamp,
+    :timestamp,
+    :timestamp
   );
   UPDATE bookmark
   SET is_reading = 1,
@@ -572,8 +570,8 @@ setPageReadingBookmark {
       WHEN is_reading = 1 AND reading_pending_op = 'CREATED' THEN reading_pending_version
       ELSE reading_pending_version + 1
     END,
-    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    reading_modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    modified_at = :timestamp,
+    reading_modified_at = :timestamp
   WHERE bookmark_type = 'PAGE' AND page = :page AND mushaf_id = 1;
 }
 
@@ -667,8 +665,8 @@ clearOtherReadingBookmarks:
       ELSE 'CREATED'
     END,
     reading_pending_version = reading_pending_version + 1,
-    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    reading_modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    modified_at = :timestamp,
+    reading_modified_at = :timestamp
   WHERE deleted = 0 AND is_reading = 1 AND local_id != :local_id;
 
 clearReadingBookmark:
@@ -680,8 +678,8 @@ clearReadingBookmark:
       ELSE 'CREATED'
     END,
     reading_pending_version = reading_pending_version + 1,
-    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    reading_modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    modified_at = :timestamp,
+    reading_modified_at = :timestamp
   WHERE local_id = :local_id;
 
 markBookmarkDeleted:
@@ -695,7 +693,7 @@ markBookmarkDeleted:
     reading_pending_version = reading_pending_version + 1,
     default_pending_op = NULL,
     default_pending_version = default_pending_version + 1,
-    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    modified_at = :timestamp
   WHERE local_id = :local_id AND remote_id IS NOT NULL;
 
 markPendingReadingBookmarkDeleted:
@@ -712,8 +710,8 @@ markPendingReadingBookmarkDeleted:
     reading_pending_version = reading_pending_version + 1,
     default_pending_op = NULL,
     default_pending_version = default_pending_version + 1,
-    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    reading_modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000)
+    modified_at = :timestamp,
+    reading_modified_at = :timestamp
   WHERE local_id = :local_id
     AND remote_id IS NULL
     AND reading_pending_op = 'CREATED';

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/collections.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/collections.sq
@@ -61,7 +61,7 @@ addNewCollection {
       WHEN deleted = 1 THEN 1
       ELSE is_edited
     END,
-    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    modified_at = :timestamp,
     pending_version = CASE
       WHEN remote_id IS NULL OR deleted = 1 OR is_edited = 1 THEN pending_version + 1
       ELSE pending_version
@@ -74,7 +74,7 @@ addNewCollection {
       WHEN remote_id IS NULL THEN 0
       ELSE 1
     END,
-    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    modified_at = :timestamp,
     pending_version = pending_version + 1
   WHERE local_id = (
     SELECT local_id FROM collection
@@ -92,8 +92,8 @@ addNewCollection {
   SELECT
     NULL,
     :name,
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    :timestamp,
+    :timestamp,
     0,
     0,
     1
@@ -147,7 +147,7 @@ updateCollectionName:
   UPDATE collection
   SET name = :name,
     is_edited = CASE WHEN remote_id IS NULL THEN is_edited ELSE 1 END,
-    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    modified_at = :timestamp,
     pending_version = pending_version + 1
   WHERE local_id = :id
     AND deleted = 0;
@@ -162,11 +162,12 @@ deleteCollection {
   SET is_active = 0,
     pending_op = 'DELETED',
     pending_version = CASE WHEN pending_op = 'DELETED' THEN pending_version ELSE pending_version + 1 END,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+    modified_at = :timestamp
   WHERE collection_local_id = :id;
   UPDATE collection
   SET deleted = 1,
     is_edited = CASE WHEN remote_id IS NULL THEN is_edited ELSE 1 END,
+    modified_at = :timestamp,
     pending_version = pending_version + 1
   WHERE local_id = :id;
 }
@@ -256,7 +257,7 @@ clearLocalMutationFor {
   UPDATE collection
   SET deleted = 0,
     is_edited = 0,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+    modified_at = :modified_at
   WHERE local_id = :id
     AND pending_version = :pending_version
     AND (

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/notes.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/notes.sq
@@ -77,8 +77,8 @@ addNewNote:
     :note,
     :start_ayah_id,
     :end_ayah_id,
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
-    COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    :timestamp,
+    :timestamp,
     0,
     1
   );
@@ -114,7 +114,7 @@ updateNote:
     end_ayah_id = :end_ayah_id,
     deleted = 0,
     is_edited = CASE WHEN remote_id IS NULL THEN 0 ELSE 1 END,
-    modified_at = COALESCE(:timestamp, CAST(strftime('%s', 'now') AS INTEGER) * 1000),
+    modified_at = :timestamp,
     pending_version = pending_version + 1
   WHERE local_id = :id;
 
@@ -122,6 +122,7 @@ deleteNote {
   UPDATE note
   SET deleted = 1,
     is_edited = CASE WHEN remote_id IS NULL THEN is_edited ELSE 1 END,
+    modified_at = :timestamp,
     pending_version = pending_version + 1
   WHERE local_id = :id;
 }
@@ -197,7 +198,7 @@ clearLocalMutationFor {
   UPDATE note
   SET deleted = 0,
     is_edited = 0,
-    modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+    modified_at = :modified_at
   WHERE local_id = :id
     AND remote_id IS NOT NULL
     AND deleted = 0

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/reading_sessions.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/reading_sessions.sq
@@ -187,6 +187,7 @@ deleteReadingSession {
   UPDATE reading_session
   SET deleted = 1,
     is_edited = CASE WHEN remote_id IS NULL THEN is_edited ELSE 1 END,
+    modified_at = :timestamp,
     pending_version = pending_version + 1
   WHERE chapter_number = :chapter_number AND verse_number = :verse_number AND deleted = 0;
 }

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarkSyncArchitectureTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarkSyncArchitectureTest.kt
@@ -17,6 +17,7 @@ import com.quran.shared.persistence.input.RemoteCollection
 import com.quran.shared.persistence.input.RemoteCollectionBookmark
 import com.quran.shared.persistence.model.DEFAULT_COLLECTION_ID
 import com.quran.shared.persistence.model.PageReadingBookmark
+import com.quran.shared.persistence.repository.bookmark.BookmarkDependencyReconciler
 import com.quran.shared.persistence.repository.bookmark.repository.BookmarksRepositoryImpl
 import com.quran.shared.persistence.repository.collection.repository.CollectionsRepositoryImpl
 import com.quran.shared.persistence.repository.collectionbookmark.repository.CollectionBookmarksRepositoryImpl
@@ -352,6 +353,24 @@ class BookmarkSyncArchitectureTest {
         assertEquals(100L, linked.bookmarkLastUpdated.fromPlatform().toEpochMilliseconds())
         assertEquals(100L, linked.bookmarkAddedDate.fromPlatform().toEpochMilliseconds())
         assertEquals(linked, queried)
+    }
+
+    @Test
+    fun `collection bookmark projections expose bookmark timestamp after default membership changes`() = runTest {
+        val collectionId = createCollection("ProjectionTimestamp", "remote-projection-timestamp")
+        val bookmark = bookmarksRepository.addBookmark(2, 22, listOf(collectionId), at(100))
+
+        collectionBookmarksRepository.addBookmarkToCollection(DEFAULT_COLLECTION_ID, bookmark, at(300))
+
+        val row = database.bookmarksQueries.getBookmarkByLocalId(bookmark.id.toLong()).executeAsOne()
+        val defaultBookmark = collectionBookmarksRepository.getBookmarksForCollection(DEFAULT_COLLECTION_ID).single()
+        val customBookmark = collectionBookmarksRepository.getBookmarksForCollection(collectionId).single()
+
+        assertEquals(300L, row.modified_at)
+        assertEquals(300L, row.default_modified_at)
+        assertEquals(100L, row.bookmark_modified_at)
+        assertEquals(100L, defaultBookmark.bookmarkLastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(100L, customBookmark.bookmarkLastUpdated.fromPlatform().toEpochMilliseconds())
     }
 
     @Test
@@ -1163,9 +1182,16 @@ class BookmarkSyncArchitectureTest {
         assertTrue(collectionsRepository.deleteCollection(collectionId))
 
         val deletion = collectionBookmarksRepository.fetchMutatedCollectionBookmarks().single()
+        val collectionRow = database.collectionsQueries.getCollectionByLocalId(collectionId.toLong()).executeAsOne()
+        val bookmarkRow = database.bookmarksQueries.getBookmarkByRemoteId("remote-bookmark-4-4").executeAsOne()
+        val linkRow = database.bookmark_collectionsQueries
+            .getCollectionBookmarkFor(bookmarkRow.local_id, collectionId.toLong())
+            .executeAsOne()
         assertEquals(Mutation.DELETED, deletion.mutation)
         assertEquals("remote-delete-collection", deletion.model.collectionRemoteId)
         assertEquals("remote-bookmark-4-4", deletion.model.bookmarkRemoteId)
+        assertEquals(collectionRow.modified_at, linkRow.modified_at)
+        assertEquals(collectionRow.modified_at, deletion.model.lastUpdated.fromPlatform().toEpochMilliseconds())
     }
 
     @Test
@@ -1423,7 +1449,7 @@ class BookmarkSyncArchitectureTest {
             modified_at = 200L,
             local_id = collectionId.toLong()
         )
-        collectionBookmarksRepository.addBookmarkToCollection(collectionId, bookmark)
+        collectionBookmarksRepository.addBookmarkToCollection(collectionId, bookmark, at(300))
 
         collectionBookmarksRepository.applyRemoteChanges(
             updatesToPersist = listOf(
@@ -1442,8 +1468,48 @@ class BookmarkSyncArchitectureTest {
         assertEquals(Mutation.CREATED, recreated.mutation)
         assertEquals("remote-new-recreate", recreated.model.collectionRemoteId)
         assertEquals("remote-bookmark-4-10", recreated.model.bookmarkRemoteId)
+        assertEquals(300L, recreated.model.lastUpdated.fromPlatform().toEpochMilliseconds())
         val row = database.bookmarksQueries.getBookmarkForAyah(4L, 10L).executeAsOne()
+        val link = database.bookmark_collectionsQueries
+            .getCollectionBookmarkFor(row.local_id, collectionId.toLong())
+            .executeAsOne()
+        assertEquals(300L, link.modified_at)
         assertEquals(1L, database.bookmark_collectionsQueries.countActiveForBookmark(row.local_id).executeAsOne())
+    }
+
+    @Test
+    fun `changed custom link snapshots use reconciler timestamp`() = runTest {
+        val collectionId = createCollection("SnapshotTimestamp", "remote-snapshot-old")
+        collectionBookmarksRepository.applyRemoteChanges(
+            updatesToPersist = listOf(
+                customRemoteMutation(
+                    collectionId = "remote-snapshot-old",
+                    sura = 4,
+                    ayah = 11,
+                    bookmarkId = "remote-bookmark-snapshot",
+                    mutation = Mutation.CREATED
+                )
+            ),
+            localMutationsToClear = emptyList()
+        )
+        database.collectionsQueries.updateRemoteCollectionByLocalId(
+            remote_id = "remote-snapshot-new",
+            name = "SnapshotTimestamp",
+            modified_at = 200L,
+            local_id = collectionId.toLong()
+        )
+
+        BookmarkDependencyReconciler(database).reconcile(777L)
+
+        val recreated = collectionBookmarksRepository.fetchMutatedCollectionBookmarks().single()
+        val bookmark = database.bookmarksQueries.getBookmarkByRemoteId("remote-bookmark-snapshot").executeAsOne()
+        val link = database.bookmark_collectionsQueries
+            .getCollectionBookmarkFor(bookmark.local_id, collectionId.toLong())
+            .executeAsOne()
+        assertEquals(Mutation.CREATED, recreated.mutation)
+        assertEquals("remote-snapshot-new", recreated.model.collectionRemoteId)
+        assertEquals(777L, link.modified_at)
+        assertEquals(777L, recreated.model.lastUpdated.fromPlatform().toEpochMilliseconds())
     }
 
     @Test
@@ -2267,6 +2333,44 @@ class BookmarkSyncArchitectureTest {
     }
 
     @Test
+    fun `reading bookmark delete stamps derived inactive custom link delete with same timestamp`() = runTest {
+        val collectionId = createCollection("ReadingDeleteLinkTimestamp", "remote-reading-delete-link-timestamp")
+        collectionBookmarksRepository.applyRemoteChanges(
+            updatesToPersist = listOf(
+                customRemoteMutation(
+                    collectionId = "remote-reading-delete-link-timestamp",
+                    sura = 6,
+                    ayah = 8,
+                    bookmarkId = "remote-reading-delete-link-bookmark",
+                    mutation = Mutation.CREATED
+                )
+            ),
+            localMutationsToClear = emptyList()
+        )
+        val bookmark = bookmarksRepository.getAllBookmarks().single()
+        collectionBookmarksRepository.removeBookmarkFromCollection(collectionId, bookmark)
+        val linkDelete = collectionBookmarksRepository.fetchMutatedCollectionBookmarks().single()
+        collectionBookmarksRepository.applyRemoteChanges(
+            updatesToPersist = emptyList(),
+            localMutationsToClear = listOf(linkDelete)
+        )
+
+        readingRepository.addAyahReadingBookmark(6, 8, at(200))
+        assertTrue(readingRepository.deleteReadingBookmark())
+
+        val bookmarkRow = database.bookmarksQueries
+            .getBookmarkByRemoteId("remote-reading-delete-link-bookmark")
+            .executeAsOne()
+        val linkRow = database.bookmark_collectionsQueries
+            .getCollectionBookmarkByLocalId(linkDelete.localID.toLong())
+            .executeAsOne()
+        val derivedLinkDelete = collectionBookmarksRepository.fetchMutatedCollectionBookmarks().single()
+        assertEquals("DELETED", linkRow.pending_op)
+        assertEquals(bookmarkRow.modified_at, linkRow.modified_at)
+        assertEquals(bookmarkRow.modified_at, derivedLinkDelete.model.lastUpdated.fromPlatform().toEpochMilliseconds())
+    }
+
+    @Test
     fun `local deletes without explicit timestamp advance modified timestamps`() = runTest {
         collectionBookmarksRepository.applyRemoteChanges(
             updatesToPersist = listOf(defaultRemoteMutation(6, 4, "remote-default-timestamp", Mutation.CREATED)),
@@ -2490,16 +2594,19 @@ class BookmarkSyncArchitectureTest {
         collectionBookmarksRepository.removeBookmarkFromCollection(DEFAULT_COLLECTION_ID, bookmark)
         val staleDefaultDelete = collectionBookmarksRepository.fetchMutatedCollectionBookmarks().single()
 
-        bookmarksRepository.addBookmark(8, 3, listOf(DEFAULT_COLLECTION_ID))
+        bookmarksRepository.addBookmark(8, 3, listOf(DEFAULT_COLLECTION_ID), at(200))
         collectionBookmarksRepository.applyRemoteChanges(
             updatesToPersist = emptyList(),
             localMutationsToClear = listOf(staleDefaultDelete)
         )
 
         val row = database.bookmarksQueries.getBookmarkByRemoteId("remote-stale-default").executeAsOne()
+        val createMutation = collectionBookmarksRepository.fetchMutatedCollectionBookmarks().single()
         assertEquals(1L, row.is_in_default_collection)
         assertEquals("CREATED", row.default_pending_op)
-        assertEquals(Mutation.CREATED, collectionBookmarksRepository.fetchMutatedCollectionBookmarks().single().mutation)
+        assertEquals(200L, row.default_modified_at)
+        assertEquals(Mutation.CREATED, createMutation.mutation)
+        assertEquals(200L, createMutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
     }
 
     @Test
@@ -2521,7 +2628,7 @@ class BookmarkSyncArchitectureTest {
         collectionBookmarksRepository.removeBookmarkFromCollection(collectionId, bookmark)
         val staleCustomDelete = collectionBookmarksRepository.fetchMutatedCollectionBookmarks().single()
 
-        collectionBookmarksRepository.addBookmarkToCollection(collectionId, bookmark)
+        collectionBookmarksRepository.addBookmarkToCollection(collectionId, bookmark, at(200))
         collectionBookmarksRepository.applyRemoteChanges(
             updatesToPersist = emptyList(),
             localMutationsToClear = listOf(staleCustomDelete)
@@ -2531,9 +2638,12 @@ class BookmarkSyncArchitectureTest {
         val link = database.bookmark_collectionsQueries
             .getCollectionBookmarkFor(row.local_id, collectionId.toLong())
             .executeAsOne()
+        val createMutation = collectionBookmarksRepository.fetchMutatedCollectionBookmarks().single()
         assertEquals(1L, link.is_active)
         assertEquals("CREATED", link.pending_op)
-        assertEquals(Mutation.CREATED, collectionBookmarksRepository.fetchMutatedCollectionBookmarks().single().mutation)
+        assertEquals(200L, link.modified_at)
+        assertEquals(Mutation.CREATED, createMutation.mutation)
+        assertEquals(200L, createMutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
     }
 
     @Test
@@ -2802,6 +2912,7 @@ class BookmarkSyncArchitectureTest {
         val tombstoneBeforeAck = database.bookmarksQueries
             .getBookmarkByLocalId(bookmark.id.toLong())
             .executeAsOne()
+        val tombstoneTimestamp = requireNotNull(tombstoneBeforeAck.default_modified_at)
         assertEquals(1L, tombstoneBeforeAck.deleted)
         assertEquals(0L, tombstoneBeforeAck.is_in_default_collection)
         assertEquals("DELETED", tombstoneBeforeAck.default_pending_op)
@@ -2825,9 +2936,11 @@ class BookmarkSyncArchitectureTest {
             .executeAsOne()
         assertEquals("remote-import-default-create", tombstoneAfterAck.remote_id)
         assertEquals("DELETED", tombstoneAfterAck.default_pending_op)
+        assertEquals(tombstoneTimestamp, tombstoneAfterAck.default_modified_at)
         val deleteMutation = collectionBookmarksRepository.fetchMutatedCollectionBookmarks().single()
         assertEquals(Mutation.DELETED, deleteMutation.mutation)
         assertEquals("remote-import-default-create", deleteMutation.model.bookmarkRemoteId)
+        assertEquals(tombstoneTimestamp, deleteMutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
     }
 
     @Test
@@ -2841,6 +2954,7 @@ class BookmarkSyncArchitectureTest {
         val linkBeforeAck = database.bookmark_collectionsQueries
             .getCollectionBookmarkByLocalId(customCreate.localID.toLong())
             .executeAsOne()
+        val linkDeleteTimestamp = linkBeforeAck.modified_at
         assertEquals(0L, linkBeforeAck.is_active)
         assertEquals("DELETED", linkBeforeAck.pending_op)
         assertNull(linkBeforeAck.last_synced_bookmark_remote_id)
@@ -2865,12 +2979,14 @@ class BookmarkSyncArchitectureTest {
         val bookmarkAfterAck = database.bookmarksQueries.getBookmarkForAyah(8L, 14L).executeAsOne()
         assertEquals("remote-import-custom-bookmark", bookmarkAfterAck.remote_id)
         assertEquals("DELETED", linkAfterAck.pending_op)
+        assertEquals(linkDeleteTimestamp, linkAfterAck.modified_at)
         assertEquals("remote-import-custom-bookmark", linkAfterAck.last_synced_bookmark_remote_id)
         assertEquals("remote-import-pending-custom", linkAfterAck.last_synced_collection_remote_id)
         val deleteMutation = collectionBookmarksRepository.fetchMutatedCollectionBookmarks().single()
         assertEquals(Mutation.DELETED, deleteMutation.mutation)
         assertEquals("remote-import-custom-bookmark", deleteMutation.model.bookmarkRemoteId)
         assertEquals("remote-import-pending-custom", deleteMutation.model.collectionRemoteId)
+        assertEquals(linkDeleteTimestamp, deleteMutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
     }
 
     @Test
@@ -2885,6 +3001,7 @@ class BookmarkSyncArchitectureTest {
         val linkBeforeAck = database.bookmark_collectionsQueries
             .getCollectionBookmarkByLocalId(customCreate.localID.toLong())
             .executeAsOne()
+        val linkDeleteTimestamp = linkBeforeAck.modified_at
         assertEquals(0L, linkBeforeAck.is_active)
         assertEquals("DELETED", linkBeforeAck.pending_op)
         assertNull(linkBeforeAck.last_synced_bookmark_remote_id)
@@ -2904,9 +3021,14 @@ class BookmarkSyncArchitectureTest {
         )
 
         val deleteMutation = collectionBookmarksRepository.fetchMutatedCollectionBookmarks().single()
+        val linkAfterAck = database.bookmark_collectionsQueries
+            .getCollectionBookmarkByLocalId(customCreate.localID.toLong())
+            .executeAsOne()
+        assertEquals(linkDeleteTimestamp, linkAfterAck.modified_at)
         assertEquals(Mutation.DELETED, deleteMutation.mutation)
         assertEquals("remote-pending-custom-delete-collection-row", deleteMutation.model.bookmarkRemoteId)
         assertEquals("remote-pending-custom-delete-collection", deleteMutation.model.collectionRemoteId)
+        assertEquals(linkDeleteTimestamp, deleteMutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
     }
 
     @Test
@@ -3189,9 +3311,11 @@ class BookmarkSyncArchitectureTest {
         val beforeAck = database.bookmarksQueries
             .getBookmarkByLocalId(bookmark.id.toLong())
             .executeAsOne()
+        val readdTimestamp = requireNotNull(beforeAck.default_modified_at)
         assertEquals(1L, beforeAck.is_in_default_collection)
         assertEquals("DELETED", beforeAck.default_pending_op)
         assertNull(beforeAck.remote_id)
+        assertEquals(150L, readdTimestamp)
 
         val createAck = LocalModelMutation(
             model = defaultCreate.model.copy(bookmarkRemoteId = "remote-default-readd"),
@@ -3211,6 +3335,7 @@ class BookmarkSyncArchitectureTest {
         assertEquals(1L, afterAck.is_in_default_collection)
         assertEquals("remote-default-readd", afterAck.remote_id)
         assertNull(afterAck.default_pending_op)
+        assertEquals(readdTimestamp, afterAck.default_modified_at)
         assertTrue(collectionBookmarksRepository.fetchMutatedCollectionBookmarks().none())
     }
 
@@ -3227,6 +3352,7 @@ class BookmarkSyncArchitectureTest {
         val beforeAck = database.bookmarksQueries
             .getBookmarkByLocalId(bookmark.id.toLong())
             .executeAsOne()
+        val deleteTimestamp = requireNotNull(beforeAck.default_modified_at)
         assertEquals(0L, beforeAck.is_in_default_collection)
         assertEquals("DELETED", beforeAck.default_pending_op)
         assertNull(beforeAck.remote_id)
@@ -3249,9 +3375,11 @@ class BookmarkSyncArchitectureTest {
             .executeAsOne()
         assertEquals("remote-default-readd-remove", afterAck.remote_id)
         assertEquals("DELETED", afterAck.default_pending_op)
+        assertEquals(deleteTimestamp, afterAck.default_modified_at)
         val deleteMutation = collectionBookmarksRepository.fetchMutatedCollectionBookmarks().single()
         assertEquals(Mutation.DELETED, deleteMutation.mutation)
         assertEquals("remote-default-readd-remove", deleteMutation.model.bookmarkRemoteId)
+        assertEquals(deleteTimestamp, deleteMutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
     }
 
     @Test
@@ -3349,6 +3477,10 @@ class BookmarkSyncArchitectureTest {
         collectionBookmarksRepository.markMutatedCollectionBookmarksInFlight(listOf(assertNotNull(remoteBackedCreate.ack)))
 
         collectionBookmarksRepository.removeBookmarkFromCollection(DEFAULT_COLLECTION_ID, remoteBackedBookmark)
+        val remoteBackedBeforeAck = database.bookmarksQueries
+            .getBookmarkByLocalId(remoteBackedBookmark.id.toLong())
+            .executeAsOne()
+        val remoteBackedDeleteTimestamp = requireNotNull(remoteBackedBeforeAck.default_modified_at)
         collectionBookmarksRepository.applyRemoteChanges(
             updatesToPersist = emptyList(),
             localMutationsToClear = listOf(remoteBackedCreate)
@@ -3364,6 +3496,8 @@ class BookmarkSyncArchitectureTest {
         }
         assertEquals(Mutation.DELETED, remoteBackedDelete.mutation)
         assertEquals("remote-pending-default-backed", remoteBackedDelete.model.bookmarkRemoteId)
+        assertEquals(remoteBackedDeleteTimestamp, remoteBackedRow.default_modified_at)
+        assertEquals(remoteBackedDeleteTimestamp, remoteBackedDelete.model.lastUpdated.fromPlatform().toEpochMilliseconds())
     }
 
     @Test
@@ -3686,7 +3820,7 @@ class BookmarkSyncArchitectureTest {
     }
 
     private fun createCollection(name: String, remoteId: String): String {
-        database.collectionsQueries.addNewCollection(name = name, timestamp = null)
+        database.collectionsQueries.addNewCollection(name = name, timestamp = 1L)
         val collection = database.collectionsQueries.getCollectionByName(name).executeAsOne()
         database.collectionsQueries.updateRemoteCollectionByLocalId(
             remote_id = remoteId,

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionsRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionsRepositoryTest.kt
@@ -149,7 +149,7 @@ class CollectionsRepositoryTest {
     }
 
     @Test
-    fun `deleteCollection preserves timestamp for remote rows`() = runTest {
+    fun `deleteCollection updates timestamp for remote rows`() = runTest {
         database.collectionsQueries.persistRemoteCollection(
             remote_id = "remote-collection-id",
             name = "Favorites",
@@ -163,8 +163,8 @@ class CollectionsRepositoryTest {
         val mutation = repository.fetchMutatedCollections().single()
         val record = database.collectionsQueries.getCollectionByRemoteId("remote-collection-id").executeAsOne()
         assertEquals(Mutation.DELETED, mutation.mutation)
-        assertEquals(1000L, mutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
-        assertEquals(1000L, record.modified_at)
+        assertTrue(mutation.model.lastUpdated.fromPlatform().toEpochMilliseconds() > 1000L)
+        assertTrue(record.modified_at > 1000L)
     }
 
     @Test
@@ -228,6 +228,7 @@ class CollectionsRepositoryTest {
         val record = database.collectionsQueries.getCollectionByRemoteId("remote-collection-id").executeAsOne()
         assertEquals("Synced", record.name)
         assertEquals(0L, record.is_edited)
+        assertEquals(2000L, record.modified_at)
         assertEquals(emptyList(), repository.fetchMutatedCollections())
     }
 

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/NotesRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/NotesRepositoryTest.kt
@@ -17,6 +17,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.time.Instant
 
 class NotesRepositoryTest {
@@ -127,7 +128,7 @@ class NotesRepositoryTest {
     }
 
     @Test
-    fun `deleteNote preserves timestamp for remote rows`() = runTest {
+    fun `deleteNote updates timestamp for remote rows`() = runTest {
         database.notesQueries.persistRemoteNote(
             remote_id = "remote-note-id",
             note = "test note",
@@ -143,8 +144,8 @@ class NotesRepositoryTest {
         val mutation = repository.fetchMutatedNotes(0).single()
         val record = database.notesQueries.getNoteByLocalId(note.local_id).executeAsOne()
         assertEquals(Mutation.DELETED, mutation.mutation)
-        assertEquals(1_700_000_001_000L, mutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
-        assertEquals(1_700_000_001_000L, record.modified_at)
+        assertTrue(mutation.model.lastUpdated.fromPlatform().toEpochMilliseconds() > 1_700_000_001_000L)
+        assertTrue(record.modified_at > 1_700_000_001_000L)
     }
 
     @Test
@@ -180,6 +181,7 @@ class NotesRepositoryTest {
         val record = database.notesQueries.getNoteByRemoteId("remote-note-id").executeAsOne()
         assertEquals("synced note", record.note)
         assertEquals(0L, record.is_edited)
+        assertEquals(1_700_000_002_000L, record.modified_at)
         assertEquals(emptyList(), repository.fetchMutatedNotes(0))
     }
 

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/ReadingSessionsRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/ReadingSessionsRepositoryTest.kt
@@ -152,7 +152,7 @@ class ReadingSessionsRepositoryTest {
     }
 
     @Test
-    fun `deleteReadingSession does not update remote row timestamp`() = runTest {
+    fun `deleteReadingSession updates remote row timestamp`() = runTest {
         repository = ReadingSessionsRepositoryImpl(database) { 1234567890123L }
         database.reading_sessionsQueries.persistRemoteReadingSession(
             remote_id = "remote-reading-session-id",
@@ -168,12 +168,12 @@ class ReadingSessionsRepositoryTest {
         val record = database.reading_sessionsQueries.getReadingSessionByRemoteId("remote-reading-session-id")
             .executeAsOne()
         assertEquals(Mutation.DELETED, localMutation.mutation)
-        assertEquals(1L, localMutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
-        assertEquals(1L, record.modified_at)
+        assertEquals(1234567890123L, localMutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1234567890123L, record.modified_at)
     }
 
     @Test
-    fun `deleteReadingSession preserves timestamp for remote rows`() = runTest {
+    fun `deleteReadingSession uses injected clock for remote row timestamp`() = runTest {
         repository = ReadingSessionsRepositoryImpl(database) { 9999L }
         database.reading_sessionsQueries.persistRemoteReadingSession(
             remote_id = "remote-reading-session-id",
@@ -189,8 +189,8 @@ class ReadingSessionsRepositoryTest {
         val record = database.reading_sessionsQueries.getReadingSessionByRemoteId("remote-reading-session-id")
             .executeAsOne()
         assertEquals(Mutation.DELETED, localMutation.mutation)
-        assertEquals(1L, localMutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
-        assertEquals(1L, record.modified_at)
+        assertEquals(9999L, localMutation.model.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(9999L, record.modified_at)
     }
 
     @Test

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/QuranDataService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/QuranDataService.kt
@@ -28,6 +28,7 @@ import com.quran.shared.persistence.repository.importdata.PersistenceImportRepos
 import com.quran.shared.persistence.repository.note.repository.NotesRepository
 import com.quran.shared.persistence.repository.readingsession.repository.ReadingSessionsRepository
 import com.quran.shared.persistence.util.PlatformDateTime
+import com.quran.shared.persistence.util.currentPlatformDateTime
 import com.quran.shared.persistence.util.toPlatform
 import com.quran.shared.syncengine.AuthenticationDataFetcher
 import com.quran.shared.syncengine.LocalModificationDateFetcher
@@ -189,7 +190,10 @@ class QuranDataService internal constructor(
                 val defaultCollectionFlow =
                     collectionBookmarksRepository.getBookmarksForCollectionFlow(DEFAULT_COLLECTION_ID)
                         .map { bookmarks ->
-                            CollectionWithAyahBookmarks(defaultCollection(bookmarks), bookmarks)
+                            CollectionWithAyahBookmarks(
+                                defaultCollection(bookmarks),
+                                bookmarks
+                            )
                         }
                 val customCollectionFlows =
                     collections
@@ -385,9 +389,7 @@ class QuranDataService internal constructor(
 
     @NativeCoroutines
     suspend fun addBookmark(sura: Int, ayah: Int): AyahBookmark {
-        return mutatingCall("Failed to add ayah bookmark") {
-            bookmarksRepository.addBookmark(sura, ayah)
-        }
+        return addBookmark(sura, ayah, currentPlatformDateTime())
     }
 
     @NativeCoroutines
@@ -399,9 +401,7 @@ class QuranDataService internal constructor(
 
     @NativeCoroutines
     suspend fun addBookmark(sura: Int, ayah: Int, collectionIds: List<String>): AyahBookmark {
-        return mutatingCall("Failed to add ayah bookmark with collection memberships") {
-            bookmarksRepository.addBookmark(sura, ayah, collectionIds)
-        }
+        return addBookmark(sura, ayah, collectionIds, currentPlatformDateTime())
     }
 
     @NativeCoroutines
@@ -418,13 +418,7 @@ class QuranDataService internal constructor(
 
     @NativeCoroutines
     suspend fun replaceBookmarkCollections(id: String, collectionIds: List<String>): Boolean {
-        return mutatingCall("Failed to replace bookmark collection memberships", triggerAfter = false) {
-            val changed = bookmarksRepository.replaceBookmarkCollections(id, collectionIds)
-            if (changed) {
-                triggerSync()
-            }
-            changed
-        }
+        return replaceBookmarkCollections(id, collectionIds, currentPlatformDateTime())
     }
 
     /**
@@ -452,13 +446,7 @@ class QuranDataService internal constructor(
         ayah: Int,
         collectionIds: List<String>
     ): AyahBookmark {
-        return mutatingCall("Failed to replace ayah bookmark collection memberships", triggerAfter = false) {
-            val result = bookmarksRepository.replaceAyahBookmarkCollections(sura, ayah, collectionIds)
-            if (result.changed) {
-                triggerSync()
-            }
-            result.bookmark
-        }
+        return replaceAyahBookmarkCollections(sura, ayah, collectionIds, currentPlatformDateTime())
     }
 
     /**
@@ -483,7 +471,7 @@ class QuranDataService internal constructor(
 
     @NativeCoroutines
     suspend fun addReadingBookmark(sura: Int, ayah: Int): AyahReadingBookmark {
-        return addAyahReadingBookmark(sura, ayah)
+        return addAyahReadingBookmark(sura, ayah, currentPlatformDateTime())
     }
 
     @NativeCoroutines
@@ -493,9 +481,7 @@ class QuranDataService internal constructor(
 
     @NativeCoroutines
     suspend fun addAyahReadingBookmark(sura: Int, ayah: Int): AyahReadingBookmark {
-        return mutatingCall("Failed to add reading ayah bookmark") {
-            readingBookmarksRepository.addAyahReadingBookmark(sura, ayah)
-        }
+        return addAyahReadingBookmark(sura, ayah, currentPlatformDateTime())
     }
 
     @NativeCoroutines
@@ -507,9 +493,7 @@ class QuranDataService internal constructor(
 
     @NativeCoroutines
     suspend fun addPageReadingBookmark(page: Int): PageReadingBookmark {
-        return mutatingCall("Failed to add reading page bookmark") {
-            readingBookmarksRepository.addPageReadingBookmark(page)
-        }
+        return addPageReadingBookmark(page, currentPlatformDateTime())
     }
 
     @NativeCoroutines
@@ -521,9 +505,7 @@ class QuranDataService internal constructor(
 
     @NativeCoroutines
     suspend fun addReadingSession(sura: Int, ayah: Int): ReadingSession {
-        return mutatingCall("Failed to add reading session") {
-            readingSessionsRepository.addReadingSession(sura, ayah)
-        }
+        return addReadingSession(sura, ayah, currentPlatformDateTime())
     }
 
     @NativeCoroutines
@@ -535,9 +517,7 @@ class QuranDataService internal constructor(
 
     @NativeCoroutines
     suspend fun updateReadingSession(id: String, sura: Int, ayah: Int): ReadingSession {
-        return mutatingCall("Failed to update reading session") {
-            readingSessionsRepository.updateReadingSession(id, sura, ayah)
-        }
+        return updateReadingSession(id, sura, ayah, currentPlatformDateTime())
     }
 
     @NativeCoroutines
@@ -617,9 +597,7 @@ class QuranDataService internal constructor(
 
     @NativeCoroutines
     suspend fun addCollection(name: String): Collection {
-        return mutatingCall("Failed to add collection") {
-            collectionsRepository.addCollection(name)
-        }
+        return addCollection(name, currentPlatformDateTime())
     }
 
     @NativeCoroutines
@@ -645,9 +623,7 @@ class QuranDataService internal constructor(
                 defaultCollection(collectionBookmarksRepository.getBookmarksForCollection(DEFAULT_COLLECTION_ID))
             }
         }
-        return mutatingCall("Failed to update collection") {
-            collectionsRepository.updateCollection(id, name)
-        }
+        return updateCollection(id, name, currentPlatformDateTime())
     }
 
     /**
@@ -696,9 +672,7 @@ class QuranDataService internal constructor(
 
     @NativeCoroutines
     suspend fun addBookmarkToCollection(collectionId: String, bookmark: AyahBookmark) {
-        mutatingCall("Failed to add bookmark to collection") {
-            collectionBookmarksRepository.addBookmarkToCollection(collectionId, bookmark)
-        }
+        addBookmarkToCollection(collectionId, bookmark, currentPlatformDateTime())
     }
 
     @NativeCoroutines
@@ -718,9 +692,7 @@ class QuranDataService internal constructor(
         sura: Int,
         ayah: Int
     ): CollectionAyahBookmark {
-        return mutatingCall("Failed to add ayah bookmark to collection") {
-            collectionBookmarksRepository.addAyahBookmarkToCollection(collectionId, sura, ayah)
-        }
+        return addAyahBookmarkToCollection(collectionId, sura, ayah, currentPlatformDateTime())
     }
 
     @NativeCoroutines
@@ -751,9 +723,7 @@ class QuranDataService internal constructor(
 
     @NativeCoroutines
     suspend fun addNote(body: String, startSura: Int, startAyah: Int, endSura: Int, endAyah: Int) {
-        mutatingCall("Failed to add note") {
-            notesRepository.addNote(body, startSura, startAyah, endSura, endAyah)
-        }
+        addNote(body, startSura, startAyah, endSura, endAyah, currentPlatformDateTime())
     }
 
     @NativeCoroutines
@@ -789,8 +759,21 @@ class QuranDataService internal constructor(
         endSura: Int,
         endAyah: Int
     ) {
+        updateNote(id, body, startSura, startAyah, endSura, endAyah, currentPlatformDateTime())
+    }
+
+    @NativeCoroutines
+    suspend fun updateNote(
+        id: String,
+        body: String,
+        startSura: Int,
+        startAyah: Int,
+        endSura: Int,
+        endAyah: Int,
+        timestamp: PlatformDateTime
+    ) {
         mutatingCall("Failed to update note") {
-            notesRepository.updateNote(id, body, startSura, startAyah, endSura, endAyah)
+            notesRepository.updateNote(id, body, startSura, startAyah, endSura, endAyah, timestamp)
         }
     }
 

--- a/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/QuranDataServiceLifecycleTest.kt
+++ b/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/QuranDataServiceLifecycleTest.kt
@@ -89,6 +89,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Instant
 
@@ -538,11 +539,10 @@ class QuranDataServiceLifecycleTest {
 
         val result = fixture.service.updateCollection("collection-local-id", "Updated collection")
 
-        assertEquals(Collection("Updated collection", testTimestamp(), "collection-local-id"), result)
-        assertEquals(
-            listOf(CollectionUpdateCall("collection-local-id", "Updated collection", null)),
-            fixture.collectionsRepository.updateCalls
-        )
+        val call = fixture.collectionsRepository.updateCalls.single()
+        val timestamp = assertNotNull(call.timestamp)
+        assertEquals(Collection("Updated collection", timestamp, "collection-local-id"), result)
+        assertEquals(CollectionUpdateCall("collection-local-id", "Updated collection", timestamp), call)
         assertEquals(1, fixture.syncClient.localDataUpdatedCount)
         fixture.clearAndJoin()
     }
@@ -710,8 +710,10 @@ class QuranDataServiceLifecycleTest {
 
         val result = fixture.service.addCollection("Favorites")
 
-        assertEquals(Collection("Favorites", testTimestamp(), "collection-1"), result)
-        assertEquals(listOf(CollectionAddCall("Favorites", null)), fixture.collectionsRepository.addCalls)
+        val call = fixture.collectionsRepository.addCalls.single()
+        val timestamp = assertNotNull(call.timestamp)
+        assertEquals(Collection("Favorites", timestamp, "collection-1"), result)
+        assertEquals(CollectionAddCall("Favorites", timestamp), call)
         assertEquals(1, fixture.syncClient.localDataUpdatedCount)
         fixture.clearAndJoin()
     }
@@ -817,10 +819,10 @@ class QuranDataServiceLifecycleTest {
             val result = fixture.service.replaceBookmarkCollections("bookmark-local-id", listOf("collection-a"))
 
             assertFalse(result)
-            assertEquals(
-                listOf(BookmarkCollectionsReplaceCall("bookmark-local-id", listOf("collection-a"))),
-                fixture.bookmarksRepository.replaceCalls
-            )
+            val call = fixture.bookmarksRepository.replaceCalls.single()
+            assertEquals("bookmark-local-id", call.id)
+            assertEquals(listOf("collection-a"), call.collectionIds)
+            assertNotNull(call.timestamp)
             assertEquals(0, fixture.syncClient.localDataUpdatedCount)
             fixture.clearAndJoin()
         }
@@ -835,10 +837,10 @@ class QuranDataServiceLifecycleTest {
             val result = fixture.service.replaceBookmarkCollections("bookmark-local-id", listOf("collection-a"))
 
             assertTrue(result)
-            assertEquals(
-                listOf(BookmarkCollectionsReplaceCall("bookmark-local-id", listOf("collection-a"))),
-                fixture.bookmarksRepository.replaceCalls
-            )
+            val call = fixture.bookmarksRepository.replaceCalls.single()
+            assertEquals("bookmark-local-id", call.id)
+            assertEquals(listOf("collection-a"), call.collectionIds)
+            assertNotNull(call.timestamp)
             assertEquals(1, fixture.syncClient.localDataUpdatedCount)
             fixture.clearAndJoin()
         }
@@ -875,19 +877,20 @@ class QuranDataServiceLifecycleTest {
 
             val result = fixture.service.replaceAyahBookmarkCollections(2, 255, listOf("collection-a"))
 
+            val call = fixture.bookmarksRepository.replaceAyahCalls.single()
+            val timestamp = assertNotNull(call.timestamp)
             assertEquals(
                 AyahBookmark(
                     sura = 2,
                     ayah = 255,
                     id = "bookmark-replaced",
-                    lastUpdated = testTimestamp()
+                    lastUpdated = timestamp
                 ),
                 result
             )
-            assertEquals(
-                listOf(BookmarkAyahCollectionsReplaceCall(2, 255, listOf("collection-a"))),
-                fixture.bookmarksRepository.replaceAyahCalls
-            )
+            assertEquals(2, call.sura)
+            assertEquals(255, call.ayah)
+            assertEquals(listOf("collection-a"), call.collectionIds)
             assertEquals(1, fixture.syncClient.localDataUpdatedCount)
             fixture.clearAndJoin()
         }
@@ -901,15 +904,20 @@ class QuranDataServiceLifecycleTest {
 
             val result = fixture.service.replaceAyahBookmarkCollections(2, 255, listOf("collection-a"))
 
+            val call = fixture.bookmarksRepository.replaceAyahCalls.single()
+            val timestamp = assertNotNull(call.timestamp)
             assertEquals(
                 AyahBookmark(
                     sura = 2,
                     ayah = 255,
                     id = "bookmark-replaced",
-                    lastUpdated = testTimestamp()
+                    lastUpdated = timestamp
                 ),
                 result
             )
+            assertEquals(2, call.sura)
+            assertEquals(255, call.ayah)
+            assertEquals(listOf("collection-a"), call.collectionIds)
             assertEquals(0, fixture.syncClient.localDataUpdatedCount)
             fixture.clearAndJoin()
         }


### PR DESCRIPTION
Today, most methods take nullable timestamps and then resolve the
timestamp in the sql using coalesce. This patch fixes it so that this is
done on the logic level, making the intent clearer.
