### PR TITLE
fix(sync): omit bookmark ID from collection bookmark creates

### DIFF
--- a/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapter.kt
+++ b/syncengine/src/commonMain/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapter.kt
@@ -186,12 +186,14 @@ internal class CollectionBookmarksSyncAdapter(
             acknowledgedRemoteId = { localMutation, pushedMutation ->
                 val requestMutation = localMutation.toSyncMutation(
                     resourceName = resourceName,
-                    resourceData = SyncCollectionBookmark::toResourceData,
+                    resourceData = { model -> model.toResourceData(localMutation.mutation) },
                     timestamp = { model -> model.lastModified.toEpochMilliseconds() },
                     createdTimestamp = { model -> model.createdAt?.toEpochMilliseconds() },
                     includeDataForDeletes = true
                 )
-                pushedMutation.acknowledgedRemoteIdFor(requestMutation)
+                pushedMutation.acknowledgedRemoteIdFor(
+                    requestMutation.withExpectedBookmarkId(localMutation.model)
+                )
                     ?: localMutation.model.remoteIdOrNull()
             },
             model = { localMutation, pushedMutation ->
@@ -213,10 +215,10 @@ internal class CollectionBookmarksSyncAdapter(
         private var markedInFlightAcks: List<LocalMutationAck> = emptyList()
 
         override suspend fun mutationsToPush(): List<SyncMutation> =
-            localMutationsToPushForCompletion.map {
-                it.toSyncMutation(
+            localMutationsToPushForCompletion.map { localMutation ->
+                localMutation.toSyncMutation(
                     resourceName = resourceName,
-                    resourceData = SyncCollectionBookmark::toResourceData,
+                    resourceData = { model -> model.toResourceData(localMutation.mutation) },
                     timestamp = { model -> model.lastModified.toEpochMilliseconds() },
                     createdTimestamp = { model -> model.createdAt?.toEpochMilliseconds() },
                     includeDataForDeletes = true
@@ -393,17 +395,32 @@ private suspend fun SyncMutation.toSyncCollectionBookmark(
     }
 }
 
-private fun SyncCollectionBookmark.toResourceData(): JsonObject {
+private fun SyncCollectionBookmark.toResourceData(mutation: Mutation): JsonObject {
     return when (this) {
         is SyncCollectionBookmark.AyahBookmark -> buildJsonObject {
             put("collectionId", collectionId)
-            bookmarkId?.let { put("bookmarkId", it) }
-            put("type", "ayah")
-            put("key", sura)
-            put("verseNumber", ayah)
-            put("mushaf", 1)
+            if (mutation == Mutation.DELETED && bookmarkId != null) {
+                put("bookmarkId", bookmarkId)
+            } else {
+                put("type", "ayah")
+                put("key", sura)
+                put("verseNumber", ayah)
+                put("mushaf", 1)
+            }
         }
     }
+}
+
+private fun SyncMutation.withExpectedBookmarkId(model: SyncCollectionBookmark): SyncMutation {
+    val bookmarkId = when (model) {
+        is SyncCollectionBookmark.AyahBookmark -> model.bookmarkId
+    } ?: return this
+    return copy(
+        data = buildJsonObject {
+            data?.forEach { (key, value) -> put(key, value) }
+            put("bookmarkId", bookmarkId)
+        }
+    )
 }
 
 private fun SyncCollectionBookmark.withPushedBookmarkId(

--- a/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapterTest.kt
+++ b/syncengine/src/commonTest/kotlin/com/quran/shared/syncengine/CollectionBookmarksSyncAdapterTest.kt
@@ -112,6 +112,18 @@ class CollectionBookmarksSyncAdapterTest {
         val earlyPushedDelete = preDependencyPlan.mutationsToPush().single()
         assertEquals(remoteId, earlyPushedDelete.resourceId)
         assertEquals(Mutation.DELETED, earlyPushedDelete.mutation)
+        assertEquals(
+            "remote-collection-1",
+            earlyPushedDelete.data?.get("collectionId")?.jsonPrimitive?.content
+        )
+        assertEquals(
+            "remote-bookmark-1",
+            earlyPushedDelete.data?.get("bookmarkId")?.jsonPrimitive?.content
+        )
+        assertNull(earlyPushedDelete.data?.get("type"))
+        assertNull(earlyPushedDelete.data?.get("key"))
+        assertNull(earlyPushedDelete.data?.get("verseNumber"))
+        assertNull(earlyPushedDelete.data?.get("mushaf"))
 
         preDependencyPlan.complete(newToken = 5L, pushedMutations = listOf(earlyPushedDelete))
 
@@ -444,7 +456,7 @@ class CollectionBookmarksSyncAdapterTest {
     }
 
     @Test
-    fun `mutations to push include bookmarkId payload field`() = runTest {
+    fun `create mutations omit bookmarkId and identify the ayah`() = runTest {
         val localMutation = LocalModelMutation<SyncCollectionBookmark>(
             model = SyncCollectionBookmark.AyahBookmark(
                 collectionId = "remote-collection-1",
@@ -509,7 +521,11 @@ class CollectionBookmarksSyncAdapterTest {
         assertNull(pushedMutations.single().resourceId)
         assertEquals(1000L, pushedMutations.single().timestamp)
         assertEquals("remote-collection-1", pushedMutations.single().data?.get("collectionId")?.jsonPrimitive?.content)
-        assertEquals("remote-bookmark-1", pushedMutations.single().data?.get("bookmarkId")?.jsonPrimitive?.content)
+        assertNull(pushedMutations.single().data?.get("bookmarkId"))
+        assertEquals("ayah", pushedMutations.single().data?.get("type")?.jsonPrimitive?.content)
+        assertEquals(2, pushedMutations.single().data?.get("key")?.jsonPrimitive?.content?.toInt())
+        assertEquals(255, pushedMutations.single().data?.get("verseNumber")?.jsonPrimitive?.content?.toInt())
+        assertEquals(1, pushedMutations.single().data?.get("mushaf")?.jsonPrimitive?.content?.toInt())
 
         plan.complete(
             newToken = 5L,


### PR DESCRIPTION
## What changed

- serialize `CREATE COLLECTION_BOOKMARK` mutations with the ayah identity fields accepted by the backend
- omit `bookmarkId` from create payloads even when the shared local bookmark already has a remote ID
- retain `bookmarkId` for delete payloads and internal ACK correlation
- add regression coverage for both create and delete payload shapes

## Root cause

MobileSync uses one bookmark record per ayah across multiple collection memberships. When that shared bookmark already had a remote ID, the collection-membership serializer included `bookmarkId` in a CREATE payload alongside the ayah fields. The backend CREATE validator rejects `bookmarkId`, resulting in HTTP 422.

## Impact

Adding an existing ayah bookmark to another collection, including a system highlight collection, can sync successfully.

## Validation

- `./gradlew :syncengine:jvmTest --tests 'com.quran.shared.syncengine.CollectionBookmarksSyncAdapterTest'` — 31 tests passed
- `git diff --check`
- end-to-end simulator validation previously confirmed successful create and delete synchronization against prelive