### PR TITLE
fix(sync): ignore unknown response fields

### DIFF
--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/network/PostMutationsRequestTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/network/PostMutationsRequestTest.kt
@@ -44,7 +44,12 @@ class PostMutationsRequestTest {
             }
         ) {
             install(ContentNegotiation) {
-                json(Json { explicitNulls = false })
+                json(
+                    Json {
+                        explicitNulls = false
+                        ignoreUnknownKeys = true
+                    }
+                )
             }
         }
         val request = PostMutationsRequest(client, "https://example.test")
@@ -102,18 +107,21 @@ class PostMutationsRequestTest {
     }
 
     @Test
-    fun `postMutations decodes collection bookmark create ACK with missing resource id`() = runTest {
+    fun `postMutations ignores unknown response fields`() = runTest {
         val localMutation = collectionBookmarkCreateRequest()
         val request = postRequestWithResponse(
             """
                 {
                   "success": true,
+                  "requestId": "request-a",
                   "data": {
                     "lastMutationAt": 1234,
+                    "serverVersion": 2,
                     "mutations": [
                       {
                         "type": "CREATE",
                         "resource": "COLLECTION_BOOKMARK",
+                        "traceId": "trace-a",
                         "data": {
                           "collectionId": "collection-a",
                           "bookmarkId": "bookmark-a",
@@ -242,7 +250,12 @@ class PostMutationsRequestTest {
             }
         ) {
             install(ContentNegotiation) {
-                json(Json { explicitNulls = false })
+                json(
+                    Json {
+                        explicitNulls = false
+                        ignoreUnknownKeys = true
+                    }
+                )
             }
         }
         return PostMutationsRequest(client, "https://example.test")

--- a/syncengine/src/iosMain/kotlin/com/quran/shared/syncengine/network/HttpClientFactory.apple.kt
+++ b/syncengine/src/iosMain/kotlin/com/quran/shared/syncengine/network/HttpClientFactory.apple.kt
@@ -17,7 +17,12 @@ actual object HttpClientFactory {
     actual fun createHttpClient(): HttpClient {
         return HttpClient(Darwin) {
             install(ContentNegotiation) {
-                json(Json { explicitNulls = false })
+                json(
+                    Json {
+                        explicitNulls = false
+                        ignoreUnknownKeys = true
+                    }
+                )
             }
             install(Logging) {
                 logger = object : KtorLogger {

--- a/syncengine/src/jvmMain/kotlin/com/quran/shared/syncengine/network/HttpClientFactory.jvm.kt
+++ b/syncengine/src/jvmMain/kotlin/com/quran/shared/syncengine/network/HttpClientFactory.jvm.kt
@@ -12,7 +12,12 @@ actual object HttpClientFactory {
     actual fun createHttpClient(): HttpClient {
         return HttpClient(OkHttp) {
             install(ContentNegotiation) {
-                json(Json { explicitNulls = false })
+                json(
+                    Json {
+                        explicitNulls = false
+                        ignoreUnknownKeys = true
+                    }
+                )
             }
             install(Logging) {
                 level = LogLevel.INFO


### PR DESCRIPTION
## Summary

- ignore unknown response fields in the JVM and Apple sync HTTP clients
- keep request encoding behavior unchanged
- mirror production JSON decoding in network tests
- cover unknown fields at the response, data, and mutation levels

## Why

Kotlin serialization rejects unknown keys by default. Additive backend response fields could therefore break otherwise compatible sync responses.

## Impact

GET and POST sync response decoding is forward-compatible with additive backend fields on both supported platforms. Required known fields remain validated normally.

## Validation

- `./gradlew :syncengine:jvmTest --tests 'com.quran.shared.syncengine.network.PostMutationsRequestTest' --stacktrace`
- `./gradlew :syncengine:allTests --stacktrace`

## Stack

Stacked on #229.