### PR TITLE
fix: correct ayah bookmark collection replacement

### DIFF
--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/BookmarkCollectionsReplacementResult.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/model/BookmarkCollectionsReplacementResult.kt
@@ -1,6 +1,6 @@
 package com.quran.shared.persistence.model
 
 data class BookmarkCollectionsReplacementResult(
-    val bookmark: AyahBookmark,
+    val bookmark: AyahBookmark?,
     val changed: Boolean
 )

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepository.kt
@@ -9,7 +9,8 @@ interface BookmarksRepository {
      * Replaces an ayah bookmark's saved collection memberships exactly.
      *
      * Non-empty memberships create the bookmark if needed. Empty memberships remove the saved
-     * bookmark, or do nothing when it does not exist.
+     * bookmark, or do nothing when it does not exist. Highlight collection memberships are always
+     * preserved and excluded from replacement.
      */
     @NativeCoroutines
     suspend fun replaceAyahBookmarkCollections(
@@ -23,7 +24,8 @@ interface BookmarksRepository {
      * timestamp.
      *
      * Non-empty memberships create the bookmark if needed. Empty memberships remove the saved
-     * bookmark, or do nothing when it does not exist.
+     * bookmark, or do nothing when it does not exist. Highlight collection memberships are always
+     * preserved and excluded from replacement.
      */
     @NativeCoroutines
     suspend fun replaceAyahBookmarkCollections(

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepository.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepository.kt
@@ -6,8 +6,10 @@ import com.rickclephas.kmp.nativecoroutines.NativeCoroutines
 
 interface BookmarksRepository {
     /**
-     * Creates an ayah bookmark if needed, then replaces its saved collection memberships exactly.
-     * Empty memberships normalize to the virtual default collection.
+     * Replaces an ayah bookmark's saved collection memberships exactly.
+     *
+     * Non-empty memberships create the bookmark if needed. Empty memberships remove the saved
+     * bookmark, or do nothing when it does not exist.
      */
     @NativeCoroutines
     suspend fun replaceAyahBookmarkCollections(
@@ -17,9 +19,11 @@ interface BookmarksRepository {
     ): BookmarkCollectionsReplacementResult
 
     /**
-     * Creates an ayah bookmark if needed, then replaces its saved collection memberships exactly
-     * with an explicit mutation timestamp.
-     * Empty memberships normalize to the virtual default collection.
+     * Replaces an ayah bookmark's saved collection memberships exactly with an explicit mutation
+     * timestamp.
+     *
+     * Non-empty memberships create the bookmark if needed. Empty memberships remove the saved
+     * bookmark, or do nothing when it does not exist.
      */
     @NativeCoroutines
     suspend fun replaceAyahBookmarkCollections(

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
@@ -57,6 +57,7 @@ class BookmarksRepositoryImpl(
         timestamp: PlatformDateTime
     ): BookmarkCollectionsReplacementResult {
         val timestampMillis = timestamp.toEpochMillisecondsFromPlatform()
+        val desiredCollectionIds = normalizeCollectionIds(collectionIds).toSet()
         logger.i { "Replacing ayah bookmark collection memberships for $sura:$ayah" }
         return withContext(Dispatchers.IO) {
             var result: BookmarkCollectionsReplacementResult? = null
@@ -66,6 +67,10 @@ class BookmarksRepositoryImpl(
                     .executeAsOneOrNull()
 
                 if (bookmark == null || bookmark.deleted == 1L) {
+                    if (desiredCollectionIds.isEmpty()) {
+                        result = BookmarkCollectionsReplacementResult(bookmark = null, changed = false)
+                        return@transaction
+                    }
                     bookmarkQueries.value.upsertAyahBookmark(
                         remote_id = null,
                         ayah_id = getAyahId(sura, ayah).toLong(),
@@ -81,13 +86,17 @@ class BookmarksRepositoryImpl(
 
                 val changed = replaceBookmarkCollectionsInTransaction(
                     bookmark = bookmark,
-                    collectionLocalIds = collectionIds,
+                    desiredCollectionIds = desiredCollectionIds,
                     timestampMillis = timestampMillis
                 )
-                val replacedBookmark = bookmarkQueries.value
-                    .getBookmarkForAyah(sura.toLong(), ayah.toLong())
-                    .executeAsOne()
-                    .toAyahBookmark()
+                val replacedBookmark = if (desiredCollectionIds.isEmpty()) {
+                    null
+                } else {
+                    bookmarkQueries.value
+                        .getBookmarkForAyah(sura.toLong(), ayah.toLong())
+                        .executeAsOne()
+                        .toAyahBookmark()
+                }
                 result = BookmarkCollectionsReplacementResult(replacedBookmark, changed)
             }
             requireNotNull(result)
@@ -96,13 +105,12 @@ class BookmarksRepositoryImpl(
 
     private fun replaceBookmarkCollectionsInTransaction(
         bookmark: DatabaseBookmark,
-        collectionLocalIds: List<String>,
+        desiredCollectionIds: Set<String>,
         timestampMillis: Long
     ): Boolean {
         require(bookmark.bookmark_type == "AYAH") {
             "Expected ayah bookmark localId=${bookmark.local_id} before replacing collections."
         }
-        val desiredCollectionIds = normalizeCollectionIds(collectionLocalIds).toSet()
         val currentCollectionIds = bookmark.currentCollectionIds()
         if (currentCollectionIds == desiredCollectionIds) {
             return false
@@ -158,16 +166,10 @@ class BookmarksRepositoryImpl(
     }
 
     private fun normalizeCollectionIds(collectionLocalIds: List<String>): List<String> {
-        val nonBlankIds = collectionLocalIds
+        return collectionLocalIds
             .map(String::trim)
             .filter(String::isNotEmpty)
             .distinct()
-        return nonBlankIds.ifEmpty {
-            val defaultCollection = requireNotNull(
-                collectionQueries.value.getDefaultCollection().executeAsOneOrNull()
-            ) { "Default collection is not available." }
-            listOf(defaultCollection.local_id.toString())
-        }
     }
 
     override suspend fun fetchMutatedBookmarks(): List<LocalModelMutation<RemoteBookmark>> {

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
@@ -13,6 +13,7 @@ import com.quran.shared.persistence.QuranDatabase
 import com.quran.shared.persistence.input.RemoteBookmark
 import com.quran.shared.persistence.model.BookmarkCollectionsReplacementResult
 import com.quran.shared.persistence.model.DatabaseBookmark
+import com.quran.shared.persistence.model.highlightColorForCollectionName
 import com.quran.shared.persistence.repository.PersistenceWriteBoundaryGuard
 import com.quran.shared.persistence.repository.buildRemoteResourceExistenceMap
 import com.quran.shared.persistence.repository.bookmark.BookmarkDependencyReconciler
@@ -65,12 +66,13 @@ class BookmarksRepositoryImpl(
         return withContext(Dispatchers.IO) {
             var result: BookmarkCollectionsReplacementResult? = null
             database.transaction {
+                val desiredSavedCollectionIds = resolveSavedCollectionIds(desiredCollectionIds)
                 var bookmark = bookmarkQueries.value
                     .getBookmarkForAyah(sura.toLong(), ayah.toLong())
                     .executeAsOneOrNull()
 
                 if (bookmark == null || bookmark.deleted == 1L) {
-                    if (desiredCollectionIds.isEmpty()) {
+                    if (desiredSavedCollectionIds.isEmpty()) {
                         result = BookmarkCollectionsReplacementResult(bookmark = null, changed = false)
                         return@transaction
                     }
@@ -89,10 +91,10 @@ class BookmarksRepositoryImpl(
 
                 val changed = replaceBookmarkCollectionsInTransaction(
                     bookmark = bookmark,
-                    desiredCollectionIds = desiredCollectionIds,
+                    desiredCollectionIds = desiredSavedCollectionIds,
                     timestampMillis = timestampMillis
                 )
-                val replacedBookmark = if (desiredCollectionIds.isEmpty()) {
+                val replacedBookmark = if (desiredSavedCollectionIds.isEmpty()) {
                     null
                 } else {
                     bookmark.toAyahBookmark()
@@ -105,36 +107,25 @@ class BookmarksRepositoryImpl(
 
     private fun replaceBookmarkCollectionsInTransaction(
         bookmark: DatabaseBookmark,
-        desiredCollectionIds: Set<String>,
+        desiredCollectionIds: Set<Long>,
         timestampMillis: Long
     ): Boolean {
         require(bookmark.bookmark_type == "AYAH") {
             "Expected ayah bookmark localId=${bookmark.local_id} before replacing collections."
         }
-        val currentCollectionIds = bookmark.currentCollectionIds()
+        val currentCollectionIds = bookmark.currentSavedCollectionIds()
         if (currentCollectionIds == desiredCollectionIds) {
             return false
         }
 
-        val idsToAdd = desiredCollectionIds
-            .map { collectionLocalId ->
-                val collection = collectionQueries.value
-                    .getCollectionByLocalId(collectionLocalId.toLong())
-                    .executeAsOneOrNull()
-                require(collection?.deleted == 0L) { "Collection not found for localId=$collectionLocalId." }
-                collection.local_id
-            }
-            .toSet()
-        val currentIds = currentCollectionIds.map(String::toLong).toSet()
-
-        (idsToAdd - currentIds).forEach { collectionLocalId ->
+        (desiredCollectionIds - currentCollectionIds).forEach { collectionLocalId ->
             bookmarkCollectionQueries.value.addBookmarkToCollection(
                 bookmark_local_id = bookmark.local_id,
                 collection_local_id = collectionLocalId,
                 timestamp = timestampMillis
             )
         }
-        (currentIds - idsToAdd).forEach { collectionLocalId ->
+        (currentCollectionIds - desiredCollectionIds).forEach { collectionLocalId ->
             bookmarkCollectionQueries.value.markBookmarkCollectionDeleted(
                 bookmark_local_id = bookmark.local_id,
                 collection_local_id = collectionLocalId,
@@ -145,11 +136,26 @@ class BookmarksRepositoryImpl(
         return true
     }
 
-    private fun DatabaseBookmark.currentCollectionIds(): Set<String> {
+    private fun resolveSavedCollectionIds(collectionIds: Set<String>): Set<Long> {
+        return collectionIds.mapNotNull { collectionLocalId ->
+            val collection = collectionQueries.value
+                .getCollectionByLocalId(collectionLocalId.toLong())
+                .executeAsOneOrNull()
+            require(collection?.deleted == 0L) { "Collection not found for localId=$collectionLocalId." }
+            collection.local_id.takeUnless { highlightColorForCollectionName(collection.name) != null }
+        }.toSet()
+    }
+
+    private fun DatabaseBookmark.currentSavedCollectionIds(): Set<Long> {
         return bookmarkCollectionQueries.value
             .getActiveCollectionLocalIdsForBookmark(local_id)
             .executeAsList()
-            .map { it.toString() }
+            .filterNot { collectionLocalId ->
+                val collection = collectionQueries.value
+                    .getCollectionByLocalId(collectionLocalId)
+                    .executeAsOne()
+                highlightColorForCollectionName(collection.name) != null
+            }
             .toSet()
     }
 

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
@@ -92,10 +92,7 @@ class BookmarksRepositoryImpl(
                 val replacedBookmark = if (desiredCollectionIds.isEmpty()) {
                     null
                 } else {
-                    bookmarkQueries.value
-                        .getBookmarkForAyah(sura.toLong(), ayah.toLong())
-                        .executeAsOne()
-                        .toAyahBookmark()
+                    bookmark.toAyahBookmark()
                 }
                 result = BookmarkCollectionsReplacementResult(replacedBookmark, changed)
             }
@@ -127,18 +124,6 @@ class BookmarksRepositoryImpl(
             .toSet()
         val currentIds = currentCollectionIds.map(String::toLong).toSet()
 
-        if (currentCollectionIds.isEmpty()) {
-            val sura = requireNotNull(bookmark.sura).toInt()
-            val ayah = requireNotNull(bookmark.ayah).toInt()
-            bookmarkQueries.value.upsertAyahBookmark(
-                remote_id = null,
-                ayah_id = getAyahId(sura, ayah).toLong(),
-                sura = sura.toLong(),
-                ayah = ayah.toLong(),
-                created_at = timestampMillis,
-                modified_at = timestampMillis
-            )
-        }
         (idsToAdd - currentIds).forEach { collectionLocalId ->
             bookmarkCollectionQueries.value.addBookmarkToCollection(
                 bookmark_local_id = bookmark.local_id,

--- a/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
+++ b/persistence/src/commonMain/kotlin/com/quran/shared/persistence/repository/bookmark/repository/BookmarksRepositoryImpl.kt
@@ -57,7 +57,10 @@ class BookmarksRepositoryImpl(
         timestamp: PlatformDateTime
     ): BookmarkCollectionsReplacementResult {
         val timestampMillis = timestamp.toEpochMillisecondsFromPlatform()
-        val desiredCollectionIds = normalizeCollectionIds(collectionIds).toSet()
+        val desiredCollectionIds = collectionIds
+            .map(String::trim)
+            .filter(String::isNotEmpty)
+            .toSet()
         logger.i { "Replacing ayah bookmark collection memberships for $sura:$ayah" }
         return withContext(Dispatchers.IO) {
             var result: BookmarkCollectionsReplacementResult? = null
@@ -148,13 +151,6 @@ class BookmarksRepositoryImpl(
             .executeAsList()
             .map { it.toString() }
             .toSet()
-    }
-
-    private fun normalizeCollectionIds(collectionLocalIds: List<String>): List<String> {
-        return collectionLocalIds
-            .map(String::trim)
-            .filter(String::isNotEmpty)
-            .distinct()
     }
 
     override suspend fun fetchMutatedBookmarks(): List<LocalModelMutation<RemoteBookmark>> {

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarkSyncArchitectureTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarkSyncArchitectureTest.kt
@@ -298,9 +298,10 @@ class BookmarkSyncArchitectureTest {
             timestamp = timestamp
         )
 
-        val row = database.bookmarksQueries.getBookmarkByLocalId(result.bookmark.id.toLong()).executeAsOne()
+        val bookmark = assertNotNull(result.bookmark)
+        val row = database.bookmarksQueries.getBookmarkByLocalId(bookmark.id.toLong()).executeAsOne()
         val link = database.bookmark_collectionsQueries
-            .getCollectionBookmarkFor(result.bookmark.id.toLong(), collectionId.toLong())
+            .getCollectionBookmarkFor(bookmark.id.toLong(), collectionId.toLong())
             .executeAsOne()
         assertTrue(result.changed)
         assertEquals(4300L, row.created_at)
@@ -308,6 +309,59 @@ class BookmarkSyncArchitectureTest {
         assertEquals(4300L, row.bookmark_modified_at)
         assertEquals(4300L, link.created_at)
         assertEquals(4300L, link.modified_at)
+    }
+
+    @Test
+    fun `empty collection replacement removes an existing saved bookmark`() = runTest {
+        val collectionId = createCollection("RemoveWithEmptyReplacement", "remote-remove-with-empty-replacement")
+        collectionBookmarksRepository.addAyahBookmarkToCollection(collectionId, 2, 15, at(100))
+
+        val result = bookmarksRepository.replaceAyahBookmarkCollections(
+            sura = 2,
+            ayah = 15,
+            collectionIds = emptyList(),
+            timestamp = at(200)
+        )
+
+        assertTrue(result.changed)
+        assertNull(result.bookmark)
+        assertNull(database.bookmarksQueries.getBookmarkForAyah(2L, 15L).executeAsOneOrNull())
+        assertEquals(0L, database.bookmark_collectionsQueries.countAll().executeAsOne())
+    }
+
+    @Test
+    fun `empty collection replacement does nothing when bookmark is missing`() = runTest {
+        val result = bookmarksRepository.replaceAyahBookmarkCollections(
+            sura = 2,
+            ayah = 16,
+            collectionIds = emptyList(),
+            timestamp = at(200)
+        )
+
+        assertFalse(result.changed)
+        assertNull(result.bookmark)
+        assertNull(database.bookmarksQueries.getBookmarkForAyah(2L, 16L).executeAsOneOrNull())
+        assertEquals(0L, database.bookmark_collectionsQueries.countAll().executeAsOne())
+    }
+
+    @Test
+    fun `empty collection replacement preserves reading bookmark facet`() = runTest {
+        val collectionId = createCollection("PreserveReadingWithEmpty", "remote-preserve-reading-with-empty")
+        readingRepository.addAyahReadingBookmark(2, 17, at(100))
+        collectionBookmarksRepository.addAyahBookmarkToCollection(collectionId, 2, 17, at(100))
+
+        val result = bookmarksRepository.replaceAyahBookmarkCollections(
+            sura = 2,
+            ayah = 17,
+            collectionIds = emptyList(),
+            timestamp = at(200)
+        )
+
+        val row = database.bookmarksQueries.getBookmarkForAyah(2L, 17L).executeAsOne()
+        assertTrue(result.changed)
+        assertNull(result.bookmark)
+        assertEquals(1L, row.is_reading)
+        assertEquals(0L, database.bookmark_collectionsQueries.countActiveForBookmark(row.local_id).executeAsOne())
     }
 
     @Test

--- a/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarkSyncArchitectureTest.kt
+++ b/persistence/src/commonTest/kotlin/com/quran/shared/persistence/repository/BookmarkSyncArchitectureTest.kt
@@ -15,6 +15,7 @@ import com.quran.shared.persistence.input.PersistenceImportData
 import com.quran.shared.persistence.input.RemoteBookmark
 import com.quran.shared.persistence.input.RemoteCollection
 import com.quran.shared.persistence.input.RemoteCollectionBookmark
+import com.quran.shared.persistence.model.AyahHighlightColor
 import com.quran.shared.persistence.model.PageReadingBookmark
 import com.quran.shared.persistence.model.CollectionAyahBookmark
 import com.quran.shared.persistence.repository.bookmark.BookmarkDependencyReconciler
@@ -26,6 +27,7 @@ import com.quran.shared.persistence.repository.readingbookmark.repository.Readin
 import com.quran.shared.persistence.util.fromPlatform
 import com.quran.shared.persistence.util.PlatformDateTime
 import com.quran.shared.persistence.util.toPlatform
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -362,6 +364,70 @@ class BookmarkSyncArchitectureTest {
         assertNull(result.bookmark)
         assertEquals(1L, row.is_reading)
         assertEquals(0L, database.bookmark_collectionsQueries.countActiveForBookmark(row.local_id).executeAsOne())
+    }
+
+    @Test
+    fun `collection replacement preserves highlight membership`() = runTest {
+        val firstCollectionId = createCollection("ReplacePreserveHighlightFirst", "remote-replace-highlight-first")
+        val secondCollectionId = createCollection("ReplacePreserveHighlightSecond", "remote-replace-highlight-second")
+        collectionBookmarksRepository.setHighlight(2, 18, AyahHighlightColor.GREEN, at(100))
+        collectionBookmarksRepository.addAyahBookmarkToCollection(firstCollectionId, 2, 18, at(100))
+
+        val result = bookmarksRepository.replaceAyahBookmarkCollections(
+            sura = 2,
+            ayah = 18,
+            collectionIds = listOf(secondCollectionId),
+            timestamp = at(200)
+        )
+
+        val bookmark = database.bookmarksQueries.getBookmarkForAyah(2L, 18L).executeAsOne()
+        val highlightCollection = database.collectionsQueries
+            .getCollectionByName(AyahHighlightColor.GREEN.collectionName)
+            .executeAsOne()
+        assertTrue(result.changed)
+        assertNotNull(result.bookmark)
+        assertEquals(
+            setOf(highlightCollection.local_id, secondCollectionId.toLong()),
+            database.bookmark_collectionsQueries
+                .getActiveCollectionLocalIdsForBookmark(bookmark.local_id)
+                .executeAsList()
+                .toSet()
+        )
+        assertEquals(
+            AyahHighlightColor.GREEN,
+            collectionBookmarksRepository.getHighlightsFlow().first().single().color
+        )
+    }
+
+    @Test
+    fun `empty collection replacement preserves highlight membership`() = runTest {
+        val collectionId = createCollection("RemovePreserveHighlight", "remote-remove-preserve-highlight")
+        collectionBookmarksRepository.setHighlight(2, 19, AyahHighlightColor.PURPLE, at(100))
+        collectionBookmarksRepository.addAyahBookmarkToCollection(collectionId, 2, 19, at(100))
+
+        val result = bookmarksRepository.replaceAyahBookmarkCollections(
+            sura = 2,
+            ayah = 19,
+            collectionIds = emptyList(),
+            timestamp = at(200)
+        )
+
+        val bookmark = database.bookmarksQueries.getBookmarkForAyah(2L, 19L).executeAsOne()
+        val highlightCollection = database.collectionsQueries
+            .getCollectionByName(AyahHighlightColor.PURPLE.collectionName)
+            .executeAsOne()
+        assertTrue(result.changed)
+        assertNull(result.bookmark)
+        assertEquals(
+            listOf(highlightCollection.local_id),
+            database.bookmark_collectionsQueries
+                .getActiveCollectionLocalIdsForBookmark(bookmark.local_id)
+                .executeAsList()
+        )
+        assertEquals(
+            AyahHighlightColor.PURPLE,
+            collectionBookmarksRepository.getHighlightsFlow().first().single().color
+        )
     }
 
     @Test

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/QuranDataService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/QuranDataService.kt
@@ -11,10 +11,10 @@ import com.quran.shared.auth.service.AuthService
 import com.quran.shared.di.AppScope
 import com.quran.shared.persistence.input.PersistenceImportData
 import com.quran.shared.persistence.input.PersistenceImportResult
-import com.quran.shared.persistence.model.AyahBookmark
 import com.quran.shared.persistence.model.AyahHighlight
 import com.quran.shared.persistence.model.AyahHighlightColor
 import com.quran.shared.persistence.model.AyahReadingBookmark
+import com.quran.shared.persistence.model.BookmarkCollectionsReplacementResult
 import com.quran.shared.persistence.model.Collection
 import com.quran.shared.persistence.model.CollectionAyahBookmark
 import com.quran.shared.persistence.model.CollectionWithAyahBookmarks
@@ -419,13 +419,16 @@ class QuranDataService internal constructor(
         sura: Int,
         ayah: Int,
         collectionIds: List<String>
-    ): AyahBookmark {
+    ): BookmarkCollectionsReplacementResult {
         return replaceAyahBookmarkCollections(sura, ayah, collectionIds, currentPlatformDateTime())
     }
 
     /**
-     * Creates an ayah bookmark if needed, then replaces its saved collection memberships with an
-     * explicit mutation timestamp and schedules sync only when memberships changed.
+     * Replaces an ayah bookmark's saved collection memberships with an explicit mutation timestamp
+     * and schedules sync only when memberships changed.
+     *
+     * Non-empty memberships create the bookmark if needed. Empty memberships remove the saved
+     * bookmark, or do nothing when it does not exist.
      */
     @NativeCoroutines
     suspend fun replaceAyahBookmarkCollections(
@@ -433,13 +436,13 @@ class QuranDataService internal constructor(
         ayah: Int,
         collectionIds: List<String>,
         timestamp: PlatformDateTime
-    ): AyahBookmark {
+    ): BookmarkCollectionsReplacementResult {
         return mutatingCall("Failed to replace ayah bookmark collection memberships", triggerAfter = false) {
             val result = bookmarksRepository.replaceAyahBookmarkCollections(sura, ayah, collectionIds, timestamp)
             if (result.changed) {
                 triggerSync()
             }
-            result.bookmark
+            result
         }
     }
 

--- a/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/QuranDataService.kt
+++ b/sync-pipelines/src/commonMain/kotlin/com/quran/shared/pipeline/QuranDataService.kt
@@ -428,7 +428,8 @@ class QuranDataService internal constructor(
      * and schedules sync only when memberships changed.
      *
      * Non-empty memberships create the bookmark if needed. Empty memberships remove the saved
-     * bookmark, or do nothing when it does not exist.
+     * bookmark, or do nothing when it does not exist. Highlight collection memberships are always
+     * preserved and excluded from replacement.
      */
     @NativeCoroutines
     suspend fun replaceAyahBookmarkCollections(

--- a/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/QuranDataServiceLifecycleTest.kt
+++ b/sync-pipelines/src/commonTest/kotlin/com/quran/shared/pipeline/QuranDataServiceLifecycleTest.kt
@@ -92,6 +92,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Instant
 
@@ -831,13 +832,15 @@ class QuranDataServiceLifecycleTest {
 
         val changedCall = fixture.bookmarksRepository.replaceAyahCalls.single()
         val generatedTimestamp = assertNotNull(changedCall.timestamp)
-        assertEquals(AyahBookmark(2, 255, "bookmark-replaced", generatedTimestamp), changed)
+        assertEquals(AyahBookmark(2, 255, "bookmark-replaced", generatedTimestamp), changed.bookmark)
+        assertTrue(changed.changed)
         assertEquals(1, fixture.syncClient.localDataUpdatedCount)
 
         fixture.bookmarksRepository.replaceAyahResultChanged = false
         val unchanged = fixture.service.replaceAyahBookmarkCollections(2, 255, listOf("collection-a"))
 
-        assertEquals("bookmark-replaced", unchanged.id)
+        assertEquals("bookmark-replaced", unchanged.bookmark?.id)
+        assertFalse(unchanged.changed)
         assertEquals(2, fixture.bookmarksRepository.replaceAyahCalls.size)
         assertEquals(1, fixture.syncClient.localDataUpdatedCount)
         fixture.clearAndJoin()
@@ -857,11 +860,26 @@ class QuranDataServiceLifecycleTest {
             timestamp = timestamp
         )
 
-        assertEquals(AyahBookmark(2, 255, "bookmark-replaced", timestamp), result)
+        assertEquals(AyahBookmark(2, 255, "bookmark-replaced", timestamp), result.bookmark)
+        assertFalse(result.changed)
         assertEquals(
             listOf(BookmarkAyahCollectionsReplaceCall(2, 255, listOf("collection-a"), timestamp)),
             fixture.bookmarksRepository.replaceAyahCalls
         )
+        assertEquals(0, fixture.syncClient.localDataUpdatedCount)
+        fixture.clearAndJoin()
+    }
+
+    @Test
+    fun `empty replacement returns no change and skips sync when bookmark is missing`() = runTest(dispatcher) {
+        val fixture = quranDataServiceFixture(useRecordingSyncClient = true)
+        fixture.bookmarksRepository.replaceAyahResultChanged = false
+        advanceUntilIdle()
+
+        val result = fixture.service.replaceAyahBookmarkCollections(2, 255, emptyList())
+
+        assertNull(result.bookmark)
+        assertFalse(result.changed)
         assertEquals(0, fixture.syncClient.localDataUpdatedCount)
         fixture.clearAndJoin()
     }
@@ -1167,7 +1185,11 @@ private class ServiceBookmarksRepository : BookmarksRepository, BookmarksSynchro
     ): BookmarkCollectionsReplacementResult {
         replaceAyahCalls += BookmarkAyahCollectionsReplaceCall(sura, ayah, collectionIds, timestamp)
         return BookmarkCollectionsReplacementResult(
-            bookmark = AyahBookmark(sura, ayah, "bookmark-replaced", timestamp),
+            bookmark = if (collectionIds.isEmpty()) {
+                null
+            } else {
+                AyahBookmark(sura, ayah, "bookmark-replaced", timestamp)
+            },
             changed = replaceAyahResultChanged
         )
     }


### PR DESCRIPTION
## What changed

- make an empty saved-collection replacement remove existing saved memberships
- make an empty replacement a no-op when the ayah bookmark does not exist
- exclude reserved `system:highlights:*` memberships from saved-collection replacement
- return the authoritative `BookmarkCollectionsReplacementResult` from `QuranDataService`
- trigger sync only when saved memberships actually change

## Why

Empty replacements previously normalized to Favorites. This retained bookmarks that callers intended to remove and created new Favorites bookmarks for missing ayahs.

The replacement path also treated highlight persistence links as saved bookmark memberships. Replacing or clearing bookmark collections could therefore remove an ayah's highlight.

## Impact

- Empty input removes only saved bookmark memberships.
- Missing bookmarks remain missing.
- Non-empty input still creates a bookmark when needed and replaces its saved memberships exactly.
- Reading-bookmark state and highlight colors remain unchanged.
- Callers receive both the resulting nullable bookmark and an authoritative `changed` value.

## Validation

- `./gradlew :persistence:jvmTest :sync-pipelines:jvmTest :demo:android:compileDebugKotlin`
- `./gradlew :umbrella:assembleSharedDebugXCFramework`
- `make build-sync-local-debug PACKAGE_DESTINATION='generic/platform=iOS Simulator'` from quran-ios
