### PR TITLE
Fix default Favorites collection sync contract

### DIFF
--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collection/repository/CollectionsRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collection/repository/CollectionsRepositoryImpl.kt
@@ -57,6 +57,13 @@ class CollectionsRepositoryImpl(
     override suspend fun updateCollection(localId: String, name: String): Collection {
         logger.i { "Updating collection localId=$localId with name=$name" }
         return withContext(Dispatchers.IO) {
+            val existing = collectionQueries.value.getCollectionByLocalId(localId.toLong())
+                .executeAsOneOrNull()
+            requireNotNull(existing) { "Expected collection localId=$localId before update." }
+            if (existing.remote_id == DEFAULT_COLLECTION_ID) {
+                logger.w { "Ignoring rename of immutable default collection localId=$localId" }
+                return@withContext existing.toCollection()
+            }
             collectionQueries.value.updateCollectionName(name = name, id = localId.toLong())
             val record = collectionQueries.value.getCollectionByLocalId(localId.toLong())
                 .executeAsOneOrNull()
@@ -67,10 +74,16 @@ class CollectionsRepositoryImpl(
 
     override suspend fun deleteCollection(localId: String): Boolean {
         logger.i { "Deleting collection localId=$localId" }
-        withContext(Dispatchers.IO) {
+        return withContext(Dispatchers.IO) {
+            val existing = collectionQueries.value.getCollectionByLocalId(localId.toLong())
+                .executeAsOneOrNull()
+            if (existing?.remote_id == DEFAULT_COLLECTION_ID) {
+                logger.w { "Ignoring deletion of immutable default collection localId=$localId" }
+                return@withContext false
+            }
             collectionQueries.value.deleteCollection(id = localId.toLong())
+            true
         }
-        return true
     }
 
     override suspend fun fetchMutatedCollections(): List<LocalModelMutation<Collection>> {
@@ -165,5 +178,9 @@ class CollectionsRepositoryImpl(
 
             remoteIDs.associateWith { existentIDs.contains(it) }
         }
+    }
+
+    private companion object {
+        const val DEFAULT_COLLECTION_ID = "__default__"
     }
 }

--- a/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/collections.sq
+++ b/persistence/src/commonMain/sqldelight/com/quran/shared/persistence/collections.sq
@@ -39,16 +39,25 @@ updateCollectionName:
   SET name = :name,
     is_edited = CASE WHEN remote_id IS NULL THEN is_edited ELSE 1 END,
     modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
-  WHERE local_id = :id;
+  WHERE local_id = :id
+    AND (remote_id IS NULL OR remote_id != '__default__');
 
 deleteCollection {
-  DELETE FROM bookmark_collection WHERE collection_local_id = :id;
+  DELETE FROM bookmark_collection
+  WHERE collection_local_id = :id
+    AND EXISTS (
+      SELECT 1 FROM collection
+      WHERE local_id = :id
+        AND (remote_id IS NULL OR remote_id != '__default__')
+    );
   DELETE FROM collection WHERE local_id = :id AND remote_id IS NULL;
   UPDATE collection
   SET deleted = 1,
     is_edited = 1,
     modified_at = CAST(strftime('%s', 'now') AS INTEGER) * 1000
-  WHERE local_id = :id AND remote_id IS NOT NULL;
+  WHERE local_id = :id
+    AND remote_id IS NOT NULL
+    AND remote_id != '__default__';
 }
 
 getUnsyncedCollections:

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/DefaultCollectionRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/DefaultCollectionRepositoryTest.kt
@@ -1,0 +1,226 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.quran.shared.persistence.repository
+
+import com.quran.shared.mutations.Mutation
+import com.quran.shared.mutations.RemoteModelMutation
+import com.quran.shared.persistence.QuranDatabase
+import com.quran.shared.persistence.TestDatabaseDriver
+import com.quran.shared.persistence.input.RemoteCollection
+import com.quran.shared.persistence.input.RemoteCollectionBookmark
+import com.quran.shared.persistence.repository.bookmark.repository.BookmarksRepository
+import com.quran.shared.persistence.repository.bookmark.repository.BookmarksRepositoryImpl
+import com.quran.shared.persistence.repository.collection.repository.CollectionsRepository
+import com.quran.shared.persistence.repository.collection.repository.CollectionsRepositoryImpl
+import com.quran.shared.persistence.repository.collection.repository.CollectionsSynchronizationRepository
+import com.quran.shared.persistence.repository.collectionbookmark.repository.CollectionBookmarksRepository
+import com.quran.shared.persistence.repository.collectionbookmark.repository.CollectionBookmarksRepositoryImpl
+import com.quran.shared.persistence.repository.collectionbookmark.repository.CollectionBookmarksSynchronizationRepository
+import com.quran.shared.persistence.util.toPlatform
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+class DefaultCollectionRepositoryTest {
+    private lateinit var database: QuranDatabase
+    private lateinit var bookmarksRepository: BookmarksRepository
+    private lateinit var collectionsRepository: CollectionsRepository
+    private lateinit var collectionsSyncRepository: CollectionsSynchronizationRepository
+    private lateinit var collectionBookmarksRepository: CollectionBookmarksRepository
+    private lateinit var collectionBookmarksSyncRepository: CollectionBookmarksSynchronizationRepository
+
+    @BeforeTest
+    fun setup() {
+        database = QuranDatabase(TestDatabaseDriver().createDriver())
+        bookmarksRepository = BookmarksRepositoryImpl(database)
+        collectionsRepository = CollectionsRepositoryImpl(database)
+        collectionsSyncRepository = collectionsRepository as CollectionsSynchronizationRepository
+        collectionBookmarksRepository = CollectionBookmarksRepositoryImpl(database)
+        collectionBookmarksSyncRepository =
+            collectionBookmarksRepository as CollectionBookmarksSynchronizationRepository
+    }
+
+    @Test
+    fun `remote default collection binds unsynced Favorites without losing pending membership`() = runTest {
+        val localFavorites = collectionsRepository.addCollection(FAVORITES_NAME)
+        val bookmark = bookmarksRepository.addBookmark(42)
+        val membership = collectionBookmarksRepository.addBookmarkToCollection(
+            localFavorites.localId,
+            bookmark
+        )
+
+        assertTrue(collectionBookmarksSyncRepository.fetchMutatedCollectionBookmarks().isEmpty())
+
+        collectionsSyncRepository.applyRemoteChanges(
+            updatesToPersist = listOf(defaultCollectionMutation()),
+            localMutationsToClear = emptyList()
+        )
+
+        val collections = collectionsRepository.getAllCollections()
+        assertEquals(1, collections.size)
+        assertEquals(localFavorites.localId, collections.single().localId)
+        assertEquals(
+            DEFAULT_COLLECTION_ID,
+            database.collectionsQueries
+                .getCollectionByLocalId(localFavorites.localId.toLong())
+                .executeAsOne()
+                .remote_id
+        )
+        assertTrue(collectionsSyncRepository.fetchMutatedCollections().isEmpty())
+
+        val memberships = collectionBookmarksRepository.getBookmarksForCollection(localFavorites.localId)
+        assertEquals(listOf(membership.localId), memberships.map { it.localId })
+        val pendingMembership = collectionBookmarksSyncRepository
+            .fetchMutatedCollectionBookmarks()
+            .single()
+        assertEquals(Mutation.CREATED, pendingMembership.mutation)
+        assertEquals(membership.localId, pendingMembership.localID)
+        assertEquals(DEFAULT_COLLECTION_ID, pendingMembership.model.collectionRemoteId)
+    }
+
+    @Test
+    fun `default collection rename is suppressed without enqueuing a collection mutation`() = runTest {
+        persistDefaultCollection()
+        val defaultCollection = collectionsRepository.getAllCollections().single()
+
+        val returned = collectionsRepository.updateCollection(defaultCollection.localId, "Renamed")
+
+        assertEquals(FAVORITES_NAME, returned.name)
+        assertEquals(FAVORITES_NAME, collectionsRepository.getAllCollections().single().name)
+        assertTrue(collectionsSyncRepository.fetchMutatedCollections().isEmpty())
+    }
+
+    @Test
+    fun `default collection delete is suppressed without removing memberships or enqueuing mutation`() = runTest {
+        persistDefaultCollection()
+        val defaultCollection = collectionsRepository.getAllCollections().single()
+        val bookmark = bookmarksRepository.addBookmark(24)
+        val membership = collectionBookmarksRepository.addBookmarkToCollection(
+            defaultCollection.localId,
+            bookmark
+        )
+
+        val deleted = collectionsRepository.deleteCollection(defaultCollection.localId)
+
+        assertFalse(deleted)
+        assertEquals(listOf(defaultCollection), collectionsRepository.getAllCollections())
+        assertEquals(
+            listOf(membership.localId),
+            collectionBookmarksRepository
+                .getBookmarksForCollection(defaultCollection.localId)
+                .map { it.localId }
+        )
+        assertTrue(collectionsSyncRepository.fetchMutatedCollections().isEmpty())
+    }
+
+    @Test
+    fun `remote default membership without its collection is rejected without side effects`() = runTest {
+        collectionBookmarksSyncRepository.applyRemoteChanges(
+            updatesToPersist = listOf(defaultMembershipMutation("remote-membership-1")),
+            localMutationsToClear = emptyList()
+        )
+
+        assertTrue(database.bookmark_collectionsQueries.getCollectionBookmarks().executeAsList().isEmpty())
+        assertTrue(bookmarksRepository.getAllBookmarks().isEmpty())
+        assertTrue(collectionBookmarksSyncRepository.fetchMutatedCollectionBookmarks().isEmpty())
+    }
+
+    @Test
+    fun `default membership add remove and re-add round trips remain syncable`() = runTest {
+        persistDefaultCollection()
+        val defaultCollection = collectionsRepository.getAllCollections().single()
+        val bookmark = bookmarksRepository.addBookmark(42)
+
+        collectionBookmarksRepository.addBookmarkToCollection(defaultCollection.localId, bookmark)
+        val pendingCreate = collectionBookmarksSyncRepository.fetchMutatedCollectionBookmarks().single()
+        assertEquals(Mutation.CREATED, pendingCreate.mutation)
+        assertEquals(DEFAULT_COLLECTION_ID, pendingCreate.model.collectionRemoteId)
+        assertNull(pendingCreate.remoteID)
+
+        collectionBookmarksSyncRepository.applyRemoteChanges(
+            updatesToPersist = listOf(defaultMembershipMutation("remote-membership-1")),
+            localMutationsToClear = listOf(pendingCreate)
+        )
+        assertTrue(collectionBookmarksSyncRepository.fetchMutatedCollectionBookmarks().isEmpty())
+        assertEquals(
+            1,
+            collectionBookmarksRepository.getBookmarksForCollection(defaultCollection.localId).size
+        )
+
+        collectionBookmarksRepository.removeBookmarkFromCollection(defaultCollection.localId, bookmark)
+        assertTrue(
+            collectionBookmarksRepository.getBookmarksForCollection(defaultCollection.localId).isEmpty()
+        )
+        val pendingDelete = collectionBookmarksSyncRepository.fetchMutatedCollectionBookmarks().single()
+        assertEquals(Mutation.DELETED, pendingDelete.mutation)
+        assertEquals(DEFAULT_COLLECTION_ID, pendingDelete.model.collectionRemoteId)
+        assertEquals("remote-membership-1", pendingDelete.remoteID)
+
+        collectionBookmarksSyncRepository.applyRemoteChanges(
+            updatesToPersist = listOf(
+                defaultMembershipMutation(
+                    remoteId = "remote-membership-1",
+                    mutation = Mutation.DELETED
+                )
+            ),
+            localMutationsToClear = listOf(pendingDelete)
+        )
+        assertTrue(collectionBookmarksSyncRepository.fetchMutatedCollectionBookmarks().isEmpty())
+
+        collectionBookmarksRepository.addBookmarkToCollection(defaultCollection.localId, bookmark)
+        val pendingReAdd = collectionBookmarksSyncRepository.fetchMutatedCollectionBookmarks().single()
+        assertEquals(Mutation.CREATED, pendingReAdd.mutation)
+        assertEquals(DEFAULT_COLLECTION_ID, pendingReAdd.model.collectionRemoteId)
+        assertNull(pendingReAdd.remoteID)
+
+        collectionBookmarksSyncRepository.applyRemoteChanges(
+            updatesToPersist = listOf(defaultMembershipMutation("remote-membership-2")),
+            localMutationsToClear = listOf(pendingReAdd)
+        )
+        assertTrue(collectionBookmarksSyncRepository.fetchMutatedCollectionBookmarks().isEmpty())
+        assertEquals(
+            1,
+            collectionBookmarksRepository.getBookmarksForCollection(defaultCollection.localId).size
+        )
+    }
+
+    private suspend fun persistDefaultCollection() {
+        collectionsSyncRepository.applyRemoteChanges(
+            updatesToPersist = listOf(defaultCollectionMutation()),
+            localMutationsToClear = emptyList()
+        )
+    }
+
+    private fun defaultCollectionMutation() = RemoteModelMutation(
+        model = RemoteCollection(
+            name = FAVORITES_NAME,
+            lastUpdated = Instant.fromEpochMilliseconds(1_000).toPlatform()
+        ),
+        remoteID = DEFAULT_COLLECTION_ID,
+        mutation = Mutation.CREATED
+    )
+
+    private fun defaultMembershipMutation(
+        remoteId: String,
+        mutation: Mutation = Mutation.CREATED
+    ): RemoteModelMutation<RemoteCollectionBookmark> = RemoteModelMutation(
+        model = RemoteCollectionBookmark.Page(
+            collectionId = DEFAULT_COLLECTION_ID,
+            page = 42,
+            lastUpdated = Instant.fromEpochMilliseconds(2_000).toPlatform(),
+            bookmarkId = "bookmark-42"
+        ),
+        remoteID = remoteId,
+        mutation = mutation
+    )
+
+    private companion object {
+        const val DEFAULT_COLLECTION_ID = "__default__"
+        const val FAVORITES_NAME = "Favorites"
+    }
+}

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/DefaultCollectionRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/DefaultCollectionRepositoryTest.kt
@@ -119,6 +119,48 @@ class DefaultCollectionRepositoryTest {
     }
 
     @Test
+    fun `rename statement rejects a row bound as default at the mutation boundary`() = runTest {
+        val localFavorites = collectionsRepository.addCollection(FAVORITES_NAME)
+        bindDefaultAtMutationBoundary(localFavorites.localId)
+
+        database.collectionsQueries.updateCollectionName(
+            name = "Renamed",
+            id = localFavorites.localId.toLong()
+        )
+
+        val persisted = database.collectionsQueries
+            .getCollectionByLocalId(localFavorites.localId.toLong())
+            .executeAsOne()
+        assertEquals(FAVORITES_NAME, persisted.name)
+        assertEquals(0L, persisted.is_edited)
+    }
+
+    @Test
+    fun `delete statement preserves a row and memberships bound as default at mutation boundary`() = runTest {
+        val localFavorites = collectionsRepository.addCollection(FAVORITES_NAME)
+        val bookmark = bookmarksRepository.addBookmark(42)
+        val membership = collectionBookmarksRepository.addBookmarkToCollection(
+            localFavorites.localId,
+            bookmark
+        )
+        bindDefaultAtMutationBoundary(localFavorites.localId)
+
+        database.collectionsQueries.deleteCollection(localFavorites.localId.toLong())
+
+        val persisted = database.collectionsQueries
+            .getCollectionByLocalId(localFavorites.localId.toLong())
+            .executeAsOne()
+        assertEquals(0L, persisted.deleted)
+        assertEquals(0L, persisted.is_edited)
+        assertEquals(
+            listOf(membership.localId),
+            collectionBookmarksRepository
+                .getBookmarksForCollection(localFavorites.localId)
+                .map { it.localId }
+        )
+    }
+
+    @Test
     fun `remote default membership without its collection is rejected without side effects`() = runTest {
         collectionBookmarksSyncRepository.applyRemoteChanges(
             updatesToPersist = listOf(defaultMembershipMutation("remote-membership-1")),
@@ -193,6 +235,15 @@ class DefaultCollectionRepositoryTest {
         collectionsSyncRepository.applyRemoteChanges(
             updatesToPersist = listOf(defaultCollectionMutation()),
             localMutationsToClear = emptyList()
+        )
+    }
+
+    private fun bindDefaultAtMutationBoundary(localId: String) {
+        database.collectionsQueries.updateRemoteCollectionByLocalId(
+            local_id = localId.toLong(),
+            remote_id = DEFAULT_COLLECTION_ID,
+            name = FAVORITES_NAME,
+            modified_at = 1_000
         )
     }
 

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncEnginePipeline.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncEnginePipeline.kt
@@ -87,7 +87,8 @@ public class SyncEnginePipeline(
             bookmarksConfigurations = bookmarksConf,
             collectionsConfigurations = collectionsConf,
             collectionBookmarksConfigurations = collectionBookmarksConf,
-            notesConfigurations = notesConf
+            notesConfigurations = notesConf,
+            synchronizationCompleted = callback::synchronizationDone
         )
 
         this.syncClient = syncClient
@@ -249,7 +250,6 @@ private class ResultReceiver(
         Logger.i { "Persisting ${mappedRemotes.count()} remote updates, and clearing ${mappedLocals.count()} local updates." }
         
         repository.applyRemoteChanges(mappedRemotes, mappedLocals)
-        callback.synchronizationDone(newToken)
     }
 }
 
@@ -289,7 +289,6 @@ private class CollectionsResultReceiver(
         }
 
         repository.applyRemoteChanges(mappedRemotes, mappedLocals)
-        callback.synchronizationDone(newToken)
     }
 }
 
@@ -329,7 +328,6 @@ private class CollectionBookmarksResultReceiver(
         }
 
         repository.applyRemoteChanges(mappedRemotes, mappedLocals)
-        callback.synchronizationDone(newToken)
     }
 }
 
@@ -392,7 +390,6 @@ private class NotesResultReceiver(
         }
 
         repository.applyRemoteChanges(mappedRemotes, mappedLocals)
-        callback.synchronizationDone(newToken)
     }
 }
 

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncService.kt
@@ -254,13 +254,23 @@ fun makeSettings(): Settings = Settings()
 
 class SettingsLocalModificationDateFetcher(private val settings: Settings) :
     LocalModificationDateFetcher {
-    private val KEY_LAST_MODIFIED = "com.quran.sync.last_modified_date"
 
     override suspend fun localLastModificationDate(): Long {
+        if (settings.getInt(KEY_PROTOCOL_VERSION, 0) < CURRENT_PROTOCOL_VERSION) {
+            settings[KEY_LAST_MODIFIED] = 0L
+            return 0L
+        }
         return settings.getLong(KEY_LAST_MODIFIED, 0L)
     }
 
     fun updateLastModificationDate(date: Long) {
         settings[KEY_LAST_MODIFIED] = date
+        settings[KEY_PROTOCOL_VERSION] = CURRENT_PROTOCOL_VERSION
+    }
+
+    private companion object {
+        const val KEY_LAST_MODIFIED = "com.quran.sync.last_modified_date"
+        const val KEY_PROTOCOL_VERSION = "com.quran.sync.protocol_version"
+        const val CURRENT_PROTOCOL_VERSION = 1
     }
 }

