### PR TITLE
fix(auth): expose typed authentication failures

### DIFF
--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/model/AuthenticationException.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/model/AuthenticationException.kt
@@ -1,0 +1,46 @@
+package com.quran.shared.auth.model
+
+import kotlin.native.HiddenFromObjC
+import kotlinx.io.IOException
+import org.publicvalue.multiplatform.oidc.OpenIdConnectException
+
+/** Stable authentication failures exported to managed clients. */
+sealed class AuthenticationException(
+    message: String,
+    cause: Throwable? = null
+) : Exception(message, cause)
+
+class AuthenticationCancelledException(
+    cause: Throwable? = null
+) : AuthenticationException("Authentication cancelled", cause)
+
+class AuthenticationNetworkException(
+    cause: Throwable
+) : AuthenticationException(cause.message ?: "Authentication network request failed", cause)
+
+class AuthenticationFailedException(
+    cause: Throwable
+) : AuthenticationException(cause.message ?: "Authentication failed", cause)
+
+@HiddenFromObjC
+fun Exception.asAuthenticationException(): AuthenticationException =
+    when {
+        this is AuthenticationException -> this
+        this is OpenIdConnectException.AuthenticationCancelled -> AuthenticationCancelledException(this)
+        hasNetworkCause() -> AuthenticationNetworkException(this)
+        else -> AuthenticationFailedException(this)
+    }
+
+private fun Throwable.hasNetworkCause(): Boolean {
+    var current: Throwable? = this
+    repeat(MAX_CAUSE_DEPTH) {
+        when (val cause = current) {
+            null -> return false
+            is IOException -> return true
+            else -> current = cause.cause.takeUnless { it === cause }
+        }
+    }
+    return false
+}
+
+private const val MAX_CAUSE_DEPTH = 16

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/service/AuthService.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/service/AuthService.kt
@@ -1,6 +1,8 @@
 package com.quran.shared.auth.service
 
 import com.quran.shared.auth.model.AuthState
+import com.quran.shared.auth.model.AuthenticationCancelledException
+import com.quran.shared.auth.model.asAuthenticationException
 import com.quran.shared.auth.repository.AuthRepository
 import com.quran.shared.auth.repository.AuthRepositoryLoginCommitCallbacks
 import com.quran.shared.auth.repository.LogoutTokenCaptureException
