### PR TITLE
feat: log full sync request bodies

### DIFF
--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/PostMutationsRequest.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/PostMutationsRequest.kt
@@ -14,6 +14,8 @@ import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 
 class PostMutationsRequest(
@@ -21,6 +23,9 @@ class PostMutationsRequest(
     private val url: String
 ) {
     private val logger = Logger.withTag("PostMutationsRequestClient")
+    private val requestBodyJson = Json {
+        explicitNulls = false
+    }
     
     // region: JSON Mapping.
     @Serializable
@@ -90,18 +95,15 @@ class PostMutationsRequest(
 
         val fullUrl = "$url/v1/sync"
         logger.i { logContext.format("Starting POST mutations request to $fullUrl") }
-        
-        // Log request body summary
+
         logger.d {
             logContext.format(
-                "Request body: mutations count=${requestBody.mutations.size}, " +
+                "Request summary: mutations count=${requestBody.mutations.size}, " +
                     "lastMutationAt=$lastModificationDate"
             )
         }
-        if (requestBody.mutations.isNotEmpty()) {
-            logger.v {
-                logContext.format("First mutation sample: ${requestBody.mutations.first()}")
-            }
+        logger.v {
+            logContext.format("Request body: ${requestBodyJson.encodeToString(requestBody)}")
         }
 
         val httpResponse = httpClient.post(fullUrl) {


### PR DESCRIPTION
## Summary

- retain the compact mutation count and `lastMutationAt` request summary
- serialize and log the complete POST mutations payload at verbose level
- include every mutation in a batch under the existing request ID and retry attempt context

## Why

Logging only the first mutation sample hides later mutations when several resources are pushed together. Full payload logging makes it possible to identify the exact mutation and field rejected by the sync API.

The payload is emitted at verbose level because it can contain user-authored content such as note bodies. Authentication headers are not logged.

## Validation

- `./gradlew :syncengine:jvmTest :syncengine:compileKotlinIosSimulatorArm64`
- `git diff --check`
- verified the iOS example logs show both NOTE and READING_SESSION mutations in the same serialized body