--- a/sync-pipelines/src/jvmTest/kotlin/com/quran/shared/pipeline/SettingsLocalModificationDateFetcherTest.kt
+++ b/sync-pipelines/src/jvmTest/kotlin/com/quran/shared/pipeline/SettingsLocalModificationDateFetcherTest.kt
@@ -1,0 +1,56 @@
+package com.quran.shared.pipeline
+
+import com.russhwolf.settings.PropertiesSettings
+import com.russhwolf.settings.get
+import com.russhwolf.settings.set
+import java.util.Properties
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class SettingsLocalModificationDateFetcherTest {
+
+    @Test
+    fun `first cursor protocol use replays from zero and marks completion only on success`() = runBlocking {
+        val settings = PropertiesSettings(Properties())
+        settings[LAST_MODIFIED_KEY] = 900L
+        settings["pending.local.mutation"] = "preserved"
+        val fetcher = SettingsLocalModificationDateFetcher(settings)
+
+        assertEquals(0L, fetcher.localLastModificationDate())
+        assertEquals(0L, settings.getLong(LAST_MODIFIED_KEY, -1L))
+        assertEquals("preserved", settings.getString("pending.local.mutation", ""))
+        assertFalse(settings.hasKey(PROTOCOL_VERSION_KEY))
+
+        fetcher.updateLastModificationDate(1_200L)
+
+        assertEquals(1_200L, settings.getLong(LAST_MODIFIED_KEY, -1L))
+        assertEquals(1, settings.getInt(PROTOCOL_VERSION_KEY, 0))
+        assertEquals(
+            1_200L,
+            SettingsLocalModificationDateFetcher(settings).localLastModificationDate()
+        )
+    }
+
+    @Test
+    fun `failed replay remains incomplete and retries from zero`() = runBlocking {
+        val settings = PropertiesSettings(Properties())
+        settings[LAST_MODIFIED_KEY] = 900L
+        val fetcher = SettingsLocalModificationDateFetcher(settings)
+
+        assertEquals(0L, fetcher.localLastModificationDate())
+        assertFalse(settings.hasKey(PROTOCOL_VERSION_KEY))
+
+        settings[LAST_MODIFIED_KEY] = 777L
+
+        assertEquals(0L, fetcher.localLastModificationDate())
+        assertEquals(0L, settings.getLong(LAST_MODIFIED_KEY, -1L))
+        assertFalse(settings.hasKey(PROTOCOL_VERSION_KEY))
+    }
+
+    private companion object {
+        const val LAST_MODIFIED_KEY = "com.quran.sync.last_modified_date"
+        const val PROTOCOL_VERSION_KEY = "com.quran.sync.protocol_version"
+    }
+}

