### PR TITLE
fix(reading-session): merge destination collisions

### DIFF
--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/readingsession/repository/ReadingSessionsRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/readingsession/repository/ReadingSessionsRepository.kt
@@ -29,12 +29,14 @@ interface ReadingSessionsRepository {
     suspend fun addReadingSession(sura: Int, ayah: Int, timestamp: PlatformDateTime): ReadingSession
 
     /**
-     * Update an existing active reading session by its mobile-sync ID.
+     * Update an existing active reading session by its mobile-sync ID. If another active
+     * session already occupies the destination, the source is deleted and the destination
+     * is updated instead.
      *
      * @param id the mobile-sync ID of the session to update
      * @param sura the new sura number of the session
      * @param ayah the new ayah number of the session
-     * @return the updated [ReadingSession]
+     * @return the updated [ReadingSession], whose ID may be the existing destination's ID
      */
     @NativeCoroutines
     suspend fun updateReadingSession(id: String, sura: Int, ayah: Int): ReadingSession

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/readingsession/repository/ReadingSessionsRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/readingsession/repository/ReadingSessionsRepositoryImpl.kt
@@ -143,22 +143,36 @@ class ReadingSessionsRepositoryImpl(
                     sura.toLong(),
                     ayah.toLong()
                 ).executeAsOneOrNull()
-                require(conflicting == null || conflicting.local_id == localId) {
-                    "Reading session already exists for $sura:$ayah."
+
+                val updatedLocalId = if (conflicting != null && conflicting.local_id != localId) {
+                    logger.i {
+                        "Merging reading session id=$id into existing session " +
+                            "id=${conflicting.local_id} at $sura:$ayah"
+                    }
+                    readingSessionsQueries.value.deleteReadingSession(
+                        chapter_number = existing.chapter_number,
+                        verse_number = existing.verse_number,
+                        timestamp = updatedAt
+                    )
+                    conflicting.local_id
+                } else {
+                    localId
                 }
 
                 readingSessionsQueries.value.updateReadingSession(
-                    local_id = localId,
+                    local_id = updatedLocalId,
                     chapter_number = sura.toLong(),
                     verse_number = ayah.toLong(),
                     modified_at = updatedAt
                 )
                 pruneOldReadingSessions()
 
-                val record = readingSessionsQueries.value.getReadingSessionByLocalId(localId)
+                val record = readingSessionsQueries.value.getReadingSessionByLocalId(updatedLocalId)
                     .executeAsOneOrNull()
-                requireNotNull(record) { "Expected reading session id=$id after update." }
-                require(record.deleted == 0L) { "Expected active reading session id=$id after update." }
+                requireNotNull(record) { "Expected reading session id=$updatedLocalId after update." }
+                require(record.deleted == 0L) {
+                    "Expected active reading session id=$updatedLocalId after update."
+                }
                 updatedSession = record.toReadingSession()
             }
 

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/ReadingSessionsRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/ReadingSessionsRepositoryTest.kt
@@ -323,21 +323,73 @@ class ReadingSessionsRepositoryTest {
     }
 
     @Test
-    fun `updateReadingSession handles target conflicts deterministically`() = runTest {
-        val source = repository.addReadingSession(2, 255)
-        val target = repository.addReadingSession(3, 10)
+    fun `updateReadingSession merges source into existing local target`() = runTest {
+        val source = repository.addReadingSession(2, 255, timestamp(1000L))
+        val target = repository.addReadingSession(3, 10, timestamp(2000L))
 
-        assertFailsWith<IllegalArgumentException> {
-            repository.updateReadingSession(source.id, 3, 10)
-        }
+        val updated = repository.updateReadingSession(source.id, 3, 10, timestamp(3000L))
 
-        val sourceRecord = database.reading_sessionsQueries.getReadingSessionByLocalId(source.id.toLong())
+        val sourceRecord = database.reading_sessionsQueries
+            .getReadingSessionByLocalId(source.id.toLong())
             .executeAsOne()
-        val targetRecord = database.reading_sessionsQueries.getReadingSessionForChapterVerse(3L, 10L)
+        val targetRecord = database.reading_sessionsQueries
+            .getReadingSessionByLocalId(target.id.toLong())
             .executeAsOne()
-        assertEquals(2L, sourceRecord.chapter_number)
-        assertEquals(255L, sourceRecord.verse_number)
-        assertEquals(target.id.toLong(), targetRecord.local_id)
+        assertEquals(target.id, updated.id)
+        assertEquals(3000L, updated.lastUpdated.fromPlatform().toEpochMilliseconds())
+        assertEquals(1L, sourceRecord.deleted)
+        assertEquals(0L, targetRecord.deleted)
+        assertEquals(3000L, targetRecord.modified_at)
+        assertEquals(listOf(target.id), repository.getReadingSessions().map { it.id })
+
+        val mutation = repository.fetchMutatedReadingSessions().single()
+        assertEquals(target.id, mutation.localID)
+        assertEquals(Mutation.CREATED, mutation.mutation)
+    }
+
+    @Test
+    fun `updateReadingSession merges remote source into existing remote target mutations`() = runTest {
+        database.reading_sessionsQueries.persistRemoteReadingSession(
+            remote_id = "remote-source",
+            chapter_number = 2L,
+            verse_number = 255L,
+            created_at = 1000L,
+            modified_at = 1000L
+        )
+        database.reading_sessionsQueries.persistRemoteReadingSession(
+            remote_id = "remote-target",
+            chapter_number = 3L,
+            verse_number = 10L,
+            created_at = 2000L,
+            modified_at = 2000L
+        )
+        val source = database.reading_sessionsQueries
+            .getReadingSessionByRemoteId("remote-source")
+            .executeAsOne()
+        val target = database.reading_sessionsQueries
+            .getReadingSessionByRemoteId("remote-target")
+            .executeAsOne()
+
+        val updated = repository.updateReadingSession(
+            source.local_id.toString(),
+            3,
+            10,
+            timestamp(3000L)
+        )
+
+        assertEquals(target.local_id.toString(), updated.id)
+        assertEquals(listOf(target.local_id.toString()), repository.getReadingSessions().map { it.id })
+        val mutations = repository.fetchMutatedReadingSessions()
+        assertEquals(2, mutations.size)
+        assertEquals(
+            setOf("remote-source" to Mutation.DELETED, "remote-target" to Mutation.MODIFIED),
+            mutations.map { it.remoteID to it.mutation }.toSet()
+        )
+        assertTrue(
+            mutations.all {
+                it.model.lastUpdated.fromPlatform().toEpochMilliseconds() == 3000L
+            }
+        )
     }
 
     @Test

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/QuranDataService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/QuranDataService.kt
@@ -515,6 +515,11 @@ class QuranDataService internal constructor(
         }
     }
 
+    /**
+     * Updates a reading session, merging it into an existing destination session when needed.
+     *
+     * The returned session is authoritative because a merge returns the destination's ID.
+     */
     @NativeCoroutines
     suspend fun updateReadingSession(id: String, sura: Int, ayah: Int): ReadingSession {
         return updateReadingSession(id, sura, ayah, currentPlatformDateTime())


### PR DESCRIPTION
## Summary

- merge a reading-session move into an existing destination instead of rejecting it
- soft-delete the source and refresh the destination in one database transaction
- return the authoritative destination identity to clients
- cover local and remote collision mutation behavior with real persistence tests

## Root cause

Moving a reading session onto a verse that already had an active session violated the active-position uniqueness constraint. The repository detected the collision but returned an error, leaving iOS unable to complete the move.

## Impact

iOS can now move a recent page onto an occupied page. The destination becomes the updated recent page, the source disappears from active observations, and sync emits the appropriate source delete and destination update mutations.

## Validation

- `./gradlew allTests --stacktrace --continue`
- local debug XCFramework and MobileSync Swift package build
- quran-ios `AnnotationsServiceTests` with local MobileSync: 31 passed
- quran-ios explicit no-sync `AnnotationsService` build
- manually validated in the iPhone 17 Pro simulator on iOS 26.1

Stacked on #230.