@@ -110,9 +112,15 @@ class AuthService private constructor(
     suspend fun loginWithReauthentication(): Unit = runLogin(LoginIntent.Reauthenticate)
 
     private suspend fun runLogin(intent: LoginIntent) {
-        val loginReservation = awaitDifferentIntentOrReserveLogin(intent) ?: return
-        runActiveLogin(loginReservation) {
-            runRepositoryLogin(intent, loginReservation)
+        try {
+            val loginReservation = awaitDifferentIntentOrReserveLogin(intent) ?: return
+            runActiveLogin(loginReservation) {
+                runRepositoryLogin(intent, loginReservation)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw e.asAuthenticationException()
         }
     }
 
@@ -241,6 +249,7 @@ class AuthService private constructor(
             }
             throw e
         } catch (e: Exception) {
+            val authenticationException = e.asAuthenticationException()
             withContext(NonCancellable) {
                 val publishResult = if (repositoryLoginCompleted) {
                     tryPublishValidatedActiveLoginSession(loginReservation.generation)
@@ -248,9 +257,13 @@ class AuthService private constructor(
                     PublishSessionResult.NoSession
                 }
                 if (publishResult != PublishSessionResult.Published) {
-                    failActiveLoginIfLoadingGenerationCurrent(e, "Login failed", loginReservation)
+                    failActiveLoginIfLoadingGenerationCurrent(
+                        authenticationException,
+                        "Login failed",
+                        loginReservation
+                    )
                 }
-                completeActiveLogin(loginReservation, e)
+                completeActiveLogin(loginReservation, authenticationException)
             }
             throw e
         }
@@ -625,7 +638,11 @@ class AuthService private constructor(
             ) {
                 cachedAccessToken = null
                 lifecycle = AuthPublicationLifecycle.Idle(loginReservation.generation + 1)
-                _authState.value = AuthState.Error(e, errorMessage)
+                _authState.value = if (e is AuthenticationCancelledException) {
+                    AuthState.Idle
+                } else {
+                    AuthState.Error(e, errorMessage)
+                }
                 loginReservation.completion.completeExceptionally(e)
             }
         }

--- a/auth/src/commonTest/kotlin/com/quran/shared/auth/service/AuthServiceTest.kt
+++ b/auth/src/commonTest/kotlin/com/quran/shared/auth/service/AuthServiceTest.kt
@@ -1,6 +1,9 @@
 package com.quran.shared.auth.service
 
 import com.quran.shared.auth.model.AuthState
+import com.quran.shared.auth.model.AuthenticationCancelledException
+import com.quran.shared.auth.model.AuthenticationFailedException
+import com.quran.shared.auth.model.AuthenticationNetworkException
 import com.quran.shared.auth.model.UserInfo
 import com.quran.shared.auth.repository.AuthRepository
 import com.quran.shared.auth.repository.AuthRepositoryLoginCommitCallbacks
@@ -8,6 +11,7 @@ import com.quran.shared.auth.repository.LogoutTokenCaptureException
 import com.quran.shared.auth.repository.LogoutTokenMaterial
 import com.quran.shared.auth.repository.RemoteLogoutFailure
 import com.quran.shared.auth.repository.RemoteLogoutOperation
+import kotlinx.io.IOException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.CompletableDeferred
@@ -22,6 +26,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.publicvalue.multiplatform.oidc.OpenIdConnectException
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -1761,6 +1766,58 @@ class AuthServiceTest {
         assertTrue(result.isFailure)
         val state = assertIs<AuthState.Error>(service.authState.value)
         assertEquals("login failed", state.message)
+    }
+
+    @Test
+    fun `user cancelled login throws typed cancellation without publishing an error`() = runTest(dispatcher) {
+        val repository = RecordingAuthRepository(
+            accessToken = null,
+            currentUser = null,
+            loginFailure = OpenIdConnectException.AuthenticationCancelled()
+        )
+        val service = AuthService(repository)
+        advanceUntilIdle()
+
+        val result = runCatching { service.login() }
+
+        assertIs<AuthenticationCancelledException>(result.exceptionOrNull())
+        assertFalse(service.isLoggedIn())
+        assertNull(service.getAccessToken())
+        assertIs<AuthState.Idle>(service.authState.value)
+    }
+
+    @Test
+    fun `login failure throws typed authentication failure`() = runTest(dispatcher) {
+        val repository = RecordingAuthRepository(
+            accessToken = null,
+            currentUser = null,
+            loginFailure = IllegalStateException("login failed")
+        )
+        val service = AuthService(repository)
+        advanceUntilIdle()
+
+        val result = runCatching { service.login() }
+
+        val failure = assertIs<AuthenticationFailedException>(result.exceptionOrNull())
+        assertIs<IllegalStateException>(failure.cause)
+        assertIs<AuthState.Error>(service.authState.value)
+    }
+
+    @Test
+    fun `network login failure throws typed network failure`() = runTest(dispatcher) {
+        val repository = RecordingAuthRepository(
+            accessToken = null,
+            currentUser = null,
+            loginFailure = IOException("offline")
+        )
+        val service = AuthService(repository)
+        advanceUntilIdle()
+
+        val result = runCatching { service.login() }
+
+        val failure = assertIs<AuthenticationNetworkException>(result.exceptionOrNull())
+        assertIs<IOException>(failure.cause)
+        assertIs<AuthState.Error>(service.authState.value)
     }
 }
 

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncAuthService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/SyncAuthService.kt
@@ -3,12 +3,14 @@ package com.quran.shared.pipeline
 import com.quran.shared.auth.model.AuthState
 import com.quran.shared.auth.model.AuthRuntimeConfig
 import com.quran.shared.auth.model.UserInfo
+import com.quran.shared.auth.model.asAuthenticationException
 import com.quran.shared.auth.service.AuthService
 import com.quran.shared.di.AppScope
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutinesState
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -60,20 +62,32 @@ class SyncAuthService internal constructor(
     }
 
     @NativeCoroutines
-    suspend fun refreshAuthentication(): Boolean =
+    suspend fun refreshAuthentication(): Boolean = withAuthenticationErrors {
         authService.refreshAccessTokenIfNeeded()
+    }
 
     @NativeCoroutines
-    suspend fun authenticationHeaders(): Map<String, String> =
+    suspend fun authenticationHeaders(): Map<String, String> = withAuthenticationErrors {
         authService.getAuthHeaders()
+    }
 
     @NativeCoroutines
-    suspend fun logout(clearLocalData: Boolean = true): LogoutResult =
+    suspend fun logout(clearLocalData: Boolean = true): LogoutResult = withAuthenticationErrors {
         quranDataService.logout(clearLocalData)
+    }
 
     fun clearError() {
         authService.clearError()
     }
 
     fun isLoggedIn(): Boolean = authService.isLoggedIn()
+
+    private suspend fun <T> withAuthenticationErrors(operation: suspend () -> T): T =
+        try {
+            operation()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            throw e.asAuthenticationException()
+        }
 }


### PR DESCRIPTION
## Summary

- export stable authentication exceptions for cancellation, network failures, and other authentication failures
- translate underlying OIDC and I/O exceptions at the Kotlin boundary while preserving their causes
- keep user cancellation in the idle authentication state instead of publishing `AuthState.Error`
- propagate the same typed contract through `SyncAuthService` operations

## Why

Interactive OAuth dismissal currently arrives as implementation-specific exceptions. Managed clients therefore cannot reliably distinguish expected user cancellation from actionable authentication failures and may present an error to the user.

This establishes a first-party authentication error taxonomy that Swift and other managed clients can inspect without depending on vendor exception details.

## Related PRs and release order

- quran/mobile-sync#237 — Kotlin typed authentication exceptions (this PR)
- quran/mobile-sync#238 — silent native logout, stacked on this PR
- quran/mobile-sync-spm#18 — Swift typed-error bridge
- quran/quran-ios#950 — application handling and cancellation UX

Required order:

1. Merge this PR.
2. Retarget quran/mobile-sync#238 to `main`, merge it, and release `mobile-sync` with both changes.
3. Update quran/mobile-sync-spm#18 to that release, verify it, merge it, and release `mobile-sync-spm`.
4. Update quran/quran-ios#950 to the new `mobile-sync-spm` release, verify published-dependency gates, then merge it.

Do not merge either downstream repository PR before its required upstream release exists.

## Validation

- `./gradlew :auth:allTests :sync-pipelines:allTests`
- local XCFramework build through the consuming Swift package
- consuming iOS sync and no-sync test plans
- iOS Simulator verification for both the system consent Cancel action and web authentication sheet dismissal