### PR TITLE
fix: sync default collection membership from bookmarks

### DIFF
--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/input/RemoteBookmark.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/input/RemoteBookmark.kt
@@ -19,6 +19,7 @@ sealed class RemoteBookmark {
         val ayah: Int,
         override val isReading: Boolean,
         override val lastUpdated: PlatformDateTime,
-        override val createdAt: PlatformDateTime? = null
+        override val createdAt: PlatformDateTime? = null,
+        val isInDefaultCollection: Boolean? = null
     ) : RemoteBookmark()
 }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
@@ -684,6 +684,29 @@ class BookmarksRepositoryImpl(
             is_reading = if (remote.model.isReading) 1L else 0L,
             modified_at = updatedAt
         )
+        applyRemoteDefaultMembership(row, remote, updatedAt)
+    }
+
+    private fun applyRemoteDefaultMembership(
+        row: DatabaseBookmark,
+        remote: RemoteModelMutation<RemoteBookmark>,
+        updatedAt: Long
+    ) {
+        val model = remote.model as? RemoteBookmark.Ayah ?: return
+        val isInDefaultCollection = model.isInDefaultCollection ?: return
+        if (row.default_pending_op != null) {
+            logger.d {
+                "Preserving pending local default membership over remote bookmark snapshot: " +
+                    "remoteId=${remote.remoteID}, pendingOp=${row.default_pending_op}"
+            }
+            return
+        }
+        bookmarkQueries.value.setDefaultFromRemote(
+            local_id = row.local_id,
+            remote_id = remote.remoteID,
+            is_in_default_collection = if (isInDefaultCollection) 1L else 0L,
+            modified_at = updatedAt
+        )
     }
 
     private fun getBookmarkAtLocation(bookmark: RemoteBookmark): DatabaseBookmark? {

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
@@ -678,35 +678,29 @@ class BookmarksRepositoryImpl(
             }
         }
 
-        bookmarkQueries.value.applyRemoteReading(
+        bookmarkQueries.value.applyRemoteBookmarkSnapshot(
             local_id = row.local_id,
             remote_id = remote.remoteID,
             is_reading = if (remote.model.isReading) 1L else 0L,
+            remote_default_membership = remoteDefaultMembership(row, remote),
             modified_at = updatedAt
         )
-        applyRemoteDefaultMembership(row, remote, updatedAt)
     }
 
