### PR TITLE
feat(highlights): add dedicated ayah highlight APIs

### DIFF
--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/AyahHighlight.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/AyahHighlight.kt
@@ -1,0 +1,10 @@
+package com.quran.shared.persistence.model
+
+import com.quran.shared.persistence.util.PlatformDateTime
+
+data class AyahHighlight(
+    val sura: Int,
+    val ayah: Int,
+    val color: AyahHighlightColor,
+    val lastUpdated: PlatformDateTime
+)

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/AyahHighlightColor.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/AyahHighlightColor.kt
@@ -1,0 +1,15 @@
+package com.quran.shared.persistence.model
+
+enum class AyahHighlightColor(internal val collectionName: String) {
+    BLUE("system:highlights:blue"),
+    PINK("system:highlights:pink"),
+    RED("system:highlights:red"),
+    GREEN("system:highlights:green"),
+    YELLOW("system:highlights:yellow"),
+    PURPLE("system:highlights:purple")
+}
+
+internal fun highlightColorForCollectionName(name: String): AyahHighlightColor? {
+    val normalizedName = name.trim().lowercase()
+    return AyahHighlightColor.entries.firstOrNull { it.collectionName == normalizedName }
+}

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/Collection.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/Collection.kt
@@ -19,4 +19,10 @@ data class Collection(
      */
     val isDefault: Boolean
         get() = id == DEFAULT_COLLECTION_ID
+
+    /**
+     * True when this collection is reserved for ayah highlight persistence.
+     */
+    val isSystemHighlight: Boolean
+        get() = highlightColorForCollectionName(name) != null
 }

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collection/repository/CollectionsRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collection/repository/CollectionsRepositoryImpl.kt
@@ -14,6 +14,7 @@ import com.quran.shared.persistence.input.LocalSyncCollection
 import com.quran.shared.persistence.input.RemoteCollection
 import com.quran.shared.persistence.model.Collection
 import com.quran.shared.persistence.model.DatabaseCollection
+import com.quran.shared.persistence.model.highlightColorForCollectionName
 import com.quran.shared.persistence.repository.PersistenceWriteBoundaryGuard
 import com.quran.shared.persistence.repository.buildRemoteResourceExistenceMap
 import com.quran.shared.persistence.repository.bookmark.BookmarkDependencyReconciler
