### PR TITLE
fix(auth): make logout silent by default

### DIFF
--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/repository/AuthRepository.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/repository/AuthRepository.kt
@@ -21,6 +21,14 @@ enum class RemoteLogoutOperation {
 }
 
 @HiddenFromObjC
+enum class RemoteLogoutMode(
+    val operations: List<RemoteLogoutOperation>
+) {
+    TOKEN_REVOCATION_ONLY(listOf(RemoteLogoutOperation.REVOKE_REFRESH_TOKEN)),
+    TOKEN_REVOCATION_AND_END_SESSION(RemoteLogoutOperation.entries)
+}
+
+@HiddenFromObjC
 data class RemoteLogoutFailure(
     val operation: RemoteLogoutOperation,
     val exception: Exception
@@ -79,7 +87,10 @@ interface AuthRepository {
 
     suspend fun clearLocalSession()
 
-    suspend fun attemptRemoteLogout(tokenMaterial: LogoutTokenMaterial): List<RemoteLogoutFailure>
+    suspend fun attemptRemoteLogout(
+        tokenMaterial: LogoutTokenMaterial,
+        mode: RemoteLogoutMode
+    ): List<RemoteLogoutFailure>
 
     /**
      * Returns the current access token if available.

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/repository/OidcAuthRepository.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/repository/OidcAuthRepository.kt
@@ -441,7 +441,10 @@ class OidcAuthRepository @Inject constructor(
 
     override suspend fun logout() {
         val tokenMaterial = captureLogoutTokenMaterialAndClearLocalSession()
-        val failures = attemptRemoteLogout(tokenMaterial)
+        val failures = attemptRemoteLogout(
+            tokenMaterial,
+            RemoteLogoutMode.TOKEN_REVOCATION_ONLY
+        )
         failures.forEach { failure ->
             logger.w(failure.exception) { "Remote logout cleanup failed: ${failure.operation}" }
         }
@@ -507,7 +510,10 @@ class OidcAuthRepository @Inject constructor(
         invalidationResult.failure?.let { throw it }
     }
 
-    override suspend fun attemptRemoteLogout(tokenMaterial: LogoutTokenMaterial): List<RemoteLogoutFailure> {
+    override suspend fun attemptRemoteLogout(
+        tokenMaterial: LogoutTokenMaterial,
+        mode: RemoteLogoutMode
+    ): List<RemoteLogoutFailure> {
         val failures = mutableListOf<RemoteLogoutFailure>()
 
         tokenMaterial.refreshToken?.let { refreshToken ->
@@ -521,7 +527,10 @@ class OidcAuthRepository @Inject constructor(
             }
         }
 
-        if (AuthFlowFactoryProvider.isInitialized()) {
+        if (
+            RemoteLogoutOperation.END_SESSION in mode.operations &&
+            AuthFlowFactoryProvider.isInitialized()
+        ) {
             try {
                 val endSessionFlow = AuthFlowFactoryProvider.factory.createEndSessionFlow(oidcClient)
                 endSessionFlow.endSession(tokenMaterial.idToken) {

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/repository/UnconfiguredAuthRepository.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/repository/UnconfiguredAuthRepository.kt
@@ -52,7 +52,10 @@ class UnconfiguredAuthRepository @Inject constructor(
         authStorage.clearAllTokens()
     }
 
-    override suspend fun attemptRemoteLogout(tokenMaterial: LogoutTokenMaterial): List<RemoteLogoutFailure> =
+    override suspend fun attemptRemoteLogout(
+        tokenMaterial: LogoutTokenMaterial,
+        mode: RemoteLogoutMode
+    ): List<RemoteLogoutFailure> =
         emptyList()
 
     override suspend fun getAccessToken(): String? = null

--- a/auth/src/commonMain/kotlin/com/quran/shared/auth/service/AuthService.kt
+++ b/auth/src/commonMain/kotlin/com/quran/shared/auth/service/AuthService.kt
@@ -8,6 +8,7 @@ import com.quran.shared.auth.repository.AuthRepositoryLoginCommitCallbacks
 import com.quran.shared.auth.repository.LogoutTokenCaptureException
 import com.quran.shared.auth.repository.LogoutTokenMaterial
 import com.quran.shared.auth.repository.RemoteLogoutFailure
+import com.quran.shared.auth.repository.RemoteLogoutMode
 import com.quran.shared.di.AppScope
 import dev.zacsweers.metro.SingleIn
 import kotlin.native.HiddenFromObjC
@@ -346,7 +347,10 @@ class AuthService private constructor(
 
         if (tokenMaterial != null) {
             try {
-                authRepository.attemptRemoteLogout(tokenMaterial)
+                authRepository.attemptRemoteLogout(
+                    tokenMaterial,
+                    RemoteLogoutMode.TOKEN_REVOCATION_ONLY
+                )
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Exception) {
@@ -394,8 +398,11 @@ class AuthService private constructor(
     }
 
     @HiddenFromObjC
-    suspend fun attemptRemoteLogout(tokenMaterial: LogoutTokenMaterial): List<RemoteLogoutFailure> =
-        authRepository.attemptRemoteLogout(tokenMaterial)
+    suspend fun attemptRemoteLogout(
+        tokenMaterial: LogoutTokenMaterial,
+        mode: RemoteLogoutMode
+    ): List<RemoteLogoutFailure> =
+        authRepository.attemptRemoteLogout(tokenMaterial, mode)
 
     suspend fun refreshAccessTokenIfNeeded(): Boolean {
         return when (val current = lifecycleSnapshot()) {

--- a/auth/src/commonTest/kotlin/com/quran/shared/auth/repository/OidcAuthRepositoryTest.kt
+++ b/auth/src/commonTest/kotlin/com/quran/shared/auth/repository/OidcAuthRepositoryTest.kt
@@ -418,8 +418,31 @@ class OidcAuthRepositoryTest {
             )
 
             assertFailsWith<CancellationException> {
-                repository.attemptRemoteLogout(LogoutTokenMaterial(refreshToken = "refresh-token", idToken = null))
+                repository.attemptRemoteLogout(
+                    LogoutTokenMaterial(refreshToken = "refresh-token", idToken = null),
+                    RemoteLogoutMode.TOKEN_REVOCATION_ONLY
+                )
             }
+        }
+
+    @Test
+    fun `token revocation logout does not start provider end session`() =
+        runTest(UnconfinedTestDispatcher()) {
+            AuthFlowFactoryProvider.initialize(CancellingEndSessionFlowFactory)
+            val repository = oidcRepository(
+                AuthStorage(
+                    tokenStore = RecordingTokenStore(),
+                    settings = MapSettings().toSuspendSettings(),
+                    json = Json { ignoreUnknownKeys = true }
+                )
+            )
+
+            val failures = repository.attemptRemoteLogout(
+                LogoutTokenMaterial(refreshToken = null, idToken = "id-token"),
+                RemoteLogoutMode.TOKEN_REVOCATION_ONLY
+            )
+
+            assertEquals(emptyList(), failures)
         }
 
     @Test
@@ -435,7 +458,10 @@ class OidcAuthRepositoryTest {
             )
 
             assertFailsWith<CancellationException> {
-                repository.attemptRemoteLogout(LogoutTokenMaterial(refreshToken = null, idToken = "id-token"))
+                repository.attemptRemoteLogout(
+                    LogoutTokenMaterial(refreshToken = null, idToken = "id-token"),
+                    RemoteLogoutMode.TOKEN_REVOCATION_AND_END_SESSION
+                )
             }
         }
 

--- a/auth/src/commonTest/kotlin/com/quran/shared/auth/repository/UnconfiguredAuthRepositoryTest.kt
+++ b/auth/src/commonTest/kotlin/com/quran/shared/auth/repository/UnconfiguredAuthRepositoryTest.kt
@@ -52,7 +52,10 @@ class UnconfiguredAuthRepositoryTest {
         )
         assertEquals(
             emptyList(),
-            repository.attemptRemoteLogout(LogoutTokenMaterial(refreshToken = "refresh", idToken = "id"))
+            repository.attemptRemoteLogout(
+                LogoutTokenMaterial(refreshToken = "refresh", idToken = "id"),
+                RemoteLogoutMode.TOKEN_REVOCATION_ONLY
+            )
         )
     }
 

--- a/auth/src/commonTest/kotlin/com/quran/shared/auth/service/AuthServiceTest.kt
+++ b/auth/src/commonTest/kotlin/com/quran/shared/auth/service/AuthServiceTest.kt
@@ -10,6 +10,7 @@ import com.quran.shared.auth.repository.AuthRepositoryLoginCommitCallbacks
 import com.quran.shared.auth.repository.LogoutTokenCaptureException
 import com.quran.shared.auth.repository.LogoutTokenMaterial
 import com.quran.shared.auth.repository.RemoteLogoutFailure
+import com.quran.shared.auth.repository.RemoteLogoutMode
 import com.quran.shared.auth.repository.RemoteLogoutOperation
 import kotlinx.io.IOException
 import kotlinx.coroutines.CancellationException
@@ -223,6 +224,23 @@ class AuthServiceTest {
         assertNull(repository.getAccessToken())
         assertNull(service.getAccessToken())
         assertIs<AuthState.Idle>(service.authState.value)
+    }
+
+    @Test
+    fun `logout revokes tokens without ending the provider session`() = runTest(dispatcher) {
+        val repository = RecordingAuthRepository(
+            accessToken = "access-token",
+            currentUser = null
+        )
+        val service = AuthService(repository)
+        advanceUntilIdle()
+
+        service.logout()
+
+        assertEquals(
+            listOf(RemoteLogoutMode.TOKEN_REVOCATION_ONLY),
+            repository.remoteLogoutModes
+        )
     }
 
     @Test
@@ -1899,6 +1917,7 @@ private class RecordingAuthRepository(
         private set
     var refreshCalls = 0
         private set
+    val remoteLogoutModes = mutableListOf<RemoteLogoutMode>()
     private var accessTokenReadCalls = 0
     private var isLoggedInReadCalls = 0
     private var currentUserCalls = 0
@@ -2060,7 +2079,11 @@ private class RecordingAuthRepository(
         }
     }
 
-    override suspend fun attemptRemoteLogout(tokenMaterial: LogoutTokenMaterial): List<RemoteLogoutFailure> {
+    override suspend fun attemptRemoteLogout(
+        tokenMaterial: LogoutTokenMaterial,
+        mode: RemoteLogoutMode
+    ): List<RemoteLogoutFailure> {
+        remoteLogoutModes += mode
         remoteLogoutStarted.complete(Unit)
         if (suspendRemoteLogout) {
             remoteLogoutCanFinish.await()

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/QuranDataService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/QuranDataService.kt
@@ -5,6 +5,7 @@ import com.quran.shared.auth.model.AuthState
 import com.quran.shared.auth.repository.LogoutTokenCaptureException
 import com.quran.shared.auth.repository.LogoutTokenMaterial
 import com.quran.shared.auth.repository.RemoteLogoutFailure
+import com.quran.shared.auth.repository.RemoteLogoutMode
 import com.quran.shared.auth.repository.RemoteLogoutOperation
 import com.quran.shared.auth.service.AuthService
 import com.quran.shared.di.AppScope
@@ -279,6 +280,7 @@ class QuranDataService internal constructor(
         if (!clearLocalData) {
             throw UnsupportedOperationException("Keep-local logout is not implemented yet")
         }
+        val remoteLogoutMode = RemoteLogoutMode.TOKEN_REVOCATION_ONLY
         var tokenMaterial: LogoutTokenMaterial? = null
         var tokenCaptureFailure: Throwable? = null
         try {
@@ -298,15 +300,18 @@ class QuranDataService internal constructor(
                 resetLocalDataAndSyncToken()
             }
             val warnings = tokenCaptureFailure?.let { failure ->
-                logoutRemoteCleanupFailureWarnings(failure)
+                logoutRemoteCleanupFailureWarnings(failure, remoteLogoutMode)
             } ?: try {
-                authService.attemptRemoteLogout(tokenMaterial!!).let { failures ->
+                authService.attemptRemoteLogout(
+                    tokenMaterial!!,
+                    remoteLogoutMode
+                ).let { failures ->
                     failures.map { it.toLogoutWarning() }
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (failure: Throwable) {
-                logoutRemoteCleanupFailureWarnings(failure)
+                logoutRemoteCleanupFailureWarnings(failure, remoteLogoutMode)
             }
             return LogoutResult(warnings)
         } catch (e: CancellationException) {
@@ -335,8 +340,11 @@ class QuranDataService internal constructor(
         syncLocalModificationDateStore.updateLastModificationDate(0L)
     }
 
-    private fun logoutRemoteCleanupFailureWarnings(failure: Throwable): List<LogoutWarning> =
-        RemoteLogoutOperation.entries.map { operation ->
+    private fun logoutRemoteCleanupFailureWarnings(
+        failure: Throwable,
+        mode: RemoteLogoutMode
+    ): List<LogoutWarning> =
+        mode.operations.map { operation ->
             LogoutWarning(
                 type = operation.toLogoutWarningType(),
                 message = failure.message

--- a/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/QuranDataServiceLifecycleTest.kt
+++ b/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/QuranDataServiceLifecycleTest.kt
@@ -9,6 +9,7 @@ import com.quran.shared.auth.model.UserInfo
 import com.quran.shared.auth.repository.AuthRepository
 import com.quran.shared.auth.repository.LogoutTokenMaterial
 import com.quran.shared.auth.repository.RemoteLogoutFailure
+import com.quran.shared.auth.repository.RemoteLogoutMode
 import com.quran.shared.auth.repository.RemoteLogoutOperation
 import com.quran.shared.auth.service.AuthSessionPublicationGuard
 import com.quran.shared.auth.service.AuthService
@@ -190,8 +191,7 @@ class QuranDataServiceLifecycleTest {
                 refreshToken = "refresh-token",
                 idToken = "id-token",
                 remoteFailures = listOf(
-                    RemoteLogoutFailure(RemoteLogoutOperation.REVOKE_REFRESH_TOKEN, Exception("revoke failed")),
-                    RemoteLogoutFailure(RemoteLogoutOperation.END_SESSION, Exception("end-session failed"))
+                    RemoteLogoutFailure(RemoteLogoutOperation.REVOKE_REFRESH_TOKEN, Exception("revoke failed"))
                 )
             )
         )
@@ -202,14 +202,17 @@ class QuranDataServiceLifecycleTest {
 
         assertEquals(
             listOf(
-                LogoutWarning(LogoutWarningType.REVOKE_TOKEN_FAILED, "revoke failed"),
-                LogoutWarning(LogoutWarningType.END_SESSION_FAILED, "end-session failed")
+                LogoutWarning(LogoutWarningType.REVOKE_TOKEN_FAILED, "revoke failed")
             ),
             result.warnings
         )
         assertEquals(null, fixture.authRepository.getAccessToken())
         assertEquals(1, fixture.resetRepository.deleteCount)
         assertEquals(0L, fixture.tokenStore.localLastModificationDate())
+        assertEquals(
+            listOf(RemoteLogoutMode.TOKEN_REVOCATION_ONLY),
+            fixture.authRepository.remoteLogoutModes
+        )
         fixture.clearAndJoin()
     }
 
@@ -457,8 +460,7 @@ class QuranDataServiceLifecycleTest {
 
         assertEquals(
             listOf(
-                LogoutWarning(LogoutWarningType.REVOKE_TOKEN_FAILED, "token capture failed"),
-                LogoutWarning(LogoutWarningType.END_SESSION_FAILED, "token capture failed")
+                LogoutWarning(LogoutWarningType.REVOKE_TOKEN_FAILED, "token capture failed")
             ),
             result.warnings
         )
@@ -1228,6 +1230,7 @@ private class ServiceAuthRepository(
     val firstAuthHeadersCanFinish = CompletableDeferred<Unit>()
     var remoteLogoutAttemptCount = 0
         private set
+    val remoteLogoutModes = mutableListOf<RemoteLogoutMode>()
     var loginCalls = 0
         private set
     var reauthenticationCalls = 0
@@ -1258,7 +1261,10 @@ private class ServiceAuthRepository(
     }
 
     override suspend fun logout() {
-        val failures = attemptRemoteLogout(captureLogoutTokenMaterial())
+        val failures = attemptRemoteLogout(
+            captureLogoutTokenMaterial(),
+            RemoteLogoutMode.TOKEN_REVOCATION_ONLY
+        )
         if (failures.isNotEmpty()) {
             throw failures.first().exception
         }
@@ -1285,8 +1291,12 @@ private class ServiceAuthRepository(
         idToken = null
     }
 
-    override suspend fun attemptRemoteLogout(tokenMaterial: LogoutTokenMaterial): List<RemoteLogoutFailure> {
+    override suspend fun attemptRemoteLogout(
+        tokenMaterial: LogoutTokenMaterial,
+        mode: RemoteLogoutMode
+    ): List<RemoteLogoutFailure> {
         remoteLogoutAttemptCount += 1
+        remoteLogoutModes += mode
         onAttemptRemoteLogout()
         remoteLogoutException?.let { throw it }
         return remoteFailures


### PR DESCRIPTION
## Summary

- make normal logout revoke the refresh token without launching OIDC provider end-session
- require an explicit internal mode before browser-based provider-session logout can run
- keep local auth and sync-data clearing behavior unchanged
- report warnings only for remote operations that were actually attempted

## Root cause

The managed logout flow cleared local authentication and sync data first, then invoked the OIDC `end_session_endpoint` through `ASWebAuthenticationSession`. iOS therefore displayed a misleading “Wants to Use … to Sign In” consent alert during sign-out. Cancelling or continuing both appeared to work because local sign-out had already completed; continuing briefly showed the logout sheet before its redirect dismissed it.

## Behavior and tradeoff

Normal app sign-out is now fully non-interactive: local state is cleared and the refresh token is revoked. The shared browser's Quran Foundation cookie remains, so this does not claim to sign the user out of quran.com in Safari. Subsequent app sign-in already uses `prompt=login` reauthentication.

Provider-session logout remains available as an explicit internal mode for a future deliberately interactive UX.

## Related PRs and release order

- quran/mobile-sync#237 — Kotlin typed authentication exceptions; base PR
- quran/mobile-sync#238 — silent native logout (this PR)
- quran/mobile-sync-spm#18 — Swift typed-error bridge
- quran/quran-ios#950 — application handling and cancellation UX

**Stacked on quran/mobile-sync#237.**

1. Merge quran/mobile-sync#237.
2. Retarget this PR to `main`, merge it, and release `mobile-sync` with both changes.
3. Update quran/mobile-sync-spm#18 to that release, verify it, merge it, and release `mobile-sync-spm`.
4. Update quran/quran-ios#950 to the new Swift package release, verify published-dependency gates, then merge it.

## Validation

- `./gradlew :auth:jvmTest :sync-pipelines:jvmTest`
- `./gradlew :auth:allTests :sync-pipelines:allTests`
- `./gradlew :umbrella:assembleSharedDebugXCFramework`
- verified `RemoteLogoutMode` is absent from exported Swift headers