-    private fun applyRemoteDefaultMembership(
+    private fun remoteDefaultMembership(
         row: DatabaseBookmark,
-        remote: RemoteModelMutation<RemoteBookmark>,
-        updatedAt: Long
-    ) {
-        val model = remote.model as? RemoteBookmark.Ayah ?: return
-        val isInDefaultCollection = model.isInDefaultCollection ?: return
+        remote: RemoteModelMutation<RemoteBookmark>
+    ): Long? {
+        val model = remote.model as? RemoteBookmark.Ayah ?: return null
+        val isInDefaultCollection = model.isInDefaultCollection ?: return null
         if (row.default_pending_op != null) {
             logger.d {
                 "Preserving pending local default membership over remote bookmark snapshot: " +
                     "remoteId=${remote.remoteID}, pendingOp=${row.default_pending_op}"
             }
-            return
+            return null
         }
-        bookmarkQueries.value.setDefaultFromRemote(
-            local_id = row.local_id,
-            remote_id = remote.remoteID,
-            is_in_default_collection = if (isInDefaultCollection) 1L else 0L,
-            modified_at = updatedAt
-        )
+        return if (isInDefaultCollection) 1L else 0L
     }
 
     private fun getBookmarkAtLocation(bookmark: RemoteBookmark): DatabaseBookmark? {

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/bookmarks.sq
@@ -852,7 +852,7 @@ clearReadingPending:
     AND reading_pending_op = :pending_op
     AND reading_pending_version = :pending_version;
 
-applyRemoteReading:
+applyRemoteBookmarkSnapshot:
   UPDATE bookmark
   SET remote_id = CASE
       WHEN :remote_id IS NULL THEN remote_id
@@ -862,13 +862,27 @@ applyRemoteReading:
       WHEN deleted = 1 AND bookmark_pending_op = 'DELETED' THEN is_reading
       ELSE :is_reading
     END,
+    is_in_default_collection = CASE
+      WHEN :remote_default_membership IS NULL THEN is_in_default_collection
+      ELSE :remote_default_membership
+    END,
+    default_last_synced_bookmark_remote_id = CASE
+      WHEN :remote_default_membership IS NULL THEN default_last_synced_bookmark_remote_id
+      WHEN :remote_default_membership = 1
+        THEN COALESCE(:remote_id, default_last_synced_bookmark_remote_id)
+      ELSE NULL
+    END,
     reading_pending_op = reading_pending_op,
     deleted = CASE
       WHEN deleted = 1 AND bookmark_pending_op = 'DELETED' THEN deleted
       ELSE 0
     END,
     modified_at = :modified_at,
-    reading_modified_at = :modified_at
+    reading_modified_at = :modified_at,
+    default_modified_at = CASE
+      WHEN :remote_default_membership IS NULL THEN default_modified_at
+      ELSE :modified_at
+    END
   WHERE local_id = :local_id;
 
 deleteUnsyncedBookmarks:

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarkSyncArchitectureTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarkSyncArchitectureTest.kt
@@ -126,6 +126,97 @@ class BookmarkSyncArchitectureTest {
     }
 
     @Test
+    fun `remote ayah bookmark populates and clears default membership`() = runTest {
+        bookmarksRepository.applyRemoteChanges(
+            updatesToPersist = listOf(
+                remoteAyahBookmark(
+                    sura = 2,
+                    ayah = 254,
+                    remoteId = "remote-default-membership",
+                    isInDefaultCollection = true,
+                    timestamp = 100
+                )
+            ),
+            localMutationsToClear = emptyList()
+        )
+
+        var row = database.bookmarksQueries.getBookmarkByRemoteId("remote-default-membership").executeAsOne()
+        assertEquals(1L, row.is_in_default_collection)
+        assertEquals(0L, database.bookmark_collectionsQueries.countAll().executeAsOne())
+
+        bookmarksRepository.applyRemoteChanges(
+            updatesToPersist = listOf(
+                remoteAyahBookmark(
+                    sura = 2,
+                    ayah = 254,
+                    remoteId = "remote-default-membership",
+                    isInDefaultCollection = false,
+                    timestamp = 200,
+                    mutation = Mutation.MODIFIED
+                )
+            ),
+            localMutationsToClear = emptyList()
+        )
+
+        row = database.bookmarksQueries.getBookmarkByRemoteId("remote-default-membership").executeAsOne()
+        assertEquals(0L, row.is_in_default_collection)
+    }
+
+    @Test
+    fun `remote ayah bookmark without default membership preserves existing value`() = runTest {
+        bookmarksRepository.applyRemoteChanges(
+            updatesToPersist = listOf(
+                remoteAyahBookmark(
+                    sura = 2,
+                    ayah = 253,
+                    remoteId = "remote-missing-default-membership",
+                    isInDefaultCollection = true,
+                    timestamp = 100
+                )
+            ),
+            localMutationsToClear = emptyList()
+        )
+        bookmarksRepository.applyRemoteChanges(
+            updatesToPersist = listOf(
+                remoteAyahBookmark(
+                    sura = 2,
+                    ayah = 253,
+                    remoteId = "remote-missing-default-membership",
+                    isInDefaultCollection = null,
+                    timestamp = 200,
+                    mutation = Mutation.MODIFIED
+                )
+            ),
+            localMutationsToClear = emptyList()
+        )
+
+        val row = database.bookmarksQueries.getBookmarkByRemoteId("remote-missing-default-membership").executeAsOne()
+        assertEquals(1L, row.is_in_default_collection)
+    }
+
+    @Test
+    fun `remote ayah default membership preserves pending local membership`() = runTest {
+        val bookmark = bookmarksRepository.addBookmark(2, 252, listOf(DEFAULT_COLLECTION_ID), at(100))
+
+        bookmarksRepository.applyRemoteChanges(
+            updatesToPersist = listOf(
+                remoteAyahBookmark(
+                    sura = 2,
+                    ayah = 252,
+                    remoteId = "remote-pending-default-membership",
+                    isInDefaultCollection = false,
+                    timestamp = 200
+                )
+            ),
+            localMutationsToClear = emptyList()
+        )
+
+        val row = database.bookmarksQueries.getBookmarkByLocalId(bookmark.id.toLong()).executeAsOne()
+        assertEquals(1L, row.is_in_default_collection)
+        assertEquals("CREATED", row.default_pending_op)
+    }
+
+    @Test
     fun `remote created page bookmark persists created_at separately from modified_at`() = runTest {
         bookmarksRepository.applyRemoteChanges(
             updatesToPersist = listOf(
@@ -3869,6 +3960,26 @@ class BookmarkSyncArchitectureTest {
             mutation = mutation
         )
     }
+
+    private fun remoteAyahBookmark(
+        sura: Int,
+        ayah: Int,
+        remoteId: String,
+        isInDefaultCollection: Boolean?,
+        timestamp: Long,
+        mutation: Mutation = Mutation.CREATED
+    ): RemoteModelMutation<RemoteBookmark> =
+        RemoteModelMutation(
+            model = RemoteBookmark.Ayah(
+                sura = sura,
+                ayah = ayah,
+                isReading = false,
+                lastUpdated = at(timestamp),
+                isInDefaultCollection = isInDefaultCollection
+            ),
+            remoteID = remoteId,
+            mutation = mutation
+        )
 
     private fun activeCustomCollectionIds(bookmarkLocalId: String): Set<String> =
         database.bookmark_collectionsQueries

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarkSyncArchitectureTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarkSyncArchitectureTest.kt
@@ -134,6 +134,7 @@ class BookmarkSyncArchitectureTest {
                     ayah = 254,
                     remoteId = "remote-default-membership",
                     isInDefaultCollection = true,
+                    isReading = true,
                     timestamp = 100
                 )
             ),
@@ -142,6 +143,7 @@ class BookmarkSyncArchitectureTest {
 
         var row = database.bookmarksQueries.getBookmarkByRemoteId("remote-default-membership").executeAsOne()
         assertEquals(1L, row.is_in_default_collection)
+        assertEquals(1L, row.is_reading)
         assertEquals(0L, database.bookmark_collectionsQueries.countAll().executeAsOne())
 
         bookmarksRepository.applyRemoteChanges(
@@ -205,6 +207,7 @@ class BookmarkSyncArchitectureTest {
                     ayah = 252,
                     remoteId = "remote-pending-default-membership",
                     isInDefaultCollection = false,
+                    isReading = true,
                     timestamp = 200
                 )
             ),
@@ -213,6 +216,7 @@ class BookmarkSyncArchitectureTest {
 
         val row = database.bookmarksQueries.getBookmarkByLocalId(bookmark.id.toLong()).executeAsOne()
         assertEquals(1L, row.is_in_default_collection)
+        assertEquals(1L, row.is_reading)
         assertEquals("CREATED", row.default_pending_op)
     }
 
@@ -3966,6 +3970,7 @@ class BookmarkSyncArchitectureTest {
         ayah: Int,
         remoteId: String,
         isInDefaultCollection: Boolean?,
+        isReading: Boolean = false,
         timestamp: Long,
         mutation: Mutation = Mutation.CREATED
     ): RemoteModelMutation<RemoteBookmark> =
@@ -3973,7 +3978,7 @@ class BookmarkSyncArchitectureTest {
             model = RemoteBookmark.Ayah(
                 sura = sura,
                 ayah = ayah,
-                isReading = false,
+                isReading = isReading,
                 lastUpdated = at(timestamp),
                 isInDefaultCollection = isInDefaultCollection
             ),

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncEnginePipeline.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncEnginePipeline.kt
@@ -502,7 +502,8 @@ private fun RemoteBookmark.toSyncEngine(id: String): SyncBookmark {
             ayah = this.ayah,
             lastModified = this.lastUpdated.fromPlatform(),
             isReading = this.isReading,
-            createdAt = this.createdAt?.fromPlatform()
+            createdAt = this.createdAt?.fromPlatform(),
+            isInDefaultCollection = this.isInDefaultCollection
         )
         is RemoteBookmark.Page -> SyncBookmark.PageBookmark(
             id = id,
@@ -541,7 +542,8 @@ private fun SyncBookmark.toRemoteInput(): RemoteBookmark {
                 ayah = this.ayah,
                 lastUpdated = this.lastModified.toPlatform(),
                 isReading = this.isReading,
-                createdAt = this.createdAt?.toPlatform()
+                createdAt = this.createdAt?.toPlatform(),
+                isInDefaultCollection = this.isInDefaultCollection
             )
         is SyncBookmark.PageBookmark ->
             RemoteBookmark.Page(

--- a/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/ResultReceiverTest.kt
+++ b/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/ResultReceiverTest.kt
@@ -88,6 +88,43 @@ class ResultReceiverTest {
     }
 
     @Test
+    fun `ayah default membership is routed to unified bookmarks repository`() = runTest {
+        val updates = mutableListOf<RemoteModelMutation<RemoteBookmark>>()
+        val receiver = ResultReceiver(
+            bookmarksRepository = RecordingBookmarksRepository(
+                events = mutableListOf(),
+                remoteUpdates = updates
+            ),
+            callback = object : SyncEngineCallback {
+                override suspend fun synchronizationDone(newLastModificationDate: Long) = Unit
+                override suspend fun encounteredError(errorMsg: String) = Unit
+            }
+        )
+
+        receiver.didSucceed(
+            newToken = 11L,
+            newRemoteMutations = listOf(
+                RemoteModelMutation(
+                    model = SyncBookmark.AyahBookmark(
+                        id = "remote-default-bookmark",
+                        sura = 1,
+                        ayah = 2,
+                        isReading = false,
+                        lastModified = Instant.fromEpochMilliseconds(1000),
+                        isInDefaultCollection = true
+                    ),
+                    remoteID = "remote-default-bookmark",
+                    mutation = com.quran.shared.mutations.Mutation.CREATED
+                )
+            ),
+            processedLocalMutations = emptyList()
+        )
+
+        val model = updates.single().model as RemoteBookmark.Ayah
+        assertEquals(true, model.isInDefaultCollection)
+    }
+
+    @Test
     fun `settings sync callback persists final sync token`() = runTest {
         val store = SyncSettingsLocalModificationDateStore(MapSettings().toSuspendSettings())
         val callback = SettingsSyncEngineCallback(store)

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/BookmarksSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/BookmarksSyncAdapter.kt
@@ -221,7 +221,8 @@ private suspend fun SyncMutation.toSyncBookmark(
                     ayah = ayah,
                     isReading = data.booleanOrNull("isReading") ?: false,
                     lastModified = lastModified,
-                    createdAt = createdAt
+                    createdAt = createdAt,
+                    isInDefaultCollection = data.booleanOrNull("isInDefaultCollection")
                 )
             } else {
                 null

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/model/SyncBookmark.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/model/SyncBookmark.kt
@@ -13,7 +13,8 @@ sealed class SyncBookmark {
         val ayah: Int,
         override val isReading: Boolean,
         override val lastModified: Instant,
-        override val createdAt: Instant? = null
+        override val createdAt: Instant? = null,
+        val isInDefaultCollection: Boolean? = null
     ) : SyncBookmark()
 
     data class PageBookmark(

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/DefaultCollectionBookmarkRemoteMappingTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/DefaultCollectionBookmarkRemoteMappingTest.kt
@@ -1,0 +1,94 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.quran.shared.syncengine
+
+import com.quran.shared.mutations.LocalModelMutation
+import com.quran.shared.mutations.Mutation
+import com.quran.shared.mutations.RemoteModelMutation
+import com.quran.shared.syncengine.model.SyncBookmark
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class DefaultCollectionBookmarkRemoteMappingTest {
+
+    @Test
+    fun `bookmark default membership is parsed without creating a collection bookmark mutation`() = runTest {
+        val remotes = listOf(
+            syncBookmark("remote-true", ayah = 2, isInDefaultCollection = true),
+            syncBookmark("remote-false", ayah = 3, isInDefaultCollection = false),
+            syncBookmark("remote-missing", ayah = 4, isInDefaultCollection = null)
+        )
+
+        val persisted = execute(remotes)
+
+        assertEquals(listOf("remote-true", "remote-false", "remote-missing"), persisted.map { it.remoteID })
+        assertEquals(
+            listOf(true, false, null),
+            persisted.map { (it.model as SyncBookmark.AyahBookmark).isInDefaultCollection }
+        )
+    }
+
+    private suspend fun execute(
+        remotes: List<SyncMutation>
+    ): List<RemoteModelMutation<SyncBookmark>> {
+        var capturedRemote: List<RemoteModelMutation<SyncBookmark>>? = null
+        val adapter = BookmarksSyncAdapter(
+            BookmarksSynchronizationConfigurations(
+                localDataFetcher = object : LocalDataFetcher<SyncBookmark> {
+                    override suspend fun fetchLocalMutations(
+                        lastModified: Long
+                    ): List<LocalModelMutation<SyncBookmark>> = emptyList()
+
+                    override suspend fun checkLocalExistence(remoteIDs: List<String>): Map<String, Boolean> =
+                        remoteIDs.associateWith { false }
+
+                    override suspend fun fetchLocalModel(remoteId: String): SyncBookmark? = null
+                },
+                resultNotifier = object : ResultNotifier<SyncBookmark> {
+                    override suspend fun didSucceed(
+                        newToken: Long,
+                        newRemoteMutations: List<RemoteModelMutation<SyncBookmark>>,
+                        processedLocalMutations: List<LocalModelMutation<SyncBookmark>>
+                    ) {
+                        capturedRemote = newRemoteMutations
+                    }
+
+                    override suspend fun didFail(message: String) {
+                        fail("didFail called: $message")
+                    }
+                },
+                localModificationDateFetcher = object : LocalModificationDateFetcher {
+                    override suspend fun localLastModificationDate(): Long? = 0L
+                }
+            )
+        )
+
+        val plan = adapter.buildPlan(lastModificationDate = 0L, remoteMutations = remotes)
+        plan.complete(newToken = 1L, pushedMutations = emptyList())
+        return checkNotNull(capturedRemote)
+    }
+
+    private fun syncBookmark(
+        id: String,
+        ayah: Int,
+        isInDefaultCollection: Boolean?
+    ): SyncMutation =
+        SyncMutation(
+            resource = "BOOKMARK",
+            resourceId = id,
+            mutation = Mutation.CREATED,
+            data = buildJsonObject {
+                put("bookmarkType", "ayah")
+                put("key", 1)
+                put("verseNumber", ayah)
+                isInDefaultCollection?.let { put("isInDefaultCollection", it) }
+                put("clientCreatedAt", "2026-07-06T21:55:26.000Z")
+                put("clientUpdatedAt", "2026-07-06T21:55:26.000Z")
+            },
+            timestamp = 1L
+        )
+}


### PR DESCRIPTION
## Summary

- map `isInDefaultCollection` from bookmark sync payloads through the sync and persistence layers
- persist the backend value directly in `is_in_default_collection`
- preserve unacknowledged local default-membership mutations over bookmark snapshots
- add adapter, pipeline, and persistence regression coverage

## Why

The bookmark sync response already reports whether an ayah belongs to the default collection, but mobile-sync discarded that field. After sign-in, the bookmark rows existed locally while Favorites appeared empty.

The default collection remains represented by `is_in_default_collection`; this change does not synthesize a `__default__` collection or collection-bookmark rows.

## Impact

Signing in now restores Favorites from the bookmark response. Pending local Favorites additions or removals continue to win until the separate collection-bookmark mutation is acknowledged.

## Validation

- `./gradlew :syncengine:jvmTest :sync-pipelines:jvmTest :persistence:jvmTest`
- local debug XCFramework, SPM package, and QuranEngineApp simulator build

## Stack

Stacked on #223. Merge #223 first; this PR targets `afifi/ios-http-debug-logging`.