@@ -69,6 +70,9 @@ class CollectionsRepositoryImpl(
     }
 
     private suspend fun addCollectionWithTimestampMillis(name: String, timestampMillis: Long): Collection {
+        require(highlightColorForCollectionName(name) == null) {
+            "System highlight collection names are reserved."
+        }
         logger.i { "Adding collection with name=$name" }
         return withContext(Dispatchers.IO) {
             collectionQueries.value.addNewCollection(
@@ -106,6 +110,12 @@ class CollectionsRepositoryImpl(
                 require(existing?.deleted == 0L) {
                     "Expected active collection id=$id before update."
                 }
+                require(highlightColorForCollectionName(existing.name) == null) {
+                    "System highlight collections cannot be renamed."
+                }
+                require(highlightColorForCollectionName(name) == null) {
+                    "System highlight collection names are reserved."
+                }
 
                 collectionQueries.value.updateCollectionName(
                     name = name,
@@ -134,6 +144,9 @@ class CollectionsRepositoryImpl(
                 val collection = collectionQueries.value.getCollectionByLocalId(localId).executeAsOneOrNull()
                 if (collection?.deleted != 0L) {
                     return@transaction
+                }
+                require(highlightColorForCollectionName(collection.name) == null) {
+                    "System highlight collections cannot be deleted."
                 }
                 collectionQueries.value.deleteCollection(
                     id = localId,

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/AyahHighlightsRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/AyahHighlightsRepository.kt
@@ -1,0 +1,194 @@
+package com.quran.shared.persistence.repository.collectionbookmark.repository
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import com.quran.shared.persistence.QuranDatabase
+import com.quran.shared.persistence.model.AyahHighlight
+import com.quran.shared.persistence.model.AyahHighlightColor
+import com.quran.shared.persistence.model.DatabaseCollection
+import com.quran.shared.persistence.model.highlightColorForCollectionName
+import com.quran.shared.persistence.repository.bookmark.BookmarkDependencyReconciler
+import com.quran.shared.persistence.util.PlatformDateTime
+import com.quran.shared.persistence.util.QuranData
+import com.quran.shared.persistence.util.toEpochMillisecondsFromPlatform
+import com.quran.shared.persistence.util.toPlatform
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import kotlin.time.Instant
+
+internal class AyahHighlightsRepository(
+    private val database: QuranDatabase,
+    private val reconciler: BookmarkDependencyReconciler
+) {
+    private val bookmarkCollectionQueries = database.bookmark_collectionsQueries
+    private val bookmarkQueries = database.bookmarksQueries
+    private val collectionQueries = database.collectionsQueries
+
+    fun getHighlightsFlow(): Flow<List<AyahHighlight>> =
+        bookmarkCollectionQueries.getCollectionBookmarksWithDetails()
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { records ->
+                records.mapNotNull { record ->
+                    val color = highlightColorForCollectionName(record.collection_name)
+                        ?: return@mapNotNull null
+                    val sura = record.sura ?: return@mapNotNull null
+                    val ayah = record.ayah ?: return@mapNotNull null
+                    HighlightRecord(
+                        highlight = AyahHighlight(
+                            sura = sura.toInt(),
+                            ayah = ayah.toInt(),
+                            color = color,
+                            lastUpdated = Instant.fromEpochMilliseconds(record.modified_at).toPlatform()
+                        ),
+                        modifiedAt = record.modified_at
+                    )
+                }
+                    .groupBy { it.highlight.sura to it.highlight.ayah }
+                    .values
+                    .map { recordsForAyah -> recordsForAyah.maxBy { it.modifiedAt }.highlight }
+                    .sortedWith(compareBy(AyahHighlight::sura, AyahHighlight::ayah))
+            }
+
+    suspend fun setHighlight(
+        sura: Int,
+        ayah: Int,
+        color: AyahHighlightColor,
+        timestamp: PlatformDateTime
+    ): AyahHighlight {
+        val timestampMillis = timestamp.toEpochMillisecondsFromPlatform()
+        return withContext(Dispatchers.IO) {
+            var result: AyahHighlight? = null
+            database.transaction {
+                val existingHighlightCollections = activeHighlightCollections()
+                val targetCollection = existingHighlightCollections
+                    .firstOrNull { it.first == color }
+                    ?.second
+                    ?: createHighlightCollection(color, timestampMillis)
+
+                val bookmark = bookmarkQueries
+                    .getBookmarkForAyah(sura.toLong(), ayah.toLong())
+                    .executeAsOneOrNull()
+                    ?: run {
+                        bookmarkQueries.upsertAyahBookmark(
+                            remote_id = null,
+                            ayah_id = QuranData.getAyahId(sura, ayah).toLong(),
+                            sura = sura.toLong(),
+                            ayah = ayah.toLong(),
+                            created_at = timestampMillis,
+                            modified_at = timestampMillis
+                        )
+                        requireNotNull(
+                            bookmarkQueries.getBookmarkForAyah(sura.toLong(), ayah.toLong()).executeAsOneOrNull()
+                        ) { "Expected ayah bookmark for $sura:$ayah after insert." }
+                    }
+
+                if (!hasActiveMembership(bookmark.local_id, targetCollection.local_id)) {
+                    bookmarkCollectionQueries.addBookmarkToCollection(
+                        bookmark_local_id = bookmark.local_id,
+                        collection_local_id = targetCollection.local_id,
+                        timestamp = timestampMillis
+                    )
+                }
+                existingHighlightCollections
+                    .asSequence()
+                    .map { it.second }
+                    .filterNot { it.local_id == targetCollection.local_id }
+                    .forEach { collection ->
+                        bookmarkCollectionQueries.markBookmarkCollectionDeleted(
+                            bookmark_local_id = bookmark.local_id,
+                            collection_local_id = collection.local_id,
+                            timestamp = timestampMillis
+                        )
+                    }
+
+                reconciler.reconcile(timestampMillis)
+                val membership = requireNotNull(
+                    bookmarkCollectionQueries
+                        .getCollectionBookmarkFor(bookmark.local_id, targetCollection.local_id)
+                        .executeAsOneOrNull()
+                ) { "Expected highlight membership for $sura:$ayah after update." }
+                result = AyahHighlight(
+                    sura,
+                    ayah,
+                    color,
+                    Instant.fromEpochMilliseconds(membership.modified_at).toPlatform()
+                )
+            }
+            requireNotNull(result)
+        }
+    }
+
+    suspend fun removeHighlight(
+        sura: Int,
+        ayah: Int,
+        timestamp: PlatformDateTime
+    ): Boolean {
+        val timestampMillis = timestamp.toEpochMillisecondsFromPlatform()
+        return withContext(Dispatchers.IO) {
+            var removed = false
+            database.transaction {
+                val bookmark = bookmarkQueries
+                    .getBookmarkForAyah(sura.toLong(), ayah.toLong())
+                    .executeAsOneOrNull() ?: return@transaction
+
+                activeHighlightCollections()
+                    .asSequence()
+                    .map { it.second }
+                    .filter { collection ->
+                        bookmarkCollectionQueries
+                            .getCollectionBookmarksForCollection(collection.local_id)
+                            .executeAsList()
+                            .any { it.bookmark_local_id == bookmark.local_id }
+                    }
+                    .forEach { collection ->
+                        bookmarkCollectionQueries.markBookmarkCollectionDeleted(
+                            bookmark_local_id = bookmark.local_id,
+                            collection_local_id = collection.local_id,
+                            timestamp = timestampMillis
+                        )
+                        removed = true
+                    }
+
+                if (removed) {
+                    reconciler.reconcile(timestampMillis)
+                }
+            }
+            removed
+        }
+    }
+
+    private fun createHighlightCollection(
+        color: AyahHighlightColor,
+        timestampMillis: Long
+    ): DatabaseCollection {
+        collectionQueries.addNewCollection(
+            name = color.collectionName,
+            timestamp = timestampMillis
+        )
+        return requireNotNull(
+            collectionQueries.getCollectionByName(color.collectionName).executeAsOneOrNull()
+        ) { "Expected highlight collection ${color.collectionName} after insert." }
+    }
+
+    private fun hasActiveMembership(bookmarkLocalId: Long, collectionLocalId: Long): Boolean =
+        bookmarkCollectionQueries
+            .getCollectionBookmarksForCollection(collectionLocalId)
+            .executeAsList()
+            .any { it.bookmark_local_id == bookmarkLocalId }
+
+    private fun activeHighlightCollections(): List<Pair<AyahHighlightColor, DatabaseCollection>> =
+        collectionQueries.getCollections()
+            .executeAsList()
+            .mapNotNull { collection ->
+                highlightColorForCollectionName(collection.name)?.let { it to collection }
+            }
+
+    private data class HighlightRecord(
+        val highlight: AyahHighlight,
+        val modifiedAt: Long
+    )
+}

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepository.kt
@@ -1,11 +1,34 @@
 package com.quran.shared.persistence.repository.collectionbookmark.repository
 
 import com.quran.shared.persistence.model.AyahBookmark
+import com.quran.shared.persistence.model.AyahHighlight
+import com.quran.shared.persistence.model.AyahHighlightColor
 import com.quran.shared.persistence.model.CollectionAyahBookmark
 import com.quran.shared.persistence.util.PlatformDateTime
 import kotlinx.coroutines.flow.Flow
 
 interface CollectionBookmarksRepository {
+    /**
+     * Observe the current highlight for every highlighted ayah.
+     */
+    fun getHighlightsFlow(): Flow<List<AyahHighlight>>
+
+    /**
+     * Sets the highlight color for one ayah, replacing any existing highlight color.
+     * Default and user collection memberships are preserved.
+     */
+    suspend fun setHighlight(
+        sura: Int,
+        ayah: Int,
+        color: AyahHighlightColor,
+        timestamp: PlatformDateTime
+    ): AyahHighlight
+
+    /**
+     * Removes all highlight memberships from one ayah while preserving default and user collections.
+     */
+    suspend fun removeHighlight(sura: Int, ayah: Int, timestamp: PlatformDateTime): Boolean
+
     /**
      * Returns all bookmarks linked to a collection.
      */

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/collectionbookmark/repository/CollectionBookmarksRepositoryImpl.kt
@@ -15,6 +15,8 @@ import com.quran.shared.persistence.QuranDatabase
 import com.quran.shared.persistence.input.LocalSyncCollectionAyahBookmark
 import com.quran.shared.persistence.input.RemoteCollectionBookmark
 import com.quran.shared.persistence.model.AyahBookmark
+import com.quran.shared.persistence.model.AyahHighlight
+import com.quran.shared.persistence.model.AyahHighlightColor
 import com.quran.shared.persistence.model.CollectionAyahBookmark
 import com.quran.shared.persistence.model.DEFAULT_COLLECTION_ID
 import com.quran.shared.persistence.model.DatabaseBookmark
@@ -50,6 +52,22 @@ class CollectionBookmarksRepositoryImpl(
     private val bookmarkCollectionQueries = lazy { database.bookmark_collectionsQueries }
     private val bookmarkQueries = lazy { database.bookmarksQueries }
     private val collectionQueries = lazy { database.collectionsQueries }
+    private val highlightsRepository = AyahHighlightsRepository(database, reconciler)
+
+    override fun getHighlightsFlow(): Flow<List<AyahHighlight>> = highlightsRepository.getHighlightsFlow()
+
+    override suspend fun setHighlight(
+        sura: Int,
+        ayah: Int,
+        color: AyahHighlightColor,
+        timestamp: PlatformDateTime
+    ): AyahHighlight = highlightsRepository.setHighlight(sura, ayah, color, timestamp)
+
+    override suspend fun removeHighlight(
+        sura: Int,
+        ayah: Int,
+        timestamp: PlatformDateTime
+    ): Boolean = highlightsRepository.removeHighlight(sura, ayah, timestamp)
 
     override suspend fun getBookmarksForCollection(collectionId: String): List<CollectionAyahBookmark> {
         if (collectionId == DEFAULT_COLLECTION_ID) {

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/AyahHighlightsRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/AyahHighlightsRepositoryTest.kt
@@ -1,0 +1,140 @@
+@file:OptIn(kotlin.time.ExperimentalTime::class)
+
+package com.quran.shared.persistence.repository
+
+import com.quran.shared.persistence.QuranDatabase
+import com.quran.shared.persistence.TestDatabaseDriver
+import com.quran.shared.persistence.model.AyahHighlight
+import com.quran.shared.persistence.model.AyahHighlightColor
+import com.quran.shared.persistence.model.DEFAULT_COLLECTION_ID
+import com.quran.shared.persistence.repository.bookmark.repository.BookmarksRepositoryImpl
+import com.quran.shared.persistence.repository.collection.repository.CollectionsRepositoryImpl
+import com.quran.shared.persistence.repository.collectionbookmark.repository.CollectionBookmarksRepositoryImpl
+import com.quran.shared.persistence.util.toPlatform
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.flow.first
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+class AyahHighlightsRepositoryTest {
+    private lateinit var database: QuranDatabase
+    private lateinit var bookmarksRepository: BookmarksRepositoryImpl
+    private lateinit var collectionsRepository: CollectionsRepositoryImpl
+    private lateinit var collectionBookmarksRepository: CollectionBookmarksRepositoryImpl
+
+    @BeforeTest
+    fun setup() {
+        database = QuranDatabase(TestDatabaseDriver().createDriver())
+        bookmarksRepository = BookmarksRepositoryImpl(database)
+        collectionsRepository = CollectionsRepositoryImpl(database)
+        collectionBookmarksRepository = CollectionBookmarksRepositoryImpl(database)
+    }
+
+    @Test
+    fun `highlight colors use fixed system collection names`() {
+        assertEquals(
+            listOf(
+                "system:highlights:blue",
+                "system:highlights:pink",
+                "system:highlights:red",
+                "system:highlights:green",
+                "system:highlights:yellow",
+                "system:highlights:purple"
+            ),
+            AyahHighlightColor.entries.map { it.collectionName }
+        )
+    }
+
+    @Test
+    fun `setHighlight creates namespaced collection and highlight-only bookmark`() = runTest {
+        val timestamp = timestamp(1_234)
+
+        val highlight = collectionBookmarksRepository.setHighlight(
+            sura = 2,
+            ayah = 255,
+            color = AyahHighlightColor.BLUE,
+            timestamp = timestamp
+        )
+
+        assertEquals(AyahHighlight(2, 255, AyahHighlightColor.BLUE, timestamp), highlight)
+        val collection = collectionsRepository.getAllCollections().single()
+        assertEquals("system:highlights:blue", collection.name)
+        assertEquals(
+            listOf(2 to 255),
+            collectionBookmarksRepository.getBookmarksForCollection(collection.id).map { it.sura to it.ayah }
+        )
+        assertEquals(
+            0L,
+            database.bookmarksQueries.getBookmarkForAyah(2L, 255L).executeAsOne().is_in_default_collection
+        )
+        assertEquals(listOf(highlight), collectionBookmarksRepository.getHighlightsFlow().first())
+    }
+
+    @Test
+    fun `highlights flow reports one latest color per ayah`() = runTest {
+        collectionBookmarksRepository.setHighlight(1, 1, AyahHighlightColor.BLUE, timestamp(100))
+        collectionBookmarksRepository.setHighlight(2, 255, AyahHighlightColor.GREEN, timestamp(200))
+        collectionBookmarksRepository.setHighlight(1, 1, AyahHighlightColor.PINK, timestamp(300))
+
+        assertEquals(
+            listOf(
+                AyahHighlight(1, 1, AyahHighlightColor.PINK, timestamp(300)),
+                AyahHighlight(2, 255, AyahHighlightColor.GREEN, timestamp(200))
+            ),
+            collectionBookmarksRepository.getHighlightsFlow().first()
+        )
+    }
+
+    @Test
+    fun `setHighlight replaces color and preserves default and user collections`() = runTest {
+        val bookmark = bookmarksRepository.addBookmark(2, 255, timestamp(100))
+        val userCollection = collectionsRepository.addCollection("Study", timestamp(200))
+        collectionBookmarksRepository.addBookmarkToCollection(userCollection.id, bookmark, timestamp(300))
+        collectionBookmarksRepository.setHighlight(2, 255, AyahHighlightColor.GREEN, timestamp(400))
+
+        collectionBookmarksRepository.setHighlight(2, 255, AyahHighlightColor.PURPLE, timestamp(500))
+
+        val collectionsByName = collectionsRepository.getAllCollections().associateBy { it.name }
+        val green = requireNotNull(collectionsByName["system:highlights:green"])
+        val purple = requireNotNull(collectionsByName["system:highlights:purple"])
+        assertEquals(emptyList(), collectionBookmarksRepository.getBookmarksForCollection(green.id))
+        assertEquals(1, collectionBookmarksRepository.getBookmarksForCollection(purple.id).size)
+        assertEquals(1, collectionBookmarksRepository.getBookmarksForCollection(userCollection.id).size)
+        assertEquals(1, collectionBookmarksRepository.getBookmarksForCollection(DEFAULT_COLLECTION_ID).size)
+    }
+
+    @Test
+    fun `removeHighlight preserves default and user collections`() = runTest {
+        val bookmark = bookmarksRepository.addBookmark(2, 255, timestamp(100))
+        val userCollection = collectionsRepository.addCollection("Study", timestamp(200))
+        collectionBookmarksRepository.addBookmarkToCollection(userCollection.id, bookmark, timestamp(300))
+        collectionBookmarksRepository.setHighlight(2, 255, AyahHighlightColor.YELLOW, timestamp(400))
+
+        val removed = collectionBookmarksRepository.removeHighlight(2, 255, timestamp(500))
+
+        val highlightCollection = collectionsRepository.getAllCollections()
+            .single { it.name == "system:highlights:yellow" }
+        assertTrue(removed)
+        assertEquals(emptyList(), collectionBookmarksRepository.getBookmarksForCollection(highlightCollection.id))
+        assertEquals(1, collectionBookmarksRepository.getBookmarksForCollection(userCollection.id).size)
+        assertEquals(1, collectionBookmarksRepository.getBookmarksForCollection(DEFAULT_COLLECTION_ID).size)
+        assertFalse(collectionBookmarksRepository.removeHighlight(2, 255, timestamp(600)))
+    }
+
+    @Test
+    fun `removeHighlight prunes a local highlight-only bookmark`() = runTest {
+        collectionBookmarksRepository.setHighlight(2, 255, AyahHighlightColor.RED, timestamp(100))
+        collectionBookmarksRepository.setHighlight(2, 255, AyahHighlightColor.RED, timestamp(150))
+
+        assertTrue(collectionBookmarksRepository.removeHighlight(2, 255, timestamp(200)))
+
+        assertNull(database.bookmarksQueries.getBookmarkForAyah(2L, 255L).executeAsOneOrNull())
+    }
+
+    private fun timestamp(milliseconds: Long) = Instant.fromEpochMilliseconds(milliseconds).toPlatform()
+}

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionsRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionsRepositoryTest.kt
@@ -42,6 +42,50 @@ class CollectionsRepositoryTest {
     }
 
     @Test
+    fun `collection identifies system highlight names case insensitively`() {
+        assertTrue(Collection(" SYSTEM:HIGHLIGHTS:GREEN ", timestamp(1L), "1").isSystemHighlight)
+        assertFalse(Collection("Green", timestamp(1L), "2").isSystemHighlight)
+    }
+
+    @Test
+    fun `collection CRUD rejects reserved highlight collections`() = runTest {
+        assertFailsWith<IllegalArgumentException> {
+            repository.addCollection("system:highlights:blue", timestamp(100L))
+        }
+        database.collectionsQueries.addNewCollection(
+            timestamp = 100L,
+            name = "system:highlights:blue"
+        )
+        val systemCollection = database.collectionsQueries
+            .getCollectionByName("system:highlights:blue")
+            .executeAsOne()
+
+        assertFailsWith<IllegalArgumentException> {
+            repository.updateCollection(systemCollection.local_id.toString(), "Blue", timestamp(200L))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            repository.deleteCollection(systemCollection.local_id.toString())
+        }
+
+        val retained = database.collectionsQueries
+            .getCollectionByLocalId(systemCollection.local_id)
+            .executeAsOne()
+        assertEquals("system:highlights:blue", retained.name)
+        assertEquals(0L, retained.deleted)
+    }
+
+    @Test
+    fun `collection rename rejects reserved highlight name`() = runTest {
+        val collection = repository.addCollection("Study", timestamp(100L))
+
+        assertFailsWith<IllegalArgumentException> {
+            repository.updateCollection(collection.id, "system:highlights:pink", timestamp(200L))
+        }
+
+        assertEquals("Study", repository.getAllCollections().single().name)
+    }
+
+    @Test
     fun `addCollection respects explicit timestamp`() = runTest {
         val collection = repository.addCollection("Favorites", timestamp(1234L))
         val record = database.collectionsQueries.getCollectionByLocalId(collection.id.toLong()).executeAsOne()

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/QuranDataService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/QuranDataService.kt
@@ -11,6 +11,8 @@ import com.quran.shared.di.AppScope
 import com.quran.shared.persistence.input.PersistenceImportData
 import com.quran.shared.persistence.input.PersistenceImportResult
 import com.quran.shared.persistence.model.AyahBookmark
+import com.quran.shared.persistence.model.AyahHighlight
+import com.quran.shared.persistence.model.AyahHighlightColor
 import com.quran.shared.persistence.model.AyahReadingBookmark
 import com.quran.shared.persistence.model.Collection
 import com.quran.shared.persistence.model.CollectionAyahBookmark
@@ -172,6 +174,12 @@ class QuranDataService internal constructor(
     @NativeCoroutines
     val bookmarks: Flow<List<AyahBookmark>> get() = bookmarksRepository.getBookmarksFlow()
 
+    /**
+     * Flow of ayah highlights, stored independently from app-facing bookmark collections.
+     */
+    @NativeCoroutines
+    val highlights: Flow<List<AyahHighlight>> get() = collectionBookmarksRepository.getHighlightsFlow()
+
     @NativeCoroutines
     val readingBookmark: Flow<ReadingBookmark?> get() = readingBookmarksRepository.getReadingBookmarkFlow()
 
@@ -197,7 +205,7 @@ class QuranDataService internal constructor(
                         }
                 val customCollectionFlows =
                     collections
-                        .filterNot { it.isDefault }
+                        .filterNot { it.isDefault || it.isSystemHighlight }
                         .map { collection ->
                             collectionBookmarksRepository.getBookmarksForCollectionFlow(collection.id)
                                 .map { bookmarks: List<CollectionAyahBookmark> ->
@@ -396,6 +404,37 @@ class QuranDataService internal constructor(
     suspend fun addBookmark(sura: Int, ayah: Int, timestamp: PlatformDateTime): AyahBookmark {
         return mutatingCall("Failed to add ayah bookmark") {
             bookmarksRepository.addBookmark(sura, ayah, timestamp)
+        }
+    }
+
+    /**
+     * Sets the highlight color for one ayah, replacing any existing highlight color.
+     * Default and user collection memberships are preserved.
+     */
+    @NativeCoroutines
+    suspend fun setHighlight(sura: Int, ayah: Int, color: AyahHighlightColor): AyahHighlight {
+        return mutatingCall("Failed to set ayah highlight") {
+            collectionBookmarksRepository.setHighlight(sura, ayah, color, currentPlatformDateTime())
+        }
+    }
+
+    /**
+     * Removes the highlight from one ayah while preserving default and user collection memberships.
+     *
+     * @return `true` when at least one highlight membership was removed.
+     */
+    @NativeCoroutines
+    suspend fun removeHighlight(sura: Int, ayah: Int): Boolean {
+        return mutatingCall("Failed to remove ayah highlight", triggerAfter = false) {
+            val removed = collectionBookmarksRepository.removeHighlight(
+                sura,
+                ayah,
+                currentPlatformDateTime()
+            )
+            if (removed) {
+                triggerSync()
+            }
+            removed
         }
     }
 

--- a/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/QuranDataServiceLifecycleTest.kt
+++ b/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/QuranDataServiceLifecycleTest.kt
@@ -30,6 +30,8 @@ import com.quran.shared.persistence.input.RemoteNote
 import com.quran.shared.persistence.input.RemoteReadingSession
 import com.quran.shared.persistence.di.PersistenceModule
 import com.quran.shared.persistence.model.AyahBookmark
+import com.quran.shared.persistence.model.AyahHighlight
+import com.quran.shared.persistence.model.AyahHighlightColor
 import com.quran.shared.persistence.model.AyahReadingBookmark
 import com.quran.shared.persistence.model.BookmarkCollectionsReplacementResult
 import com.quran.shared.persistence.model.Collection
@@ -676,6 +678,32 @@ class QuranDataServiceLifecycleTest {
         }
 
     @Test
+    fun `collectionsWithBookmarks excludes system highlight collections`() = runTest(dispatcher) {
+        val fixture = quranDataServiceFixture()
+        fixture.collectionsRepository.collections.value = listOf(
+            Collection("Study", testTimestamp(), "7"),
+            Collection("system:highlights:green", testTimestamp(), "8")
+        )
+        advanceUntilIdle()
+
+        val result = fixture.service.collectionsWithBookmarks.first()
+
+        assertEquals(listOf(DEFAULT_COLLECTION_ID, "7"), result.map { it.collection.id })
+        assertFalse("8" in fixture.collectionBookmarksRepository.flowRequests)
+        fixture.clearAndJoin()
+    }
+
+    @Test
+    fun `highlights exposes repository flow`() = runTest(dispatcher) {
+        val fixture = quranDataServiceFixture()
+        val highlight = AyahHighlight(2, 255, AyahHighlightColor.PURPLE, testTimestamp())
+        fixture.collectionBookmarksRepository.highlights.value = listOf(highlight)
+
+        assertEquals(listOf(highlight), fixture.service.highlights.first())
+        fixture.clearAndJoin()
+    }
+
+    @Test
     fun `deleteReadingSession returns false without triggering sync when nothing is deleted`() = runTest(dispatcher) {
         val fixture = quranDataServiceFixture(useRecordingSyncClient = true)
         fixture.readingSessionsRepository.deleteResult = false
@@ -729,6 +757,46 @@ class QuranDataServiceLifecycleTest {
         assertEquals(Collection("Favorites", timestamp, "collection-1"), result)
         assertEquals(listOf(CollectionAddCall("Favorites", timestamp)), fixture.collectionsRepository.addCalls)
         assertEquals(1, fixture.syncClient.localDataUpdatedCount)
+        fixture.clearAndJoin()
+    }
+
+    @Test
+    fun `setHighlight returns repository highlight and triggers local sync`() = runTest(dispatcher) {
+        val fixture = quranDataServiceFixture(useRecordingSyncClient = true)
+        advanceUntilIdle()
+
+        val result = fixture.service.setHighlight(2, 255, AyahHighlightColor.BLUE)
+
+        val call = fixture.collectionBookmarksRepository.setHighlightCalls.single()
+        assertEquals(2, call.sura)
+        assertEquals(255, call.ayah)
+        assertEquals(AyahHighlightColor.BLUE, call.color)
+        assertEquals(
+            AyahHighlight(2, 255, AyahHighlightColor.BLUE, call.timestamp),
+            result
+        )
+        assertEquals(1, fixture.syncClient.localDataUpdatedCount)
+        fixture.clearAndJoin()
+    }
+
+    @Test
+    fun `removeHighlight triggers local sync only when a highlight was removed`() = runTest(dispatcher) {
+        val fixture = quranDataServiceFixture(useRecordingSyncClient = true)
+        advanceUntilIdle()
+
+        fixture.collectionBookmarksRepository.removeHighlightResult = false
+        assertFalse(fixture.service.removeHighlight(2, 255))
+        assertEquals(0, fixture.syncClient.localDataUpdatedCount)
+
+        fixture.collectionBookmarksRepository.removeHighlightResult = true
+        assertTrue(fixture.service.removeHighlight(2, 255))
+        assertEquals(1, fixture.syncClient.localDataUpdatedCount)
+        assertEquals(
+            listOf(HighlightRemoveCall(2, 255), HighlightRemoveCall(2, 255)),
+            fixture.collectionBookmarksRepository.removeHighlightCalls.map {
+                HighlightRemoveCall(it.sura, it.ayah)
+            }
+        )
         fixture.clearAndJoin()
     }
 
@@ -1475,6 +1543,19 @@ private data class CollectionDeleteCall(
     val id: String
 )
 
+private data class HighlightSetCall(
+    val sura: Int,
+    val ayah: Int,
+    val color: AyahHighlightColor,
+    val timestamp: PlatformDateTime
+)
+
+private data class HighlightRemoveCall(
+    val sura: Int,
+    val ayah: Int,
+    val timestamp: PlatformDateTime? = null
+)
+
 private class ServiceCollectionsRepository : CollectionsRepository, CollectionsSynchronizationRepository {
     val addCalls = mutableListOf<CollectionAddCall>()
     val updateCalls = mutableListOf<CollectionUpdateCall>()
@@ -1525,7 +1606,32 @@ private class ServiceCollectionBookmarksRepository :
     CollectionBookmarksRepository,
     CollectionBookmarksSynchronizationRepository {
     val flowRequests = mutableListOf<String>()
+    val setHighlightCalls = mutableListOf<HighlightSetCall>()
+    val removeHighlightCalls = mutableListOf<HighlightRemoveCall>()
+    var removeHighlightResult = true
+    val highlights = MutableStateFlow<List<AyahHighlight>>(emptyList())
     private val bookmarksByCollectionId = mutableMapOf<String, MutableStateFlow<List<CollectionAyahBookmark>>>()
+
+    override fun getHighlightsFlow(): Flow<List<AyahHighlight>> = highlights
+
+    override suspend fun setHighlight(
+        sura: Int,
+        ayah: Int,
+        color: AyahHighlightColor,
+        timestamp: PlatformDateTime
+    ): AyahHighlight {
+        setHighlightCalls += HighlightSetCall(sura, ayah, color, timestamp)
+        return AyahHighlight(sura, ayah, color, timestamp)
+    }
+
+    override suspend fun removeHighlight(
+        sura: Int,
+        ayah: Int,
+        timestamp: PlatformDateTime
+    ): Boolean {
+        removeHighlightCalls += HighlightRemoveCall(sura, ayah, timestamp)
+        return removeHighlightResult
+    }
 
     fun setBookmarksForCollection(collectionId: String, bookmarks: List<CollectionAyahBookmark>) {
         bookmarksFlow(collectionId).value = bookmarks


### PR DESCRIPTION
## Context

Builds on the collection-bookmark payload fix merged in #234.

## What changed

- add dedicated `AyahHighlight` and `AyahHighlightColor` models for the six reserved system colors
- expose single-ayah set and remove highlight APIs
- expose a dedicated observable highlights flow
- keep system highlight collections out of the app-facing generic collections flow
- prevent generic collection creation, rename, and deletion from operating on reserved highlight names
- add repository and `QuranDataService` regression coverage

## Why

Highlights are persisted using reserved system collections, but they are a distinct product concept. Callers should work with highlights directly instead of treating their backing storage as user-manageable collections.

## Impact

Clients can set, replace, remove, and observe highlights independently. Favorites and normal collections remain unchanged, while backing system collections stay synchronized without appearing in the generic collections UI.

## Validation

- affected persistence and sync-pipeline JVM suites passed, including 6 highlight repository tests, 28 collections repository tests, and 44 `QuranDataServiceLifecycleTest` tests
- `git diff --check`
- end-to-end iOS Simulator validation against prelive: set Pink on an ayah, observed the highlight and count, removed it, and confirmed successful synchronization