### PR TITLE
feat: correlate sync request logs

### DIFF
--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClientImpl.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClientImpl.kt
@@ -9,6 +9,7 @@ import com.quran.shared.syncengine.network.PostMutationsRequest
 import com.quran.shared.syncengine.scheduling.Scheduler
 import com.quran.shared.syncengine.scheduling.Trigger
 import com.quran.shared.syncengine.scheduling.createScheduler
+import com.quran.shared.syncengine.scheduling.currentSchedulerAttempt
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.currentCoroutineContext
@@ -85,6 +86,7 @@ internal class SynchronizationClientImpl(
     }
 
     private suspend fun startSyncOperation() {
+        val attempt = currentSchedulerAttempt()
         val syncEpoch = try {
             if (!syncLifecycleGate.canStartSync()) {
                 logger.i { "Sync lifecycle is unavailable, skipping sync operation" }
@@ -101,7 +103,7 @@ internal class SynchronizationClientImpl(
             return
         }
 
-        logger.i { "Starting sync operation for ${resourceAdapters.size} resource(s)" }
+        logger.i { "Starting sync operation attempt=$attempt for ${resourceAdapters.size} resource(s)" }
 
         val authHeaders = getAuthHeaders()
         if (authHeaders.isEmpty()) {
@@ -115,7 +117,7 @@ internal class SynchronizationClientImpl(
             .localLastModificationDate() ?: 0L
 
         val resources = resourceAdapters.map { it.resourceName }.distinct()
-        val remoteResponse = fetchRemoteMutations(lastModificationDate, authHeaders, resources)
+        val remoteResponse = fetchRemoteMutations(lastModificationDate, authHeaders, resources, attempt)
 
         try {
             executeDependencyAwareSync(
@@ -128,7 +130,7 @@ internal class SynchronizationClientImpl(
                         syncLifecycleGate.admitSyncPost(syncEpoch)
                         admitPost()
                     }
-                    val response = pushMutations(mutations, mutationToken, authHeaders)
+                    val response = pushMutations(mutations, mutationToken, authHeaders, attempt)
                     syncLifecycleGate.checkSyncEpoch(syncEpoch)
                     response
                 },
@@ -151,7 +153,8 @@ internal class SynchronizationClientImpl(
     private suspend fun pushMutations(
         mutations: List<SyncMutation>,
         lastModificationDate: Long,
-        authHeaders: Map<String, String>
+        authHeaders: Map<String, String>,
+        attempt: Int
     ): MutationsResponse {
         if (mutations.isEmpty()) {
             logger.d { "No local mutations to push, skipping network request" }
@@ -161,7 +164,7 @@ internal class SynchronizationClientImpl(
         logger.i { "Pushing ${mutations.size} local mutations" }
         val url = environment.endPointURL
         val request = PostMutationsRequest(httpClient, url)
-        val response = request.postMutations(mutations, lastModificationDate, authHeaders)
+        val response = request.postMutations(mutations, lastModificationDate, authHeaders, attempt)
         logger.i { "Successfully pushed mutations: received ${response.mutations.size} pushed remote mutations" }
         return response
     }
@@ -176,7 +179,8 @@ internal class SynchronizationClientImpl(
     private suspend fun fetchRemoteMutations(
         lastModificationDate: Long,
         authHeaders: Map<String, String>,
-        resources: List<String>
+        resources: List<String>,
+        attempt: Int
     ): MutationsResponse {
         logger.d {
             "Fetching remote modifications from ${environment.endPointURL} with " +
@@ -184,7 +188,7 @@ internal class SynchronizationClientImpl(
         }
         val url = environment.endPointURL
         val request = GetMutationsRequest(httpClient, url)
-        return request.getMutations(lastModificationDate, authHeaders, resources)
+        return request.getMutations(lastModificationDate, authHeaders, resources, attempt)
     }
 }
 

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/GetMutationsRequest.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/GetMutationsRequest.kt
@@ -52,10 +52,23 @@ class GetMutationsRequest(
         lastModificationDate: Long,
         authHeaders: Map<String, String>,
         resources: List<String> = emptyList()
+    ): MutationsResponse =
+        getMutations(lastModificationDate, authHeaders, resources, attempt = 0)
+
+    internal suspend fun getMutations(
+        lastModificationDate: Long,
+        authHeaders: Map<String, String>,
+        resources: List<String>,
+        attempt: Int
     ): MutationsResponse {
+        val logContext = SyncRequestLogContext.create(attempt)
         val fullUrl = "$url/v1/sync"
-        logger.i { "Starting GET mutations request to $fullUrl" }
-        logger.d { "Request params: mutationsSince=$lastModificationDate, resources=$resources" }
+        logger.i { logContext.format("Starting GET mutations request to $fullUrl") }
+        logger.d {
+            logContext.format(
+                "Request params: mutationsSince=$lastModificationDate, resources=$resources"
+            )
+        }
 
         val httpResponse = httpClient.get(fullUrl) {
             headers {
@@ -70,20 +83,30 @@ class GetMutationsRequest(
             }
         }
         
-        logger.d { "HTTP response status: ${httpResponse.status}" }
+        logger.d { logContext.format("HTTP response status: ${httpResponse.status}") }
         if (!httpResponse.status.isSuccess()) {
-            httpResponse.processError(logger)
+            httpResponse.processError(logger, logContext)
         }
         
         val apiResponse: ApiResponse = httpResponse.body()
         if (!apiResponse.success) {
-            logger.e { "Server returned success=false in response body" }
-            logger.e { "Response data: lastMutationAt=${apiResponse.data.lastMutationAt}, mutations count=${apiResponse.data.mutations.size}" }
+            logger.e { logContext.format("Server returned success=false in response body") }
+            logger.e {
+                logContext.format(
+                    "Response data: lastMutationAt=${apiResponse.data.lastMutationAt}, " +
+                        "mutations count=${apiResponse.data.mutations.size}"
+                )
+            }
             throw RuntimeException("Server returned success=false in response body")
         }
         
-        logger.i { "Received response: success=${apiResponse.success}" }
-        logger.d { "Response data: lastMutationAt=${apiResponse.data.lastMutationAt}, mutations count=${apiResponse.data.mutations.size}" }
+        logger.i { logContext.format("Received response: success=${apiResponse.success}") }
+        logger.d {
+            logContext.format(
+                "Response data: lastMutationAt=${apiResponse.data.lastMutationAt}, " +
+                    "mutations count=${apiResponse.data.mutations.size}"
+            )
+        }
 
         return apiResponse.data.toMutationsResponse()
     }

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/NetworkUtil.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/NetworkUtil.kt
@@ -45,14 +45,21 @@ internal fun String.asMutation(logger: Logger): Mutation {
     }
 }
 
-internal suspend fun HttpResponse.processError(logger: Logger) {
+internal suspend fun HttpResponse.processError(
+    logger: Logger,
+    logContext: SyncRequestLogContext
+) {
     val errorBody = bodyAsText()
-    logger.e { "HTTP error response: status=${status}, body=$errorBody" }
+    logger.e {
+        logContext.format("HTTP error response: status=${status}, body=$errorBody")
+    }
 
     val parsedMessage = try {
         errorResponseJson.decodeFromString<SyncErrorResponse>(errorBody).message
     } catch (e: Exception) {
-        logger.w { "Failed to parse error response, using raw body: ${e.message}" }
+        logger.w {
+            logContext.format("Failed to parse error response, using raw body: ${e.message}")
+        }
         null
     }
 

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/PostMutationsRequest.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/PostMutationsRequest.kt
@@ -67,7 +67,16 @@ class PostMutationsRequest(
         mutations: List<SyncMutation>,
         lastModificationDate: Long,
         authHeaders: Map<String, String>
+    ): MutationsResponse =
+        postMutations(mutations, lastModificationDate, authHeaders, attempt = 0)
+
+    internal suspend fun postMutations(
+        mutations: List<SyncMutation>,
+        lastModificationDate: Long,
+        authHeaders: Map<String, String>,
+        attempt: Int
     ): MutationsResponse {
+        val logContext = SyncRequestLogContext.create(attempt)
         val requestBody = PostMutationsRequestData(
             mutations = mutations.map { localMutation ->
                 PostMutationRequestData(
@@ -80,12 +89,19 @@ class PostMutationsRequest(
         )
 
         val fullUrl = "$url/v1/sync"
-        logger.i { "Starting POST mutations request to $fullUrl" }
+        logger.i { logContext.format("Starting POST mutations request to $fullUrl") }
         
         // Log request body summary
-        logger.d { "Request body: mutations count=${requestBody.mutations.size}, lastMutationAt=$lastModificationDate" }
+        logger.d {
+            logContext.format(
+                "Request body: mutations count=${requestBody.mutations.size}, " +
+                    "lastMutationAt=$lastModificationDate"
+            )
+        }
         if (requestBody.mutations.isNotEmpty()) {
-            logger.v { "First mutation sample: ${requestBody.mutations.first()}" }
+            logger.v {
+                logContext.format("First mutation sample: ${requestBody.mutations.first()}")
+            }
         }
 
         val httpResponse = httpClient.post(fullUrl) {
@@ -99,26 +115,33 @@ class PostMutationsRequest(
             setBody(requestBody)
         }
 
-        logger.d { "HTTP response status: ${httpResponse.status}" }
+        logger.d { logContext.format("HTTP response status: ${httpResponse.status}") }
 
         if (!httpResponse.status.isSuccess()) {
-            httpResponse.processError(logger)
+            httpResponse.processError(logger, logContext)
         }
 
         val response: PostMutationsResponse = httpResponse.body()
         if (!response.success) {
-            logger.e { "Server returned success=false in response body" }
+            logger.e { logContext.format("Server returned success=false in response body") }
             logger.e {
-                "Response data: lastMutationAt=${response.data.lastMutationAt}, " +
-                    "mutations count=${response.data.mutations.size}"
+                logContext.format(
+                    "Response data: lastMutationAt=${response.data.lastMutationAt}, " +
+                        "mutations count=${response.data.mutations.size}"
+                )
             }
             throw RuntimeException("Server returned success=false in response body")
         }
 
-        logger.i { "Received response: success=${response.success}" }
+        logger.i { logContext.format("Received response: success=${response.success}") }
 
         val result = response.data.toMutationsResponse()
-        logger.i { "lastModificationDate=${result.lastModificationDate}, mutations count=${result.mutations.size}" }
+        logger.i {
+            logContext.format(
+                "lastModificationDate=${result.lastModificationDate}, " +
+                    "mutations count=${result.mutations.size}"
+            )
+        }
 
         return result
     }

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/SyncRequestLogContext.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/SyncRequestLogContext.kt
@@ -1,0 +1,19 @@
+package com.quran.shared.syncengine.network
+
+import kotlin.uuid.Uuid
+
+internal data class SyncRequestLogContext(
+    val requestId: String,
+    val attempt: Int
+) {
+    fun format(message: String): String =
+        "[requestId=$requestId attempt=$attempt] $message"
+
+    companion object {
+        fun create(attempt: Int): SyncRequestLogContext =
+            SyncRequestLogContext(
+                requestId = Uuid.random().toString(),
+                attempt = attempt
+            )
+    }
+}

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/scheduling/Scheduler.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/scheduling/Scheduler.kt
@@ -15,7 +15,10 @@ import kotlinx.coroutines.internal.synchronized
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
 import kotlin.math.pow
 import kotlin.time.Clock
 import kotlin.time.Duration
@@ -70,6 +73,15 @@ private sealed class SchedulerState {
 
 internal var schedulerAfterCommandDrainSnapshotHook: (() -> Unit)? = null
 internal var schedulerBeforeCommandDrainReleaseHook: (() -> Unit)? = null
+
+private class SchedulerAttemptContext(
+    val attempt: Int
+) : AbstractCoroutineContextElement(SchedulerAttemptContext) {
+    companion object Key : CoroutineContext.Key<SchedulerAttemptContext>
+}
+
+internal suspend fun currentSchedulerAttempt(): Int =
+    currentCoroutineContext()[SchedulerAttemptContext]?.attempt ?: 0
 
 /**
  * A scheduler that manages the execution of a task function with configurable timing and retry logic.
@@ -296,7 +308,9 @@ class Scheduler(
 
         logger.d { "Executing task function, state: WaitingForReply" }
         try {
-            taskFunction()
+            withContext(SchedulerAttemptContext(startingState.getRetryCount())) {
+                taskFunction()
+            }
 
             mutex.withLock {
                 state = SchedulerState.Replied(original = startingState)

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/network/SyncRequestLogContextTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/network/SyncRequestLogContextTest.kt
@@ -1,0 +1,20 @@
+package com.quran.shared.syncengine.network
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SyncRequestLogContextTest {
+
+    @Test
+    fun `format associates request id and attempt with message`() {
+        val context = SyncRequestLogContext(
+            requestId = "request-a",
+            attempt = 3
+        )
+
+        assertEquals(
+            "[requestId=request-a attempt=3] HTTP response status: 422",
+            context.format("HTTP response status: 422")
+        )
+    }
+}

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/scheduling/SchedulerTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/scheduling/SchedulerTest.kt
@@ -249,6 +249,7 @@ class SchedulerTest {
     fun `task function failures should retry with exponential backoff until maximum retries reached`() = runTimeoutTest {
         val timings = STANDARD_TEST_TIMINGS
         var callCount = 0
+        val attempts = mutableListOf<Int>()
         var maxRetriesError: Exception? = null
         val maxRetriesDeferred = CompletableDeferred<Unit>()
 
@@ -256,6 +257,7 @@ class SchedulerTest {
             timings = timings,
             taskFunction = {
                 callCount++
+                attempts += currentSchedulerAttempt()
                 throw Exception("Test failure")
             },
             reachedMaximumFailureRetries = { error ->
@@ -274,6 +276,11 @@ class SchedulerTest {
             timings.failureRetryingConfig.maximumRetries + 1,
             callCount,
             "Should be called maximum retries + 1 times (initial + retries)"
+        )
+        assertEquals(
+            (0..timings.failureRetryingConfig.maximumRetries).toList(),
+            attempts,
+            "Task context should expose the initial attempt and each retry number"
         )
         assertEquals("Test failure", maxRetriesError?.message, "Exception should be passed to max retries callback")
         assertEquals(


### PR DESCRIPTION
## Summary

- generate a unique request ID for every sync GET and POST call
- propagate the scheduler retry attempt into each network request
- prefix request, response, and error logs with the shared request context
- cover request formatting and scheduler attempt propagation

## Why

A sync operation can perform multiple HTTP requests and retry several times. Previously, concurrent logs did not identify which response or error belonged to which request. The added request ID and attempt number make each request lifecycle traceable.

## Validation

- `./gradlew :syncengine:jvmTest :syncengine:compileKotlinIosSimulatorArm64`
- verified request/response correlation in the iOS example app logs