### PR TITLE
fix(highlights): remove unsupported pink color

### DIFF
--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/AyahHighlightColor.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/AyahHighlightColor.kt
@@ -2,7 +2,6 @@ package com.quran.shared.persistence.model
 
 enum class AyahHighlightColor(internal val collectionName: String) {
     BLUE("system:highlights:blue"),
-    PINK("system:highlights:pink"),
     RED("system:highlights:red"),
     GREEN("system:highlights:green"),
     YELLOW("system:highlights:yellow"),

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/AyahHighlightsRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/AyahHighlightsRepositoryTest.kt
@@ -40,7 +40,6 @@ class AyahHighlightsRepositoryTest {
         assertEquals(
             listOf(
                 "system:highlights:blue",
-                "system:highlights:pink",
                 "system:highlights:red",
                 "system:highlights:green",
                 "system:highlights:yellow",
@@ -79,11 +78,11 @@ class AyahHighlightsRepositoryTest {
     fun `highlights flow reports one latest color per ayah`() = runTest {
         collectionBookmarksRepository.setHighlight(1, 1, AyahHighlightColor.BLUE, timestamp(100))
         collectionBookmarksRepository.setHighlight(2, 255, AyahHighlightColor.GREEN, timestamp(200))
-        collectionBookmarksRepository.setHighlight(1, 1, AyahHighlightColor.PINK, timestamp(300))
+        collectionBookmarksRepository.setHighlight(1, 1, AyahHighlightColor.RED, timestamp(300))
 
         assertEquals(
             listOf(
-                AyahHighlight(1, 1, AyahHighlightColor.PINK, timestamp(300)),
+                AyahHighlight(1, 1, AyahHighlightColor.RED, timestamp(300)),
                 AyahHighlight(2, 255, AyahHighlightColor.GREEN, timestamp(200))
             ),
             collectionBookmarksRepository.getHighlightsFlow().first()

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionsRepositoryTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/CollectionsRepositoryTest.kt
@@ -79,7 +79,7 @@ class CollectionsRepositoryTest {
         val collection = repository.addCollection("Study", timestamp(100L))
 
         assertFailsWith<IllegalArgumentException> {
-            repository.updateCollection(collection.id, "system:highlights:pink", timestamp(200L))
+            repository.updateCollection(collection.id, "system:highlights:yellow", timestamp(200L))
         }
 
         assertEquals("Study", repository.getAllCollections().single().name)


### PR DESCRIPTION
## What changed

- remove `PINK` from `AyahHighlightColor`
- remove the `system:highlights:pink` reserved collection name
- update highlight and collection-protection tests to use the five supported colors

## Why

quran-ios supports five established highlight colors: red, green, blue, yellow, and purple. Pink was introduced only as part of the new MobileSync highlight API and is not an existing product color.

## Impact

MobileSync and quran-ios now expose the same five-color set.

## Validation

- `./gradlew :persistence:jvmTest --tests 'com.quran.shared.persistence.repository.AyahHighlightsRepositoryTest' --tests 'com.quran.shared.persistence.repository.CollectionsRepositoryTest'`
- `git diff --check`