### PR TITLE
fix: parse extended sync error responses

### DIFF
--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/GetMutationsRequest.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/GetMutationsRequest.kt
@@ -72,9 +72,7 @@ class GetMutationsRequest(
         
         logger.d { "HTTP response status: ${httpResponse.status}" }
         if (!httpResponse.status.isSuccess()) {
-            httpResponse.processError(logger) {
-                httpResponse.body<SyncErrorResponse>().message
-            }
+            httpResponse.processError(logger)
         }
         
         val apiResponse: ApiResponse = httpResponse.body()

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/NetworkUtil.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/NetworkUtil.kt
@@ -5,7 +5,8 @@ import com.quran.shared.mutations.Mutation
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import kotlinx.serialization.Serializable
-import io.ktor.client.call.body
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
 
 @Serializable
 internal data class SyncErrorResponse(
@@ -24,8 +25,13 @@ internal data class SyncErrorDetails(
 @Serializable
 internal data class SyncErrorDetail(
     val code: String,
-    val message: String
+    val message: String,
+    val details: JsonElement? = null
 )
+
+private val errorResponseJson = Json {
+    ignoreUnknownKeys = true
+}
 
 internal fun String.asMutation(logger: Logger): Mutation {
     return when (this) {
@@ -39,12 +45,12 @@ internal fun String.asMutation(logger: Logger): Mutation {
     }
 }
 
-internal suspend fun HttpResponse.processError(logger: Logger, errorMessageExtractor: suspend () -> String? = { null }) {
+internal suspend fun HttpResponse.processError(logger: Logger) {
     val errorBody = bodyAsText()
     logger.e { "HTTP error response: status=${status}, body=$errorBody" }
 
     val parsedMessage = try {
-        errorMessageExtractor()
+        errorResponseJson.decodeFromString<SyncErrorResponse>(errorBody).message
     } catch (e: Exception) {
         logger.w { "Failed to parse error response, using raw body: ${e.message}" }
         null

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/PostMutationsRequest.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/PostMutationsRequest.kt
@@ -102,9 +102,7 @@ class PostMutationsRequest(
         logger.d { "HTTP response status: ${httpResponse.status}" }
 
         if (!httpResponse.status.isSuccess()) {
-            httpResponse.processError(logger) {
-                httpResponse.body<SyncErrorResponse>().message
-            }
+            httpResponse.processError(logger)
         }
 
         val response: PostMutationsResponse = httpResponse.body()

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/network/PostMutationsRequestTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/network/PostMutationsRequestTest.kt
@@ -67,6 +67,41 @@ class PostMutationsRequestTest {
     }
 
     @Test
+    fun `postMutations preserves message from error response with nested details`() = runTest {
+        val errorBody = """
+            {
+              "details": {
+                "success": false,
+                "error": {
+                  "code": "ValidationError",
+                  "message": "\"bookmarkId\" is not allowed",
+                  "details": {}
+                }
+              },
+              "message": "\"bookmarkId\" is not allowed",
+              "type": "unprocessable_entity",
+              "success": false,
+              "requestId": "request-a"
+            }
+        """.trimIndent()
+        val request = postRequestWithResponse(errorBody, HttpStatusCode.UnprocessableEntity)
+
+        val exception = assertFailsWith<SyncNetworkException> {
+            request.postMutations(
+                mutations = listOf(collectionBookmarkCreateRequest()),
+                lastModificationDate = 1000L,
+                authHeaders = emptyMap()
+            )
+        }
+
+        assertEquals("\"bookmarkId\" is not allowed", exception.parsedMessage)
+        assertEquals(errorBody, exception.rawBody)
+
+        val errorResponse = errorResponseJson.decodeFromString<SyncErrorResponse>(errorBody)
+        assertEquals(buildJsonObject {}, errorResponse.details?.error?.details)
+    }
+
+    @Test
     fun `postMutations decodes collection bookmark create ACK with missing resource id`() = runTest {
         val localMutation = collectionBookmarkCreateRequest()
         val request = postRequestWithResponse(
@@ -193,12 +228,15 @@ class PostMutationsRequestTest {
             timestamp = null
         )
 
-    private fun postRequestWithResponse(responseContent: String): PostMutationsRequest {
+    private fun postRequestWithResponse(
+        responseContent: String,
+        responseStatus: HttpStatusCode = HttpStatusCode.OK
+    ): PostMutationsRequest {
         val client = HttpClient(
             MockEngine {
                 respond(
                     content = responseContent,
-                    status = HttpStatusCode.OK,
+                    status = responseStatus,
                     headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 )
             }
@@ -208,5 +246,11 @@ class PostMutationsRequestTest {
             }
         }
         return PostMutationsRequest(client, "https://example.test")
+    }
+
+    private companion object {
+        val errorResponseJson = Json {
+            ignoreUnknownKeys = true
+        }
     }
 }


### PR DESCRIPTION
## Summary

- decode sync error envelopes with a dedicated tolerant JSON parser
- preserve nested `error.details` as flexible JSON metadata
- centralize GET and POST mutation error decoding
- add regression coverage for the backend validation-error shape

## Why

The sync API includes nested `details` metadata in validation failures. The normal strict response decoder rejected that unknown field, logged a misleading secondary parsing failure, and fell back to the raw response body. Error responses should remain forward-compatible while successful sync responses stay strictly decoded.

## Impact

Validation failures now surface their clean server message without the extra `Failed to parse error response` warning. Raw response bodies remain available through `SyncNetworkException`.

## Validation

- `./gradlew :syncengine:jvmTest`
- rebuilt the debug XCFramework and Example app
- reproduced a live prelive 422 response and verified clean message extraction with no parsing warning

## Stack

Stacked on #224.