--- a/sync-pipelines/src/jvmTest/kotlin/com/quran/shared/pipeline/SyncEnginePipelineCompletionTest.kt
+++ b/sync-pipelines/src/jvmTest/kotlin/com/quran/shared/pipeline/SyncEnginePipelineCompletionTest.kt
@@ -1,0 +1,286 @@
+package com.quran.shared.pipeline
+
+import com.quran.shared.mutations.LocalModelMutation
+import com.quran.shared.mutations.Mutation
+import com.quran.shared.mutations.RemoteModelMutation
+import com.quran.shared.persistence.input.RemoteBookmark
+import com.quran.shared.persistence.input.RemoteCollection
+import com.quran.shared.persistence.model.Bookmark
+import com.quran.shared.persistence.model.Collection
+import com.quran.shared.persistence.repository.bookmark.repository.BookmarksSynchronizationRepository
+import com.quran.shared.persistence.repository.collection.repository.CollectionsSynchronizationRepository
+import com.quran.shared.syncengine.AuthenticationDataFetcher
+import com.quran.shared.syncengine.LocalModificationDateFetcher
+import com.quran.shared.syncengine.SynchronizationEnvironment
+import com.russhwolf.settings.PropertiesSettings
+import com.russhwolf.settings.get
+import com.russhwolf.settings.set
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+import java.util.Properties
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+class SyncEnginePipelineCompletionTest {
+
+    @Test
+    fun `first protocol replay keeps and pushes pending local mutations`() = runBlocking {
+        ReplaySyncServer().use { server ->
+            val settings = PropertiesSettings(Properties())
+            settings["com.quran.sync.last_modified_date"] = 900L
+            val dateFetcher = SettingsLocalModificationDateFetcher(settings)
+            val bookmarkRepository = PendingBookmarksRepository()
+            val completion = CompletableDeferred<Unit>()
+            val pipeline = SyncEnginePipeline(
+                bookmarkRepository,
+                SuccessfulCollectionsRepository()
+            )
+            val client = pipeline.setup(
+                environment = SynchronizationEnvironment(server.baseUrl),
+                localModificationDateFetcher = dateFetcher,
+                authenticationDataFetcher = LoggedInAuthenticationDataFetcher,
+                callback = object : SyncEngineCallback {
+                    override fun synchronizationDone(newLastModificationDate: Long) {
+                        dateFetcher.updateLastModificationDate(newLastModificationDate)
+                        completion.complete(Unit)
+                    }
+
+                    override fun encounteredError(errorMsg: String) = Unit
+                }
+            )
+
+            try {
+                client.triggerSyncImmediately()
+                withTimeout(5_000) {
+                    completion.await()
+                }
+            } finally {
+                client.cancelSyncing()
+            }
+
+            assertTrue(server.getQueries.single().contains("mutationsSince=0"))
+            assertTrue(server.postBodies.single().filterNot(Char::isWhitespace).contains(""""key":42"""))
+            assertEquals(listOf("pending-1"), bookmarkRepository.clearedLocalIds)
+            assertEquals(2_000L, settings.getLong("com.quran.sync.last_modified_date", -1L))
+            assertEquals(1, settings.getInt("com.quran.sync.protocol_version", 0))
+        }
+    }
+
+    @Test
+    fun `timestamp completion is not reported when a later resource fails`() = runBlocking {
+        EmptySyncServer().use { server ->
+            val completionTokens = CopyOnWriteArrayList<Long>()
+            val bookmarkRepository = RecordingBookmarksRepository()
+            val collectionRepository = FailingCollectionsRepository(completionTokens)
+            val pipeline = SyncEnginePipeline(bookmarkRepository, collectionRepository)
+            val client = pipeline.setup(
+                environment = SynchronizationEnvironment(server.baseUrl),
+                localModificationDateFetcher = object : LocalModificationDateFetcher {
+                    override suspend fun localLastModificationDate(): Long = 100L
+                },
+                authenticationDataFetcher = object : AuthenticationDataFetcher {
+                    override suspend fun fetchAuthenticationHeaders(): Map<String, String> =
+                        emptyMap()
+
+                    override fun isLoggedIn(): Boolean = true
+                },
+                callback = object : SyncEngineCallback {
+                    override fun synchronizationDone(newLastModificationDate: Long) {
+                        completionTokens += newLastModificationDate
+                    }
+
+                    override fun encounteredError(errorMsg: String) = Unit
+                }
+            )
+
+            try {
+                client.triggerSyncImmediately()
+                withTimeout(5_000) {
+                    collectionRepository.failureAttempted.await()
+                }
+            } finally {
+                client.cancelSyncing()
+            }
+
+            assertTrue(bookmarkRepository.applied)
+            assertFalse(collectionRepository.completionObservedBeforeFailure)
+            assertTrue(completionTokens.isEmpty())
+        }
+    }
+}
+
+private object LoggedInAuthenticationDataFetcher : AuthenticationDataFetcher {
+    override suspend fun fetchAuthenticationHeaders(): Map<String, String> = emptyMap()
+    override fun isLoggedIn(): Boolean = true
+}
+
+private class PendingBookmarksRepository : BookmarksSynchronizationRepository {
+    private val pending: LocalModelMutation<Bookmark> = LocalModelMutation(
+        model = Bookmark.PageBookmark(
+            page = 42,
+            lastUpdated = Instant.fromEpochMilliseconds(500),
+            localId = "pending-1"
+        ),
+        remoteID = null,
+        localID = "pending-1",
+        mutation = Mutation.CREATED
+    )
+    val clearedLocalIds = mutableListOf<String>()
+
+    override suspend fun fetchMutatedBookmarks(): List<LocalModelMutation<Bookmark>> =
+        listOf(pending)
+
+    override suspend fun applyRemoteChanges(
+        updatesToPersist: List<RemoteModelMutation<RemoteBookmark>>,
+        localMutationsToClear: List<LocalModelMutation<Bookmark>>
+    ) {
+        clearedLocalIds += localMutationsToClear.map { it.localID }
+    }
+
+    override suspend fun remoteResourcesExist(remoteIDs: List<String>): Map<String, Boolean> =
+        emptyMap()
+
+    override suspend fun fetchBookmarkByRemoteId(remoteId: String): Bookmark? = null
+}
+
+private class SuccessfulCollectionsRepository : CollectionsSynchronizationRepository {
+    override suspend fun fetchMutatedCollections(): List<LocalModelMutation<Collection>> =
+        emptyList()
+
+    override suspend fun applyRemoteChanges(
+        updatesToPersist: List<RemoteModelMutation<RemoteCollection>>,
+        localMutationsToClear: List<LocalModelMutation<Collection>>
+    ) = Unit
+
+    override suspend fun remoteResourcesExist(remoteIDs: List<String>): Map<String, Boolean> =
+        emptyMap()
+}
+
+private class RecordingBookmarksRepository : BookmarksSynchronizationRepository {
+    var applied = false
+
+    override suspend fun fetchMutatedBookmarks(): List<LocalModelMutation<Bookmark>> = emptyList()
+
+    override suspend fun applyRemoteChanges(
+        updatesToPersist: List<RemoteModelMutation<RemoteBookmark>>,
+        localMutationsToClear: List<LocalModelMutation<Bookmark>>
+    ) {
+        applied = true
+    }
+
+    override suspend fun remoteResourcesExist(remoteIDs: List<String>): Map<String, Boolean> =
+        emptyMap()
+
+    override suspend fun fetchBookmarkByRemoteId(remoteId: String): Bookmark? = null
+}
+
+private class FailingCollectionsRepository(
+    private val completionTokens: List<Long>
+) : CollectionsSynchronizationRepository {
+    val failureAttempted = CompletableDeferred<Unit>()
+    var completionObservedBeforeFailure = false
+
+    override suspend fun fetchMutatedCollections(): List<LocalModelMutation<Collection>> =
+        emptyList()
+
+    override suspend fun applyRemoteChanges(
+        updatesToPersist: List<RemoteModelMutation<RemoteCollection>>,
+        localMutationsToClear: List<LocalModelMutation<Collection>>
+    ) {
+        completionObservedBeforeFailure = completionTokens.isNotEmpty()
+        failureAttempted.complete(Unit)
+        throw IllegalStateException("collection persistence failed")
+    }
+
+    override suspend fun remoteResourcesExist(remoteIDs: List<String>): Map<String, Boolean> =
+        emptyMap()
+}
+
+private class EmptySyncServer : AutoCloseable {
+    private val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    val baseUrl: String
+
+    init {
+        server.createContext("/v1/sync") { exchange ->
+            val body = """
+                {
+                  "success": true,
+                  "data": {
+                    "lastMutationAt": 2000,
+                    "mutations": [],
+                    "page": 1,
+                    "hasMore": false
+                  }
+                }
+            """.trimIndent().toByteArray(StandardCharsets.UTF_8)
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        server.start()
+        baseUrl = "http://127.0.0.1:${server.address.port}"
+    }
+
+    override fun close() {
+        server.stop(0)
+    }
+}
+
+private class ReplaySyncServer : AutoCloseable {
+    private val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    val getQueries = CopyOnWriteArrayList<String>()
+    val postBodies = CopyOnWriteArrayList<String>()
+    val baseUrl: String
+
+    init {
+        server.createContext("/v1/sync") { exchange ->
+            val response = if (exchange.requestMethod == "GET") {
+                getQueries += exchange.requestURI.rawQuery
+                """
+                    {
+                      "success": true,
+                      "data": {
+                        "lastMutationAt": 2000,
+                        "mutations": [],
+                        "page": 1,
+                        "hasMore": false
+                      }
+                    }
+                """.trimIndent()
+            } else {
+                postBodies += exchange.requestBody.bufferedReader().use { it.readText() }
+                """
+                    {
+                      "success": true,
+                      "data": {
+                        "lastMutationAt": 2000,
+                        "mutations": [{
+                          "type": "CREATE",
+                          "resource": "BOOKMARK",
+                          "resourceId": "remote-1",
+                          "timestamp": 2000
+                        }]
+                      }
+                    }
+                """.trimIndent()
+            }.toByteArray(StandardCharsets.UTF_8)
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, response.size.toLong())
+            exchange.responseBody.use { it.write(response) }
+        }
+        server.start()
+        baseUrl = "http://127.0.0.1:${server.address.port}"
+    }
+
+    override fun close() {
+        server.stop(0)
+    }
+}

