### PR TITLE
feat: support explicit highlight timestamps

### DIFF
--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/QuranDataService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/QuranDataService.kt
@@ -421,8 +421,18 @@ class QuranDataService internal constructor(
      */
     @NativeCoroutines
     suspend fun setHighlight(sura: Int, ayah: Int, color: AyahHighlightColor): AyahHighlight {
+        return setHighlight(sura, ayah, color, currentPlatformDateTime())
+    }
+
+    @NativeCoroutines
+    suspend fun setHighlight(
+        sura: Int,
+        ayah: Int,
+        color: AyahHighlightColor,
+        timestamp: PlatformDateTime
+    ): AyahHighlight {
         return mutatingCall("Failed to set ayah highlight") {
-            collectionBookmarksRepository.setHighlight(sura, ayah, color, currentPlatformDateTime())
+            collectionBookmarksRepository.setHighlight(sura, ayah, color, timestamp)
         }
     }
 

--- a/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/QuranDataServiceLifecycleTest.kt
+++ b/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/QuranDataServiceLifecycleTest.kt
@@ -782,6 +782,23 @@ class QuranDataServiceLifecycleTest {
     }
 
     @Test
+    fun `setHighlight forwards explicit timestamp`() = runTest(dispatcher) {
+        val fixture = quranDataServiceFixture(useRecordingSyncClient = true)
+        val timestamp = Instant.fromEpochMilliseconds(42).toPlatform()
+        advanceUntilIdle()
+
+        val result = fixture.service.setHighlight(2, 255, AyahHighlightColor.BLUE, timestamp)
+
+        assertEquals(
+            HighlightSetCall(2, 255, AyahHighlightColor.BLUE, timestamp),
+            fixture.collectionBookmarksRepository.setHighlightCalls.single()
+        )
+        assertEquals(AyahHighlight(2, 255, AyahHighlightColor.BLUE, timestamp), result)
+        assertEquals(1, fixture.syncClient.localDataUpdatedCount)
+        fixture.clearAndJoin()
+    }
+
+    @Test
     fun `removeHighlight triggers local sync only when a highlight was removed`() = runTest(dispatcher) {
         val fixture = quranDataServiceFixture(useRecordingSyncClient = true)
         advanceUntilIdle()


### PR DESCRIPTION
## Summary

- add a `QuranDataService.setHighlight` overload accepting an explicit timestamp
- preserve the convenience overload using the current platform time
- verify timestamp forwarding and sync triggering

## Testing

- `./gradlew :sync-pipelines:jvmTest`