--- a/sync-pipelines/src/jvmTest/kotlin/com/quran/shared/pipeline/SyncEnginePipelineCompletionTest.kt
+++ b/sync-pipelines/src/jvmTest/kotlin/com/quran/shared/pipeline/SyncEnginePipelineCompletionTest.kt
@@ -78,6 +78,72 @@ class SyncEnginePipelineCompletionTest {
     }
 
     @Test
+    fun `first protocol replay preserves same bookmark memberships across collections`() = runBlocking {
+        CollectionMembershipReplayServer().use { server ->
+            val settings = PropertiesSettings(Properties())
+            settings["com.quran.sync.last_modified_date"] = 900L
+            val dateFetcher = SettingsLocalModificationDateFetcher(settings)
+            val collectionBookmarksRepository =
+                ReplayCollectionBookmarksRepository(settings)
+            val completion = CompletableDeferred<Unit>()
+            val pipeline = SyncEnginePipeline(
+                bookmarksRepository = ReplayBookmarksRepository(),
+                collectionsRepository = SuccessfulCollectionsRepository(),
+                collectionBookmarksRepository = collectionBookmarksRepository
+            )
+            val client = pipeline.setup(
+                environment = SynchronizationEnvironment(server.baseUrl),
+                localModificationDateFetcher = dateFetcher,
+                authenticationDataFetcher = LoggedInAuthenticationDataFetcher,
+                callback = object : SyncEngineCallback {
+                    override fun synchronizationDone(newLastModificationDate: Long) {
+                        dateFetcher.updateLastModificationDate(newLastModificationDate)
+                        completion.complete(Unit)
+                    }
+
+                    override fun encounteredError(errorMsg: String) = Unit
+                }
+            )
+
+            try {
+                client.triggerSyncImmediately()
+                withTimeout(5_000) {
+                    completion.await()
+                }
+            } finally {
+                client.cancelSyncing()
+            }
+
+            assertTrue(server.getQueries.single().contains("mutationsSince=0"))
+            assertEquals(listOf("GET"), server.requestMethods)
+            assertEquals(
+                setOf(
+                    "__default__-bookmark-42",
+                    "custom-collection-bookmark-42"
+                ),
+                collectionBookmarksRepository.persistedRemoteIds.toSet()
+            )
+            assertEquals(
+                setOf("__default__", "custom-collection"),
+                collectionBookmarksRepository.persistedCollectionIds.toSet()
+            )
+            assertEquals(
+                listOf("pending-default-membership"),
+                collectionBookmarksRepository.clearedLocalIds
+            )
+            assertEquals(
+                0L,
+                collectionBookmarksRepository.lastModificationDateWhenApplied
+            )
+            assertEquals(
+                2_000L,
+                settings.getLong("com.quran.sync.last_modified_date", -1L)
+            )
+            assertEquals(1, settings.getInt("com.quran.sync.protocol_version", 0))
+        }
+    }
+
+    @Test
     fun `timestamp completion is not reported when a later resource fails`() = runBlocking {
         EmptySyncServer().use { server ->
             val completionTokens = CopyOnWriteArrayList<Long>()
@@ -194,6 +260,30 @@ private class PendingBookmarksRepository : BookmarksSynchronizationRepository {
     override suspend fun fetchBookmarkByRemoteId(remoteId: String): Bookmark? = null
 }
 
+private class ReplayBookmarksRepository : BookmarksSynchronizationRepository {
+    override suspend fun fetchMutatedBookmarks(): List<LocalModelMutation<Bookmark>> =
+        emptyList()
+
+    override suspend fun applyRemoteChanges(
+        updatesToPersist: List<RemoteModelMutation<RemoteBookmark>>,
+        localMutationsToClear: List<LocalModelMutation<Bookmark>>
+    ) = Unit
+
+    override suspend fun remoteResourcesExist(remoteIDs: List<String>): Map<String, Boolean> =
+        remoteIDs.associateWith { false }
+
+    override suspend fun fetchBookmarkByRemoteId(remoteId: String): Bookmark? =
+        if (remoteId == "bookmark-42") {
+            Bookmark.PageBookmark(
+                page = 42,
+                lastUpdated = Instant.fromEpochMilliseconds(500),
+                localId = "local-bookmark-42"
+            )
+        } else {
+            null
+        }
+}
+
 private class SuccessfulCollectionsRepository : CollectionsSynchronizationRepository {
     override suspend fun fetchMutatedCollections(): List<LocalModelMutation<Collection>> =
         emptyList()
@@ -268,7 +358,16 @@ private class OrderingBookmarksRepository(
     override suspend fun remoteResourcesExist(remoteIDs: List<String>): Map<String, Boolean> =
         remoteIDs.associateWith { false }
 
-    override suspend fun fetchBookmarkByRemoteId(remoteId: String): Bookmark? = null
+    override suspend fun fetchBookmarkByRemoteId(remoteId: String): Bookmark? =
+        if (remoteId == "bookmark-42") {
+            Bookmark.PageBookmark(
+                page = 42,
+                lastUpdated = Instant.fromEpochMilliseconds(500),
+                localId = "local-bookmark-42"
+            )
+        } else {
+            null
+        }
 }
 
 private class OrderingCollectionsRepository(
@@ -301,6 +400,45 @@ private class OrderingCollectionBookmarksRepository(
         state.applicationOrder += "COLLECTION_BOOKMARK"
         state.collectionExistedWhenMembershipWasApplied =
             state.collectionRemoteId == updatesToPersist.single().model.collectionId
+    }
+
+    override suspend fun remoteResourcesExist(remoteIDs: List<String>): Map<String, Boolean> =
+        remoteIDs.associateWith { false }
+}
+
+private class ReplayCollectionBookmarksRepository(
+    private val settings: PropertiesSettings
+) : CollectionBookmarksSynchronizationRepository {
+    private val pending: LocalModelMutation<CollectionBookmark> = LocalModelMutation(
+        model = CollectionBookmark.PageBookmark(
+            collectionLocalId = "default-local",
+            collectionRemoteId = "__default__",
+            bookmarkLocalId = "local-bookmark-42",
+            page = 42,
+            lastUpdated = Instant.fromEpochMilliseconds(500),
+            localId = "pending-default-membership"
+        ),
+        remoteID = null,
+        localID = "pending-default-membership",
+        mutation = Mutation.CREATED
+    )
+    val persistedRemoteIds = mutableListOf<String>()
+    val persistedCollectionIds = mutableListOf<String>()
+    val clearedLocalIds = mutableListOf<String>()
+    var lastModificationDateWhenApplied: Long? = null
+
+    override suspend fun fetchMutatedCollectionBookmarks():
+        List<LocalModelMutation<CollectionBookmark>> = listOf(pending)
+
+    override suspend fun applyRemoteChanges(
+        updatesToPersist: List<RemoteModelMutation<RemoteCollectionBookmark>>,
+        localMutationsToClear: List<LocalModelMutation<CollectionBookmark>>
+    ) {
+        lastModificationDateWhenApplied =
+            settings.getLong("com.quran.sync.last_modified_date", -1L)
+        persistedRemoteIds += updatesToPersist.map { it.remoteID }
+        persistedCollectionIds += updatesToPersist.map { it.model.collectionId }
+        clearedLocalIds += localMutationsToClear.map { it.localID }
     }
 
     override suspend fun remoteResourcesExist(remoteIDs: List<String>): Map<String, Boolean> =
@@ -388,6 +526,77 @@ private class ReplaySyncServer : AutoCloseable {
     }
 }
 
+private class CollectionMembershipReplayServer : AutoCloseable {
+    private val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    val getQueries = CopyOnWriteArrayList<String>()
+    val requestMethods = CopyOnWriteArrayList<String>()
+    val baseUrl: String
+
+    init {
+        server.createContext("/v1/sync") { exchange ->
+            requestMethods += exchange.requestMethod
+            getQueries += exchange.requestURI.rawQuery
+            val body = """
+                {
+                  "success": true,
+                  "data": {
+                    "lastMutationAt": 2000,
+                    "mutations": [
+                      {
+                        "type": "CREATE",
+                        "resource": "COLLECTION_BOOKMARK",
+                        "timestamp": 1100,
+                        "data": {
+                          "collectionId": "__default__",
+                          "bookmarkId": "bookmark-42"
+                        }
+                      },
+                      {
+                        "type": "CREATE",
+                        "resource": "COLLECTION_BOOKMARK",
+                        "timestamp": 1200,
+                        "data": {
+                          "collectionId": "custom-collection",
+                          "bookmarkId": "bookmark-42"
+                        }
+                      },
+                      {
+                        "type": "CREATE",
+                        "resource": "COLLECTION",
+                        "resourceId": "__default__",
+                        "timestamp": 1000,
+                        "data": {
+                          "name": "Favorites"
+                        }
+                      },
+                      {
+                        "type": "CREATE",
+                        "resource": "COLLECTION",
+                        "resourceId": "custom-collection",
+                        "timestamp": 1050,
+                        "data": {
+                          "name": "Reading"
+                        }
+                      }
+                    ],
+                    "page": 1,
+                    "hasMore": false
+                  }
+                }
+            """.trimIndent().toByteArray(StandardCharsets.UTF_8)
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        server.start()
+        baseUrl = "http://127.0.0.1:${server.address.port}"
+    }
+
+    override fun close() {
+        server.stop(0)
+    }
+}
+
 private class DefaultCollectionSyncServer : AutoCloseable {
     private val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
     val baseUrl: String
@@ -403,13 +612,10 @@ private class DefaultCollectionSyncServer : AutoCloseable {
                       {
                         "type": "CREATE",
                         "resource": "COLLECTION_BOOKMARK",
-                        "resourceId": "__default__-bookmark-42",
                         "timestamp": 2000,
                         "data": {
                           "collectionId": "__default__",
-                          "bookmarkId": "bookmark-42",
-                          "type": "page",
-                          "key": 42
+                          "bookmarkId": "bookmark-42"
                         }
                       },
                       {

--- a/sync-pipelines/src/jvmTest/kotlin/com/quran/shared/pipeline/SyncEnginePipelineCompletionTest.kt
+++ b/sync-pipelines/src/jvmTest/kotlin/com/quran/shared/pipeline/SyncEnginePipelineCompletionTest.kt
@@ -5,10 +5,13 @@ import com.quran.shared.mutations.Mutation
 import com.quran.shared.mutations.RemoteModelMutation
 import com.quran.shared.persistence.input.RemoteBookmark
 import com.quran.shared.persistence.input.RemoteCollection
+import com.quran.shared.persistence.input.RemoteCollectionBookmark
 import com.quran.shared.persistence.model.Bookmark
 import com.quran.shared.persistence.model.Collection
+import com.quran.shared.persistence.model.CollectionBookmark
 import com.quran.shared.persistence.repository.bookmark.repository.BookmarksSynchronizationRepository
 import com.quran.shared.persistence.repository.collection.repository.CollectionsSynchronizationRepository
+import com.quran.shared.persistence.repository.collectionbookmark.repository.CollectionBookmarksSynchronizationRepository
 import com.quran.shared.syncengine.AuthenticationDataFetcher
 import com.quran.shared.syncengine.LocalModificationDateFetcher
 import com.quran.shared.syncengine.SynchronizationEnvironment
@@ -115,6 +118,46 @@ class SyncEnginePipelineCompletionTest {
             assertTrue(completionTokens.isEmpty())
         }
     }
+
+    @Test
+    fun `remote default collection is applied before its membership`() = runBlocking {
+        DefaultCollectionSyncServer().use { server ->
+            val state = DefaultCollectionPersistenceState()
+            val completion = CompletableDeferred<Unit>()
+            val pipeline = SyncEnginePipeline(
+                bookmarksRepository = OrderingBookmarksRepository(state),
+                collectionsRepository = OrderingCollectionsRepository(state),
+                collectionBookmarksRepository = OrderingCollectionBookmarksRepository(state)
+            )
+            val client = pipeline.setup(
+                environment = SynchronizationEnvironment(server.baseUrl),
+                localModificationDateFetcher = object : LocalModificationDateFetcher {
+                    override suspend fun localLastModificationDate(): Long = 0
+                },
+                authenticationDataFetcher = LoggedInAuthenticationDataFetcher,
+                callback = object : SyncEngineCallback {
+                    override fun synchronizationDone(newLastModificationDate: Long) {
+                        completion.complete(Unit)
+                    }
+
+                    override fun encounteredError(errorMsg: String) = Unit
+                }
+            )
+
+            try {
+                client.triggerSyncImmediately()
+                withTimeout(5_000) {
+                    completion.await()
+                }
+            } finally {
+                client.cancelSyncing()
+            }
+
+            assertEquals(listOf("BOOKMARK", "COLLECTION", "COLLECTION_BOOKMARK"), state.applicationOrder)
+            assertEquals("__default__", state.collectionRemoteId)
+            assertTrue(state.collectionExistedWhenMembershipWasApplied)
+        }
+    }
 }
 
 private object LoggedInAuthenticationDataFetcher : AuthenticationDataFetcher {
@@ -204,6 +247,66 @@ private class FailingCollectionsRepository(
         emptyMap()
 }
 
+private class DefaultCollectionPersistenceState {
+    val applicationOrder = mutableListOf<String>()
+    var collectionRemoteId: String? = null
+    var collectionExistedWhenMembershipWasApplied = false
+}
+
+private class OrderingBookmarksRepository(
+    private val state: DefaultCollectionPersistenceState
+) : BookmarksSynchronizationRepository {
+    override suspend fun fetchMutatedBookmarks(): List<LocalModelMutation<Bookmark>> = emptyList()
+
+    override suspend fun applyRemoteChanges(
+        updatesToPersist: List<RemoteModelMutation<RemoteBookmark>>,
+        localMutationsToClear: List<LocalModelMutation<Bookmark>>
+    ) {
+        state.applicationOrder += "BOOKMARK"
+    }
+
+    override suspend fun remoteResourcesExist(remoteIDs: List<String>): Map<String, Boolean> =
+        remoteIDs.associateWith { false }
+
+    override suspend fun fetchBookmarkByRemoteId(remoteId: String): Bookmark? = null
+}
+
+private class OrderingCollectionsRepository(
+    private val state: DefaultCollectionPersistenceState
+) : CollectionsSynchronizationRepository {
+    override suspend fun fetchMutatedCollections(): List<LocalModelMutation<Collection>> = emptyList()
+
+    override suspend fun applyRemoteChanges(
+        updatesToPersist: List<RemoteModelMutation<RemoteCollection>>,
+        localMutationsToClear: List<LocalModelMutation<Collection>>
+    ) {
+        state.applicationOrder += "COLLECTION"
+        state.collectionRemoteId = updatesToPersist.single().remoteID
+    }
+
+    override suspend fun remoteResourcesExist(remoteIDs: List<String>): Map<String, Boolean> =
+        remoteIDs.associateWith { false }
+}
+
+private class OrderingCollectionBookmarksRepository(
+    private val state: DefaultCollectionPersistenceState
+) : CollectionBookmarksSynchronizationRepository {
+    override suspend fun fetchMutatedCollectionBookmarks():
+        List<LocalModelMutation<CollectionBookmark>> = emptyList()
+
+    override suspend fun applyRemoteChanges(
+        updatesToPersist: List<RemoteModelMutation<RemoteCollectionBookmark>>,
+        localMutationsToClear: List<LocalModelMutation<CollectionBookmark>>
+    ) {
+        state.applicationOrder += "COLLECTION_BOOKMARK"
+        state.collectionExistedWhenMembershipWasApplied =
+            state.collectionRemoteId == updatesToPersist.single().model.collectionId
+    }
+
+    override suspend fun remoteResourcesExist(remoteIDs: List<String>): Map<String, Boolean> =
+        remoteIDs.associateWith { false }
+}
+
 private class EmptySyncServer : AutoCloseable {
     private val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
     val baseUrl: String
@@ -275,6 +378,58 @@ private class ReplaySyncServer : AutoCloseable {
             exchange.responseHeaders.add("Content-Type", "application/json")
             exchange.sendResponseHeaders(200, response.size.toLong())
             exchange.responseBody.use { it.write(response) }
+        }
+        server.start()
+        baseUrl = "http://127.0.0.1:${server.address.port}"
+    }
+
+    override fun close() {
+        server.stop(0)
+    }
+}
+
+private class DefaultCollectionSyncServer : AutoCloseable {
+    private val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    val baseUrl: String
+
+    init {
+        server.createContext("/v1/sync") { exchange ->
+            val body = """
+                {
+                  "success": true,
+                  "data": {
+                    "lastMutationAt": 2000,
+                    "mutations": [
+                      {
+                        "type": "CREATE",
+                        "resource": "COLLECTION_BOOKMARK",
+                        "resourceId": "__default__-bookmark-42",
+                        "timestamp": 2000,
+                        "data": {
+                          "collectionId": "__default__",
+                          "bookmarkId": "bookmark-42",
+                          "type": "page",
+                          "key": 42
+                        }
+                      },
+                      {
+                        "type": "CREATE",
+                        "resource": "COLLECTION",
+                        "resourceId": "__default__",
+                        "timestamp": 1000,
+                        "data": {
+                          "name": "Favorites"
+                        }
+                      }
+                    ],
+                    "page": 1,
+                    "hasMore": false
+                  }
+                }
+            """.trimIndent().toByteArray(StandardCharsets.UTF_8)
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
         }
         server.start()
         baseUrl = "http://127.0.0.1:${server.address.port}"

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapter.kt
@@ -81,13 +81,16 @@ internal class CollectionBookmarksSyncAdapter(
             if (!mutation.resource.equals(resourceName, ignoreCase = true)) {
                 return@mapNotNull null
             }
-            val bookmarkId = mutation.data?.stringOrNull("bookmarkId")
-            val resourceId = mutation.resourceId ?: bookmarkId
+            val collectionBookmark =
+                mutation.toSyncCollectionBookmark(
+                    logger,
+                    configurations.localDataFetcher
+                ) ?: return@mapNotNull null
+            val resourceId = mutation.resourceId ?: collectionBookmark.fallbackResourceId()
             if (resourceId == null) {
                 logger.w { "Skipping collection bookmark mutation without resourceId" }
                 return@mapNotNull null
             }
-            val collectionBookmark = mutation.toSyncCollectionBookmark(logger, configurations.localDataFetcher) ?: return@mapNotNull null
             RemoteModelMutation(
                 model = collectionBookmark,
                 remoteID = resourceId,
@@ -298,6 +301,14 @@ private fun parseBookmarkId(resourceId: String?, collectionId: String): String? 
     } else {
         null
     }
+}
+
+private fun SyncCollectionBookmark.fallbackResourceId(): String? {
+    val bookmarkId = when (this) {
+        is SyncCollectionBookmark.PageBookmark -> bookmarkId
+        is SyncCollectionBookmark.AyahBookmark -> bookmarkId
+    }
+    return bookmarkId?.let { "$collectionId-$it" }
 }
 
 private fun JsonObject.stringOrNull(key: String): String? =

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClient.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClient.kt
@@ -97,7 +97,8 @@ object SynchronizationClientBuilder {
         collectionsConfigurations: CollectionsSynchronizationConfigurations? = null,
         collectionBookmarksConfigurations: CollectionBookmarksSynchronizationConfigurations? = null,
         notesConfigurations: NotesSynchronizationConfigurations? = null,
-        httpClient: HttpClient? = null
+        httpClient: HttpClient? = null,
+        synchronizationCompleted: (Long) -> Unit = {}
     ): SynchronizationClient {
         val adapters = buildList {
             add(BookmarksSyncAdapter(bookmarksConfigurations))
@@ -109,7 +110,8 @@ object SynchronizationClientBuilder {
             environment,
             httpClient ?: HttpClientFactory.createHttpClient(),
             adapters,
-            authFetcher
+            authFetcher,
+            synchronizationCompleted
         )
     }
 }

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClientImpl.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/SynchronizationClientImpl.kt
@@ -13,7 +13,9 @@ internal class SynchronizationClientImpl(
     private val environment: SynchronizationEnvironment,
     private val httpClient: HttpClient,
     private val resourceAdapters: List<SyncResourceAdapter>,
-    private val authenticationDataFetcher: AuthenticationDataFetcher): SynchronizationClient {
+    private val authenticationDataFetcher: AuthenticationDataFetcher,
+    private val synchronizationCompleted: (Long) -> Unit
+) : SynchronizationClient {
 
     private val logger = Logger.withTag("SynchronizationClient")
     
@@ -90,6 +92,7 @@ internal class SynchronizationClientImpl(
             val pushedForResource = pushedMutationsByResource[plan.resourceName.uppercase()].orEmpty()
             plan.complete(pushResponse.lastModificationDate, pushedForResource)
         }
+        synchronizationCompleted(pushResponse.lastModificationDate)
     }
 
     private suspend fun pushMutations(

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/GetMutationsRequest.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/GetMutationsRequest.kt
@@ -34,7 +34,9 @@ class GetMutationsRequest(
         val page: Int? = null,
         val limit: Int? = null,
         val total: Int? = null,
-        val hasMore: Boolean? = null
+        val hasMore: Boolean? = null,
+        val nextCursor: String? = null,
+        val syncUntil: Long? = null
     )
 
     @Serializable
@@ -53,9 +55,54 @@ class GetMutationsRequest(
         authHeaders: Map<String, String>,
         resources: List<String> = emptyList()
     ): MutationsResponse {
+        var response = getMutationsPage(
+            lastModificationDate = lastModificationDate,
+            authHeaders = authHeaders,
+            resources = resources
+        )
+        val mutations = response.mutations.toMutableList()
+        val fixedSyncUntil = response.syncUntil
+        var pagesFetched = 1
+
+        while (response.hasMore == true) {
+            val nextCursor = response.nextCursor
+            val useCursor = fixedSyncUntil != null && nextCursor != null
+            response = getMutationsPage(
+                lastModificationDate = lastModificationDate,
+                authHeaders = authHeaders,
+                resources = resources,
+                page = if (useCursor) null else pagesFetched + 1,
+                syncUntil = if (useCursor) fixedSyncUntil else null,
+                cursor = if (useCursor) nextCursor else null
+            )
+            mutations += response.mutations
+            pagesFetched += 1
+        }
+
+        return response.copy(
+            lastModificationDate = fixedSyncUntil ?: response.lastModificationDate,
+            mutations = mutations,
+            page = null,
+            hasMore = false,
+            nextCursor = null,
+            syncUntil = fixedSyncUntil
+        )
+    }
+
+    private suspend fun getMutationsPage(
+        lastModificationDate: Long,
+        authHeaders: Map<String, String>,
+        resources: List<String>,
+        page: Int? = null,
+        syncUntil: Long? = null,
+        cursor: String? = null
+    ): MutationsResponse {
         val fullUrl = "$url/v1/sync"
         logger.i { "Starting GET mutations request to $fullUrl" }
-        logger.d { "Request params: mutationsSince=$lastModificationDate, resources=$resources" }
+        logger.d {
+            "Request params: mutationsSince=$lastModificationDate, resources=$resources, " +
+                "page=$page, syncUntil=$syncUntil, cursor=${cursor != null}"
+        }
 
         val httpResponse = httpClient.get(fullUrl) {
             headers {
@@ -68,6 +115,9 @@ class GetMutationsRequest(
             if (resources.isNotEmpty()) {
                 parameter("resources", resources.joinToString(","))
             }
+            page?.let { parameter("page", it) }
+            syncUntil?.let { parameter("syncUntil", it) }
+            cursor?.let { parameter("cursor", it) }
         }
         
         logger.d { "HTTP response status: ${httpResponse.status}" }
@@ -104,7 +154,13 @@ class GetMutationsRequest(
 
         val result = MutationsResponse(
             lastModificationDate = lastMutationAt,
-            mutations = mutations
+            mutations = mutations,
+            page = page,
+            limit = limit,
+            total = total,
+            hasMore = hasMore,
+            nextCursor = nextCursor,
+            syncUntil = syncUntil
         )
         
         return result

--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/MutationsResponse.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/network/MutationsResponse.kt
@@ -4,5 +4,11 @@ import com.quran.shared.syncengine.SyncMutation
 
 data class MutationsResponse(
     val lastModificationDate: Long,
-    val mutations: List<SyncMutation>
+    val mutations: List<SyncMutation>,
+    val page: Int? = null,
+    val limit: Int? = null,
+    val total: Int? = null,
+    val hasMore: Boolean? = null,
+    val nextCursor: String? = null,
+    val syncUntil: Long? = null
 )

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapterTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapterTest.kt
@@ -1,0 +1,70 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.quran.shared.syncengine
+
+import com.quran.shared.mutations.LocalModelMutation
+import com.quran.shared.mutations.Mutation
+import com.quran.shared.mutations.RemoteModelMutation
+import com.quran.shared.syncengine.model.SyncCollectionBookmark
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+import kotlin.time.Instant
+
+class CollectionBookmarksSyncAdapterTest {
+
+    @Test
+    fun `default membership serializes with collection bookmark resource and default collection id`() = runTest {
+        val localMutation: LocalModelMutation<SyncCollectionBookmark> = LocalModelMutation(
+            model = SyncCollectionBookmark.PageBookmark(
+                collectionId = "__default__",
+                page = 42,
+                lastModified = Instant.fromEpochMilliseconds(1_000),
+                bookmarkId = "bookmark-42"
+            ),
+            remoteID = null,
+            localID = "membership-1",
+            mutation = Mutation.CREATED
+        )
+        val adapter = CollectionBookmarksSyncAdapter(
+            CollectionBookmarksSynchronizationConfigurations(
+                localDataFetcher = object : LocalDataFetcher<SyncCollectionBookmark> {
+                    override suspend fun fetchLocalMutations(
+                        lastModified: Long
+                    ): List<LocalModelMutation<SyncCollectionBookmark>> = listOf(localMutation)
+
+                    override suspend fun checkLocalExistence(
+                        remoteIDs: List<String>
+                    ): Map<String, Boolean> = remoteIDs.associateWith { false }
+
+                    override suspend fun fetchLocalModel(remoteId: String): SyncCollectionBookmark? = null
+                },
+                resultNotifier = object : ResultNotifier<SyncCollectionBookmark> {
+                    override suspend fun didSucceed(
+                        newToken: Long,
+                        newRemoteMutations: List<RemoteModelMutation<SyncCollectionBookmark>>,
+                        processedLocalMutations: List<LocalModelMutation<SyncCollectionBookmark>>
+                    ) = Unit
+
+                    override suspend fun didFail(message: String) {
+                        fail("didFail called: $message")
+                    }
+                },
+                localModificationDateFetcher = object : LocalModificationDateFetcher {
+                    override suspend fun localLastModificationDate(): Long = 0
+                }
+            )
+        )
+
+        val mutation = adapter
+            .buildPlan(lastModificationDate = 0, remoteMutations = emptyList())
+            .mutationsToPush()
+            .single()
+
+        assertEquals("COLLECTION_BOOKMARK", mutation.resource)
+        assertEquals("__default__", mutation.data?.get("collectionId")?.jsonPrimitive?.content)
+        assertEquals("bookmark-42", mutation.data?.get("bookmarkId")?.jsonPrimitive?.content)
+    }
+}

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapterTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapterTest.kt
@@ -7,9 +7,12 @@ import com.quran.shared.mutations.Mutation
 import com.quran.shared.mutations.RemoteModelMutation
 import com.quran.shared.syncengine.model.SyncCollectionBookmark
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlin.time.Instant
 
@@ -67,4 +70,105 @@ class CollectionBookmarksSyncAdapterTest {
         assertEquals("__default__", mutation.data?.get("collectionId")?.jsonPrimitive?.content)
         assertEquals("bookmark-42", mutation.data?.get("bookmarkId")?.jsonPrimitive?.content)
     }
+
+    @Test
+    fun `membership fallback identity includes collection while explicit identity is preserved`() = runTest {
+        val localMutation: LocalModelMutation<SyncCollectionBookmark> = LocalModelMutation(
+            model = SyncCollectionBookmark.PageBookmark(
+                collectionId = "__default__",
+                page = 42,
+                lastModified = Instant.fromEpochMilliseconds(500),
+                bookmarkId = "bookmark-42"
+            ),
+            remoteID = null,
+            localID = "pending-default-membership",
+            mutation = Mutation.CREATED
+        )
+        var persistedMutations = emptyList<RemoteModelMutation<SyncCollectionBookmark>>()
+        var clearedMutations = emptyList<LocalModelMutation<SyncCollectionBookmark>>()
+        val adapter = CollectionBookmarksSyncAdapter(
+            CollectionBookmarksSynchronizationConfigurations(
+                localDataFetcher = object : LocalDataFetcher<SyncCollectionBookmark> {
+                    override suspend fun fetchLocalMutations(
+                        lastModified: Long
+                    ): List<LocalModelMutation<SyncCollectionBookmark>> = listOf(localMutation)
+
+                    override suspend fun checkLocalExistence(
+                        remoteIDs: List<String>
+                    ): Map<String, Boolean> = remoteIDs.associateWith { false }
+
+                    override suspend fun fetchLocalModel(
+                        remoteId: String
+                    ): SyncCollectionBookmark = SyncCollectionBookmark.PageBookmark(
+                        collectionId = "",
+                        page = 42,
+                        lastModified = Instant.fromEpochMilliseconds(500),
+                        bookmarkId = remoteId
+                    )
+                },
+                resultNotifier = object : ResultNotifier<SyncCollectionBookmark> {
+                    override suspend fun didSucceed(
+                        newToken: Long,
+                        newRemoteMutations: List<RemoteModelMutation<SyncCollectionBookmark>>,
+                        processedLocalMutations: List<LocalModelMutation<SyncCollectionBookmark>>
+                    ) {
+                        persistedMutations = newRemoteMutations
+                        clearedMutations = processedLocalMutations
+                    }
+
+                    override suspend fun didFail(message: String) {
+                        fail("didFail called: $message")
+                    }
+                },
+                localModificationDateFetcher = object : LocalModificationDateFetcher {
+                    override suspend fun localLastModificationDate(): Long = 0
+                }
+            )
+        )
+        val remoteMutations = listOf(
+            collectionMembershipMutation("__default__", "bookmark-42"),
+            collectionMembershipMutation("custom-collection", "bookmark-42"),
+            collectionMembershipMutation(
+                collectionId = "legacy-collection",
+                bookmarkId = "bookmark-42",
+                resourceId = "server-membership-id"
+            )
+        )
+
+        val plan = adapter.buildPlan(lastModificationDate = 0, remoteMutations = remoteMutations)
+
+        assertTrue(plan.mutationsToPush().isEmpty())
+        plan.complete(newToken = 2_000, pushedMutations = emptyList())
+        assertEquals(
+            setOf(
+                "__default__-bookmark-42",
+                "custom-collection-bookmark-42",
+                "server-membership-id"
+            ),
+            persistedMutations.map { it.remoteID }.toSet()
+        )
+        assertEquals(
+            setOf("__default__", "custom-collection", "legacy-collection"),
+            persistedMutations.map { it.model.collectionId }.toSet()
+        )
+        assertEquals(
+            listOf("pending-default-membership"),
+            clearedMutations.map { it.localID }
+        )
+    }
+
+    private fun collectionMembershipMutation(
+        collectionId: String,
+        bookmarkId: String,
+        resourceId: String? = null
+    ): SyncMutation = SyncMutation(
+        resource = "COLLECTION_BOOKMARK",
+        resourceId = resourceId,
+        mutation = Mutation.CREATED,
+        data = buildJsonObject {
+            put("collectionId", collectionId)
+            put("bookmarkId", bookmarkId)
+        },
+        timestamp = 1_000
+    )
 }

--- a/syncengine/src/jvmTest/kotlin/com/quran/shared/syncengine/network/GetMutationsRequestPaginationTest.kt
+++ b/syncengine/src/jvmTest/kotlin/com/quran/shared/syncengine/network/GetMutationsRequestPaginationTest.kt
@@ -1,0 +1,218 @@
+package com.quran.shared.syncengine.network
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+
+class GetMutationsRequestPaginationTest {
+
+    @Test
+    fun `cursor pagination aggregates every page with a stable snapshot`() = runTest {
+        TestServer(
+            listOf(
+                Response(
+                    body = syncResponse(
+                        mutationId = "remote-1",
+                        hasMore = true,
+                        page = 1,
+                        syncUntil = 2_000,
+                        nextCursor = "cursor-1"
+                    )
+                ),
+                Response(
+                    body = syncResponse(
+                        mutationId = "remote-2",
+                        hasMore = false,
+                        syncUntil = 2_000
+                    )
+                )
+            )
+        ).use { server ->
+            val client = HttpClientFactory.createHttpClient()
+            try {
+                val response = GetMutationsRequest(client, server.baseUrl).getMutations(
+                    lastModificationDate = 100,
+                    authHeaders = mapOf("x-auth-token" to "token"),
+                    resources = listOf("BOOKMARK", "COLLECTION")
+                )
+
+                assertEquals(listOf("remote-1", "remote-2"), response.mutations.map { it.resourceId })
+                assertEquals(2_000, response.lastModificationDate)
+                assertEquals(
+                    mapOf(
+                        "mutationsSince" to "100",
+                        "resources" to "BOOKMARK,COLLECTION"
+                    ),
+                    server.queries[0]
+                )
+                assertEquals(
+                    mapOf(
+                        "mutationsSince" to "100",
+                        "resources" to "BOOKMARK,COLLECTION",
+                        "syncUntil" to "2000",
+                        "cursor" to "cursor-1"
+                    ),
+                    server.queries[1]
+                )
+            } finally {
+                client.close()
+            }
+        }
+    }
+
+    @Test
+    fun `legacy pagination keeps the original timestamp and increments page`() = runTest {
+        TestServer(
+            listOf(
+                Response(
+                    body = syncResponse(
+                        mutationId = "remote-1",
+                        hasMore = true,
+                        page = 1
+                    )
+                ),
+                Response(
+                    body = syncResponse(
+                        mutationId = "remote-2",
+                        hasMore = false,
+                        page = 2
+                    )
+                )
+            )
+        ).use { server ->
+            val client = HttpClientFactory.createHttpClient()
+            try {
+                val response = GetMutationsRequest(client, server.baseUrl).getMutations(
+                    lastModificationDate = 321,
+                    authHeaders = emptyMap(),
+                    resources = listOf("BOOKMARK")
+                )
+
+                assertEquals(listOf("remote-1", "remote-2"), response.mutations.map { it.resourceId })
+                assertEquals("321", server.queries[1]["mutationsSince"])
+                assertEquals("2", server.queries[1]["page"])
+                assertFalse(server.queries[1].containsKey("syncUntil"))
+                assertFalse(server.queries[1].containsKey("cursor"))
+            } finally {
+                client.close()
+            }
+        }
+    }
+
+    @Test
+    fun `failure on a later page fails the whole fetch`() = runTest {
+        TestServer(
+            listOf(
+                Response(
+                    body = syncResponse(
+                        mutationId = "remote-1",
+                        hasMore = true,
+                        page = 1,
+                        syncUntil = 2_000,
+                        nextCursor = "cursor-1"
+                    )
+                ),
+                Response(
+                    status = 500,
+                    body = """{"success":false,"type":"server_error","message":"page failed"}"""
+                )
+            )
+        ).use { server ->
+            val client = HttpClientFactory.createHttpClient()
+            try {
+                assertFailsWith<Exception> {
+                    GetMutationsRequest(client, server.baseUrl).getMutations(
+                        lastModificationDate = 100,
+                        authHeaders = emptyMap()
+                    )
+                }
+                assertEquals(2, server.queries.size)
+            } finally {
+                client.close()
+            }
+        }
+    }
+
+    private fun syncResponse(
+        mutationId: String,
+        hasMore: Boolean,
+        page: Int? = null,
+        syncUntil: Long? = null,
+        nextCursor: String? = null
+    ): String {
+        val paginationFields = buildList {
+            page?.let { add(""""page":$it""") }
+            add(""""hasMore":$hasMore""")
+            syncUntil?.let { add(""""syncUntil":$it""") }
+            nextCursor?.let { add(""""nextCursor":"$it"""") }
+        }.joinToString(",")
+        return """
+            {
+              "success": true,
+              "data": {
+                "lastMutationAt": ${syncUntil ?: 2_000},
+                "mutations": [{
+                  "resource": "BOOKMARK",
+                  "resourceId": "$mutationId",
+                  "type": "CREATE",
+                  "data": {"type": "PAGE", "page": 1},
+                  "timestamp": 1000
+                }],
+                $paginationFields
+              }
+            }
+        """.trimIndent()
+    }
+}
+
+private data class Response(
+    val status: Int = 200,
+    val body: String
+)
+
+private class TestServer(
+    private val responses: List<Response>
+) : AutoCloseable {
+    private val requestIndex = AtomicInteger(0)
+    private val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+    val queries = mutableListOf<Map<String, String>>()
+    val baseUrl: String
+
+    init {
+        server.createContext("/v1/sync") { exchange ->
+            handle(exchange)
+        }
+        server.start()
+        baseUrl = "http://127.0.0.1:${server.address.port}"
+    }
+
+    private fun handle(exchange: HttpExchange) {
+        queries += parseQuery(exchange.requestURI.rawQuery)
+        val response = responses[requestIndex.getAndIncrement()]
+        val body = response.body.toByteArray(StandardCharsets.UTF_8)
+        exchange.responseHeaders.add("Content-Type", "application/json")
+        exchange.sendResponseHeaders(response.status, body.size.toLong())
+        exchange.responseBody.use { it.write(body) }
+    }
+
+    private fun parseQuery(rawQuery: String?): Map<String, String> {
+        if (rawQuery.isNullOrEmpty()) return emptyMap()
+        return rawQuery.split("&").associate { entry ->
+            val parts = entry.split("=", limit = 2)
+            URLDecoder.decode(parts[0], StandardCharsets.UTF_8.name()) to
+                URLDecoder.decode(parts.getOrElse(1) { "" }, StandardCharsets.UTF_8.name())
+        }
+    }
+
+    override fun close() {
+        server.stop(0)
+    }
+}


### PR DESCRIPTION
## Summary

- consume every page from the backend's fixed sync snapshot and advance the local checkpoint only after the full operation succeeds
- replay server mutations once for existing installations while preserving local entities and pending mutations
- bind and protect the virtual Favorites collection at remote ID `__default__`
- derive collection-membership fallback identity as `${collectionId}-${bookmarkId}` when the wire mutation omits `resourceId`

## Why

KMP models Favorites as a normal `COLLECTION` plus `COLLECTION_BOOKMARK` relationships. It must therefore receive and persist the virtual collection before memberships, avoid outbound rename/delete mutations for it, and consume all paginated mutations without advancing its checkpoint early.

## Impact

Favorites memberships now round-trip through the same resource model as other collections. Existing local Favorites data is retained and rebound to `__default__`, and no KMP code depends on `isInDefaultCollection`.

## Validation

- `./gradlew :persistence:jvmTest :syncengine:jvmTest :sync-pipelines:jvmTest --rerun-tasks`
  - succeeded with 23/23 tasks executed
- `git diff --check origin/main...HEAD`
- focused coverage includes pagination, replay/checkpoint behavior, immutable Favorites, membership add/remove/re-add, and the real backend wire shape

## Related PR

- Backend contract and backfill: https://github.com/quran/quran.com-users-backend/pull/1491
